### PR TITLE
Add LLM agent instructions (CLAUDE.md + AGENTS.md + docs) — #5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+Guidance for Claude Code (and, via the `AGENTS.md` symlink, Codex / Copilot / other agents)
+working in this repository. Keep this file concise; link out to [docs/](docs/) for depth.
+
+## What this repo is
+
+A **local two-player dungeon fighting game** built in C++ on **SFML 2.x**. Two sprite-animated
+fighters trade sword/laser attacks in an arena while dodging fire hazards; first to out-score
+the other before the clock runs out wins. It runs as a native desktop window (macOS / Linux /
+Windows) — there is no server component beyond optional peer-to-peer online play.
+
+The game supports several **control sources** that all feed the same movement/attack logic:
+local shared-keyboard (player 1 numpad, player 2 WASD), online host/client over TCP, and
+(planned) a single-player AI opponent. See [docs/architecture.md](docs/architecture.md).
+
+## Build, run, test
+
+The build system is **CMake** (≥3.16). SFML 2.6.2 is fetched and pinned via `FetchContent`, so
+no system SFML install is required (a `find_package` fallback is used if a compatible SFML 2 is
+already present). Full details in [docs/building.md](docs/building.md).
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Debug     # configure (first run fetches + builds SFML)
+cmake --build build                          # build the dungeon_game executable
+./build/dungeon_game                         # run
+ctest --test-dir build --output-on-failure   # run the test suite
+```
+
+Assets in [elements/](elements/) are copied next to the binary at build time and resolved relative
+to the executable, so the game runs from any directory.
+
+## Repo layout
+
+Sources currently live at the repo root (a conventional `src/`/`include/`/`tests/`/`assets/`
+layout is being introduced — see issue #8). The load-bearing pieces:
+
+- `main.cpp` — entry point + menus (start/end screens, mode selection).
+- `Game.{h,cpp}` — the game: window, fixed game loop (`processEvents` → `update` → `render`),
+  collision, scoring, audio, and network integration.
+- `GameObject.h` — abstract entity interface, implemented by `RegularGameObject`
+  (`RegularGameObject.{h,cpp}`, static sprite) and `AnimatedGameObject`
+  (`AnimatedGameObject.{h,cpp}`, sprite-sheet animation) — each a separate file.
+- `NetworkManager.{h,cpp}` — TCP host/client transport; `PlayerInput` / `GameState` packet
+  structs are the wire format and the uniform input channel across local/network/AI/replay.
+- `resource_path.h` — asset path resolution.
+
+## Conventions
+
+- **C++17**, warnings-as-signal (`-Wall -Wextra -Wpedantic`; `-Werror` in CI). See issue #6.
+- Format with `clang-format` and lint with `clang-tidy` (configs at repo root) before committing.
+- Prefer RAII and value/smart-pointer ownership over raw `new`/`delete` (see issue #9).
+- Keep gameplay/AI/network logic **separable from rendering** so it is unit-testable without a
+  window (SFML opens a real window + audio device). See [docs/architecture.md](docs/architecture.md).
+- Follow existing patterns; if a pattern looks wrong or fragile, flag it rather than copying it.
+
+## Design decisions (don't "fix" these without reason)
+
+- **SFML pinned at 2.6.2 via FetchContent**, not the system package. Reproducible across
+  machines/CI and matches the SFML 2.x API the code uses. A full SFML 3 migration is a separate,
+  out-of-scope effort.
+- **`PlayerInput` is the single input abstraction.** Local input, network packets, the AI
+  opponent, and the replay/debug harness all produce a `PlayerInput` per frame that flows through
+  one code path — do not special-case per-mode behavior in the update loop.
+- **Online play is peer-to-peer** (one player hosts, the other joins); the host is authoritative
+  for shared state. There is no dedicated server.
+
+## Working in this repo
+
+- **Merge convention:** feature branches off `master`, **squash-merged to `master`** via PR. One
+  PR per coherent effort (may span multiple issues). See [docs/contributing.md](docs/contributing.md).
+- Run the four gates before declaring a change done: **build**, **clang-format --dry-run**,
+  **clang-tidy**, **ctest** — all must pass. CI enforces the same on every PR.
+- This game opens a real window; for automated/headless testing use the debug harness
+  (screenshots + scriptable input + `--frames N`) — see issue #13 and
+  [docs/contributing.md](docs/contributing.md#automated-playtesting).
+- The overhaul in progress is tracked in GitHub issues #1–#13; read the relevant issue before
+  starting work in its area.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,94 @@
+# Architecture
+
+A conceptual map of the game. File paths are given where stable, but the emphasis is on
+concepts that survive refactors (the physical layout is being reorganized under issue #8).
+
+## The game in one paragraph
+
+Two fighters share one arena: **player 1 ("rocket")** and **player 2 ("robot")**. Each can move
+in four directions, face left/right, and throw a melee/ranged attack that sweeps a rectangle in
+their facing direction. Landing an attack on the opponent scores a point and triggers a short
+**cooldown** ("intermission") that recenters both fighters. Standing in a **fire hazard** costs a
+point (with brief post-hit invincibility). A running clock is displayed; when the window closes
+the final scores + elapsed time are returned to the menu, which tracks a high score.
+
+## Control sources → one input path
+
+Every mode ultimately drives the same per-player movement/attack booleans consumed in
+`Game::update`. This uniformity is the central design invariant:
+
+- **Local** — a shared keyboard: player 1 on the numpad (+ arrow to attack), player 2 on WASD
+  (+ space to attack). Handled in `Game::handlePlayerInput`.
+- **Online** — one peer hosts, the other joins over TCP. The client samples its keyboard into a
+  `PlayerInput`, sends it to the host; the host simulates authoritatively and streams `GameState`
+  back. See `NetworkManager`.
+- **AI (planned, #12)** — a `state → PlayerInput` function drives player 2 from game state.
+- **Replay/debug (planned, #13)** — a scripted sequence of `PlayerInput`s feeds player 2.
+
+`PlayerInput` (`NetworkManager.h`) is the shared abstraction. New control sources should produce
+a `PlayerInput` per frame rather than reaching into `Game` internals.
+
+## Entity model
+
+`GameObject` (`GameObject.h`) is an abstract interface: `load`, `draw`, `update`, position/scale,
+validity, origin. Two implementations:
+
+- **`RegularGameObject`** — a single static sprite (walls, backgrounds, menu art).
+- **`AnimatedGameObject`** — a sprite sheet advanced frame-by-frame in `update()`; constructed with
+  frame dimensions + count. Players, fire, and menu buttons are animated objects.
+
+Objects are currently created with raw `new` and stored as `GameObject*` (including the `stuff`
+vector of arena props). Ownership is being moved to smart pointers / RAII (issue #9); note the base
+class currently has **no virtual destructor**.
+
+## The game loop
+
+`Game::run()` drives a loop while the window is open:
+
+1. **`processEvents()`** — pump SFML events; key up/down toggles per-player input booleans.
+2. **`update(deltaT, time)`** — apply movement (`speed * deltaT`, frame-rate independent),
+   resolve player↔player push-out, evaluate attacks (a facing-direction hit rectangle vs. the
+   opponent), and set the cooldown flag on a scoring hit.
+3. **Hazard damage** is resolved back in `run()` itself (not `update()`): after `update()` and
+   before `render()`, `run()` tests each player against the hazards and decrements score with a
+   per-player invincibility window.
+4. **`render()`** — clear, draw hazards/props, HUD (scores + timer), both players, then display.
+
+> Note the split: `update()` handles movement/attacks/cooldown-flag, while `run()` owns the
+> per-frame timing, hazard-damage loop, and cooldown countdown. When extending hazard logic, edit
+> `run()`, not `update()`.
+
+**Timing caveats (issue #11):** movement scales with `deltaT` (good), but sprite animation uses a
+`time > .1f` reset accumulator (a frame-rate-sensitive hack), and the window is a fixed
+non-resizable `1920x1080` while menus are `1024x576`. Fixed-timestep + a scalable view are the
+intended fixes, and are also what makes deterministic replay (#13) and AI testing (#12) possible.
+
+## Scoring, hazards, cooldown
+
+- **Attacks:** each attack builds a `sf::Rect` extending from the attacker in its facing direction
+  and tests overlap with the opponent (`Game::collision(sf::Rect, GameObject*)`). A hit scores and
+  sets `reset`, which recenters both fighters and enters `wait` (cooldown).
+- **Hazards:** the `stuff` vector holds a wall + fire objects; touching one decrements score,
+  gated by a per-player timeout so damage can't repeat every frame.
+- **Cooldown (`wait`):** after a score, the loop pauses gameplay ~1.75s (showing an intermission
+  banner) before resuming with a gong.
+
+> Internal score naming is currently inverted/confusing (`points` tracks the robot/p2 score,
+> `p2points` tracks the rocket/p1 score); this is a known smell (#9) — verify against the HUD
+> strings and the `run()` return tuple before relying on either name.
+
+## Network model
+
+`NetworkManager` wraps an `sf::TcpListener` + `sf::TcpSocket`. `PlayerInput` and `GameState`
+serialize via `sf::Packet`. The host is authoritative: it receives the client's `PlayerInput`,
+simulates, and returns the full `GameState` each frame. Known hardening work (issue #2): packets
+are demultiplexed by a leading type byte but mismatches are silently dropped, disconnection isn't
+detected, full state is sent every frame with no interpolation, and join input isn't validated.
+
+## Testability seams
+
+SFML opens a real window and audio device, so **logic that must be unit-tested should not depend
+on the window**: packet round-trips (`PlayerInput`/`GameState`), collision/overlap math, animation
+frame indexing, `GameState` capture/apply, and (planned) AI decisions are all pure functions of
+data and should be reachable without constructing a `Game`/window. CI runs the windowed paths
+headless under `xvfb` on Linux (see [contributing.md](contributing.md)).

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,0 +1,60 @@
+# Building & running
+
+## Prerequisites
+
+- A C++17 compiler (Clang, GCC, or MSVC).
+- **CMake ≥ 3.16.**
+- Git (for `FetchContent` to pull SFML) and a network connection on the first configure.
+- Platform toolchains for SFML's dependencies:
+  - **macOS:** Xcode command-line tools. Homebrew optional.
+  - **Linux:** X11/OpenGL/udev/FLAC/OpenAL/etc. dev packages (see the SFML docs; on Debian/Ubuntu
+    the `libsfml-dev` build-deps cover it). CI installs these explicitly.
+  - **Windows:** Visual Studio 2019+ (MSVC) — see issue #1 for the release path.
+
+## SFML
+
+SFML **2.6.2** is pinned and built via CMake `FetchContent`, so a system SFML install is **not**
+required and every machine/CI runner builds against the same version. If a compatible SFML 2 is
+already discoverable, a `find_package(SFML 2 ...)` fast path is used instead to skip the source
+build. (A full SFML 3 migration is intentionally out of scope — the code targets the SFML 2.x API.)
+
+The first configure fetches and compiles SFML, which takes a few minutes; subsequent builds reuse
+the cached build tree.
+
+## Configure, build, run
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Debug   # or Release
+cmake --build build -j
+./build/dungeon_game
+```
+
+Assets from [../elements/](../elements/) are copied next to the executable at build time, so the
+game finds them regardless of the working directory. (Historically the game only ran from the repo
+root because of a hardcoded relative asset path — that dependency has been removed.)
+
+## Tests
+
+```bash
+ctest --test-dir build --output-on-failure
+```
+
+The suite uses Catch2 (fetched via `FetchContent`). Pure-logic tests (packets, collision,
+animation math, state capture/apply, AI decisions) run anywhere; windowed integration tests run
+headless in CI (below).
+
+## Headless / CI
+
+- **Linux:** run windowed binaries under a virtual framebuffer:
+  ```bash
+  xvfb-run -s "-screen 0 1920x1080x24" ./build/dungeon_game --frames 120 --screenshot-every 30
+  ```
+- **macOS:** there is no true headless mode (native Cocoa/OpenGL); a real window must open. Use a
+  local window plus the debug harness (issue #13) for playtesting.
+
+## Warnings & tooling
+
+Builds enable `-Wall -Wextra -Wpedantic` (and `-Werror` in CI). Format with `clang-format` and
+statically analyze with `clang-tidy` using the repo-root configs; install both via `brew install
+llvm` on macOS or your distro's LLVM packages on Linux. See issue #6 and
+[contributing.md](contributing.md).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,52 @@
+# Contributing
+
+## Workflow
+
+- Branch off `master`; open a PR; **squash-merge to `master`**. Keep one PR per coherent effort
+  (a PR may resolve more than one issue).
+- Read the relevant GitHub issue (#1–#13 track the current overhaul) before working in its area.
+- Before declaring a change done, run the **four gates** locally — CI enforces the same:
+
+```bash
+cmake --build build -j                                   # 1. builds clean (warnings are errors in CI)
+clang-format --dry-run --Werror $(git ls-files '*.cpp' '*.h')   # 2. formatting
+clang-tidy -p build $(git ls-files '*.cpp')              # 3. static analysis
+ctest --test-dir build --output-on-failure               # 4. tests
+```
+
+## Code style
+
+- **C++17.** Format is defined by [`.clang-format`](../.clang-format); do not hand-format against
+  it. Editor defaults come from [`.editorconfig`](../.editorconfig).
+- Prefer RAII and smart-pointer/value ownership over raw `new`/`delete`. Give polymorphic base
+  classes a virtual destructor.
+- Prefer clear names over cleverness; avoid single-letter state and "joke" identifiers.
+- Keep gameplay/network/AI logic separable from rendering so it stays unit-testable without a
+  window. New control sources produce a `PlayerInput` (see [architecture.md](architecture.md)).
+- Follow existing patterns; if one looks wrong or fragile, flag it rather than reproducing it.
+
+## Testing
+
+- Framework: **Catch2** via CMake `FetchContent`; targets are registered with `ctest`.
+- Favor real dependencies over mocks; only mock what genuinely cannot run in a test.
+- Target meaningful coverage of logic (packets, collision, animation indexing, state capture/apply,
+  AI). Windowed paths are exercised headless in CI.
+
+## Automated playtesting
+
+Because SFML has no API to inject synthetic events, automated testing reuses the game's own input
+and rendering channels behind a debug flag/build (issue #13):
+
+- **Scriptable input** — feed a sequence of `PlayerInput`s (`--replay <file>`) or drive player 2
+  over the network client path; deterministic and focus-independent.
+- **Screenshots** — capture the framebuffer to a file on a debug key and/or `--screenshot-every N`.
+- **Determinism** — fixed timestep + seedable RNG + `--frames N` (run N frames then exit) make
+  playthroughs reproducible: drive → capture → assess in a loop.
+
+A scripted playthrough doubles as an integration test (#7).
+
+## CI
+
+A GitHub Actions workflow builds on macOS + Linux (+ Windows for releases, #1), runs
+`clang-format` in check mode, `clang-tidy`, and the `ctest` suite (Linux under `xvfb`). PRs must be
+green before merge.


### PR DESCRIPTION
Resolves #5.

Onboarding instructions for AI coding agents.

## What's here
- **`CLAUDE.md`** (root, 78 lines — under the 150-line target): what the repo is, build/run/test commands, repo layout, conventions, design decisions, and a "Working in this repo" gate checklist. Links out to `docs/` for depth.
- **`AGENTS.md`** → symlink to `CLAUDE.md`, so Codex/Copilot and other agents read the same source of truth (no drift).
- **`docs/architecture.md`** — conceptual map: control-source → single `PlayerInput` path, entity model, game loop (incl. the `update()` vs `run()` split), scoring/hazards/cooldown, network model, testability seams.
- **`docs/building.md`** — CMake + FetchContent SFML build/run/test, platform + headless/CI notes.
- **`docs/contributing.md`** — workflow (branch → PR → squash-merge), the four gates, code style, testing, automated playtesting.

## Notes
- The docs intentionally describe the **target repo state**: they reference the CMake build, `ctest`, and `clang-format`/CI that land in the immediately-following PRs (#10 build, #6 lint/CI). Onboarding docs describe where the repo is going, and those PRs follow directly.
- Authored against the actual source and reviewed for completeness/style/links and technical accuracy against the code; findings incorporated (asset-path wording, `run()` vs `update()` hazard-damage attribution, separate-header clarification).
