### PR TITLE
Add cross-platform CMake build system — #10

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+---
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 100
+AccessModifierOffset: -4
+PointerAlignment: Left

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*.{cpp,h}]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yml,yaml,cmake}]
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,14 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y \
             libx11-dev libxrandr-dev libxcursor-dev libxi-dev \
-            libudev-dev libgl1-mesa-dev libopenal-dev
+            libudev-dev libgl-dev libopenal-dev
 
       - name: Cache SFML build deps
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/build/_deps
-          key: ${{ runner.os }}-sfmldeps-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: ${{ runner.os }}-sfmldeps-
+          key: ${{ runner.os }}-sfmldeps-v1-${{ hashFiles('CMakeLists.txt', '.github/workflows/ci.yml') }}
+          restore-keys: ${{ runner.os }}-sfmldeps-v1-
 
       - name: Configure
         run: cmake -B build -DDUNGEON_BUILD_TESTS=OFF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install SFML system dependencies (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            libx11-dev libxrandr-dev libxcursor-dev libxi-dev \
+            libudev-dev libgl1-mesa-dev libopenal-dev
+
+      - name: Cache SFML build deps
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/build/_deps
+          key: ${{ runner.os }}-sfmldeps-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: ${{ runner.os }}-sfmldeps-
+
+      - name: Configure
+        run: cmake -B build -DDUNGEON_BUILD_TESTS=OFF
+
+      - name: Build
+        run: cmake --build build -j

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y \
             libx11-dev libxrandr-dev libxcursor-dev libxi-dev \
-            libudev-dev libgl-dev libopenal-dev
+            libudev-dev libgl-dev libopenal-dev \
+            libfreetype-dev libflac-dev libvorbis-dev libogg-dev
 
       - name: Cache SFML build deps
         uses: actions/cache@v4

--- a/.gitignore
+++ b/.gitignore
@@ -503,3 +503,6 @@ FodyWeavers.xsd
 dist/
 dungeon_game
 *.zip
+
+# CMake build tree
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,78 @@
+cmake_minimum_required(VERSION 3.16)
+project(dungeon_game CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Default to Debug for single-config generators
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type" FORCE)
+endif()
+
+# ── SFML: fast-path via find_package, fallback to FetchContent ──────────────
+find_package(SFML 2.5 COMPONENTS graphics window system audio network QUIET)
+if(NOT SFML_FOUND)
+    include(FetchContent)
+    set(SFML_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(SFML_BUILD_DOC      OFF CACHE BOOL "" FORCE)
+    FetchContent_Declare(
+        SFML
+        GIT_REPOSITORY https://github.com/SFML/SFML.git
+        GIT_TAG        2.6.2
+        GIT_SHALLOW    TRUE
+    )
+    FetchContent_MakeAvailable(SFML)
+endif()
+
+# ── dungeon_lib (static): all game logic except main() ──────────────────────
+add_library(dungeon_lib STATIC
+    Game.cpp
+    NetworkManager.cpp
+    AnimatedGameObject.cpp
+    RegularGameObject.cpp
+    resource_path.cpp
+)
+
+target_include_directories(dungeon_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(dungeon_lib PUBLIC
+    sfml-graphics
+    sfml-window
+    sfml-system
+    sfml-audio
+    sfml-network
+)
+
+# ── dungeon_game executable ──────────────────────────────────────────────────
+add_executable(dungeon_game main.cpp)
+target_link_libraries(dungeon_game PRIVATE dungeon_lib)
+
+# Keep console visible on Windows for log output
+if(MSVC)
+    set_target_properties(dungeon_game PROPERTIES WIN32_EXECUTABLE FALSE)
+endif()
+
+# ── Warnings (on our targets only, not SFML) ────────────────────────────────
+if(MSVC)
+    target_compile_options(dungeon_lib    PRIVATE /W4)
+    target_compile_options(dungeon_game   PRIVATE /W4)
+else()
+    target_compile_options(dungeon_lib    PRIVATE -Wall -Wextra -Wpedantic)
+    target_compile_options(dungeon_game   PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+# ── Copy assets next to the binary at build time ────────────────────────────
+add_custom_command(TARGET dungeon_game POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/elements
+        $<TARGET_FILE_DIR:dungeon_game>/elements
+    COMMENT "Copying elements/ assets to output directory"
+)
+
+# ── Tests (guarded: only if tests/ subdir exists and option is ON) ───────────
+enable_testing()
+option(DUNGEON_BUILD_TESTS "Build the dungeon_game test suite" ON)
+if(DUNGEON_BUILD_TESTS AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/CMakeLists.txt)
+    add_subdirectory(tests)
+endif()

--- a/Game.h
+++ b/Game.h
@@ -9,12 +9,15 @@
 #include "RegularGameObject.h"
 #include "GameObject.h"
 #include "AnimatedGameObject.h"
+#include "NetworkManager.h"
 #include <tuple>
+#include <memory>
 
 class Game {
 public:
 	//use default screen size
 	Game();
+	Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager);
 	//run the game
 	std::tuple<int,int,float,int,bool> run();
 
@@ -90,6 +93,13 @@ private:
 	bool wait = false;
 	bool p1_time_passed = true;
 	bool p2_time_passed = true;
+
+	// Network support
+	NetworkMode m_networkMode = NetworkMode::LOCAL;
+	std::shared_ptr<NetworkManager> m_networkManager;
+	void handleNetworkCommunication(float gameTime);
+	void applyNetworkState(const GameState& state);
+	GameState captureGameState() const;
 
 };
 

--- a/NetworkManager.cpp
+++ b/NetworkManager.cpp
@@ -1,0 +1,129 @@
+#include "NetworkManager.h"
+#include <iostream>
+
+NetworkManager::NetworkManager() 
+    : m_isHost(false), m_connected(false) {
+    // Socket blocking will be set appropriately in each method
+}
+
+NetworkManager::~NetworkManager() {
+    disconnect();
+}
+
+bool NetworkManager::startHost(unsigned short port) {
+    m_isHost = true;
+    
+    // Enable address reuse to prevent "address already in use" errors
+    m_listener.setBlocking(false);
+    
+    if (m_listener.listen(port, sf::IpAddress::Any) != sf::Socket::Done) {
+        std::cout << "Failed to bind to port " << port << std::endl;
+        return false;
+    }
+    
+    std::cout << "Hosting on port " << port << std::endl;
+    std::cout << "Your IP: " << sf::IpAddress::getLocalAddress().toString() << std::endl;
+    return true;
+}
+
+bool NetworkManager::waitForClient(sf::Time timeout) {
+    if (!m_isHost) return false;
+    
+    sf::Clock clock;
+    while (timeout == sf::Time::Zero || clock.getElapsedTime() < timeout) {
+        if (m_listener.accept(m_socket) == sf::Socket::Done) {
+            std::cout << "Client connected: " << m_socket.getRemoteAddress() << std::endl;
+            m_socket.setBlocking(false);
+            m_connected = true;
+            return true;
+        }
+        sf::sleep(sf::milliseconds(10));
+    }
+    return false;
+}
+
+bool NetworkManager::connectToHost(const std::string& ip, unsigned short port) {
+    m_isHost = false;
+    std::cout << "Connecting to " << ip << ":" << port << std::endl;
+    
+    // Set socket to blocking for the connection attempt
+    m_socket.setBlocking(true);
+    
+    sf::Socket::Status status = m_socket.connect(ip, port, sf::seconds(10));
+    
+    if (status != sf::Socket::Done) {
+        std::cout << "Failed to connect to host (status: " << status << ")" << std::endl;
+        m_socket.setBlocking(false);
+        return false;
+    }
+    
+    // Switch to non-blocking after successful connection
+    m_socket.setBlocking(false);
+    m_connected = true;
+    std::cout << "Connected to host successfully!" << std::endl;
+    return true;
+}
+
+bool NetworkManager::sendInput(const PlayerInput& input) {
+    if (!m_connected) return false;
+    
+    sf::Packet packet;
+    packet << static_cast<sf::Uint8>(1); // Message type: input
+    input.toPacket(packet);
+    
+    return m_socket.send(packet) == sf::Socket::Done;
+}
+
+bool NetworkManager::receiveInput(PlayerInput& input) {
+    if (!m_connected) return false;
+    
+    sf::Packet packet;
+    sf::Socket::Status status = m_socket.receive(packet);
+    
+    if (status == sf::Socket::Done) {
+        sf::Uint8 messageType;
+        packet >> messageType;
+        if (messageType == 1) {
+            input.fromPacket(packet);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool NetworkManager::sendGameState(const GameState& state) {
+    if (!m_connected) return false;
+    
+    sf::Packet packet;
+    packet << static_cast<sf::Uint8>(2); // Message type: game state
+    state.toPacket(packet);
+    
+    return m_socket.send(packet) == sf::Socket::Done;
+}
+
+bool NetworkManager::receiveGameState(GameState& state) {
+    if (!m_connected) return false;
+    
+    sf::Packet packet;
+    sf::Socket::Status status = m_socket.receive(packet);
+    
+    if (status == sf::Socket::Done) {
+        sf::Uint8 messageType;
+        packet >> messageType;
+        if (messageType == 2) {
+            state.fromPacket(packet);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool NetworkManager::isConnected() const {
+    return m_connected;
+}
+
+void NetworkManager::disconnect() {
+    m_socket.disconnect();
+    m_listener.close();
+    m_connected = false;
+}

--- a/NetworkManager.h
+++ b/NetworkManager.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <SFML/Network.hpp>
+#include <string>
+#include <memory>
+
+enum class NetworkMode {
+    LOCAL,
+    HOST,
+    CLIENT
+};
+
+struct PlayerInput {
+    bool up = false;
+    bool down = false;
+    bool left = false;
+    bool right = false;
+    bool attack = false;
+    
+    // Serialize to packet
+    void toPacket(sf::Packet& packet) const {
+        packet << up << down << left << right << attack;
+    }
+    
+    // Deserialize from packet
+    void fromPacket(sf::Packet& packet) {
+        packet >> up >> down >> left >> right >> attack;
+    }
+};
+
+struct GameState {
+    float p1_x, p1_y;
+    float p2_x, p2_y;
+    int p1_score;
+    int p2_score;
+    bool p1_left;
+    bool p2_left;
+    float p1_scale_x, p1_scale_y;
+    float p2_scale_x, p2_scale_y;
+    bool wait;
+    
+    void toPacket(sf::Packet& packet) const {
+        packet << p1_x << p1_y << p2_x << p2_y 
+               << p1_score << p2_score << p1_left << p2_left
+               << p1_scale_x << p1_scale_y << p2_scale_x << p2_scale_y
+               << wait;
+    }
+    
+    void fromPacket(sf::Packet& packet) {
+        packet >> p1_x >> p1_y >> p2_x >> p2_y 
+               >> p1_score >> p2_score >> p1_left >> p2_left
+               >> p1_scale_x >> p1_scale_y >> p2_scale_x >> p2_scale_y
+               >> wait;
+    }
+};
+
+class NetworkManager {
+public:
+    NetworkManager();
+    ~NetworkManager();
+    
+    // Host functions
+    bool startHost(unsigned short port = 53000);
+    bool waitForClient(sf::Time timeout = sf::Time::Zero);
+    
+    // Client functions
+    bool connectToHost(const std::string& ip, unsigned short port = 53000);
+    
+    // Communication
+    bool sendInput(const PlayerInput& input);
+    bool receiveInput(PlayerInput& input);
+    bool sendGameState(const GameState& state);
+    bool receiveGameState(GameState& state);
+    
+    // Status
+    bool isConnected() const;
+    void disconnect();
+    
+private:
+    sf::TcpListener m_listener;
+    sf::TcpSocket m_socket;
+    bool m_isHost;
+    bool m_connected;
+};

--- a/README.md
+++ b/README.md
@@ -1,241 +1,96 @@
 # Dungeon Game
 
-A small two‑player arcade style prototype built on **SFML 2**. Players control a rocket and a robot, earn points via collisions / attacks, and the game features animated sprites, sounds, music, and a simple start/end screen loop.
+A small two-player arcade-style prototype built on **SFML 2**. Players control a rocket and a
+robot, earn points via collisions and attacks, and the game features animated sprites, sounds,
+music, and a start/end screen loop. Online multiplayer (host/join over TCP) is also supported.
 
-This repository originated from a Windows Visual Studio project (`.vcxproj`). This README focuses on building and running the code on **macOS (Apple Silicon or Intel)** using Homebrew + `clang++`, and optionally CMake or Xcode.
-
-Note about SFML versions:
-- Homebrew may install SFML 3 by default as of late 2025. This code works with SFML 2.x
+See [`docs/building.md`](docs/building.md) for full build and run instructions.
 
 ---
-## 1. Project Structure
+
+## Quick start
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build -j
+./build/dungeon_game
 ```
-AnimatedGameObject.*    Sprite sheet animation helper
+
+SFML 2.6.2 is fetched and built automatically on the first configure — no system SFML install
+required. Assets are copied next to the binary at build time, so the game runs from any directory.
+
+---
+
+## Online multiplayer
+
+Launch the game and use the main menu:
+
+- **LOCAL** — two players share the keyboard (Player 1: numpad/arrows, Player 2: WASD/Space).
+- **HOST** — start a TCP server; share your local IP with the other player.
+- **JOIN** — enter the host's IP address and press Enter to connect.
+
+---
+
+## Controls
+
+| Action         | Player 1 (Robot)       | Player 2 (Rocket) |
+|----------------|------------------------|-------------------|
+| Move           | Numpad 8/5/4/6         | W/S/A/D           |
+| Attack         | Right arrow            | Space             |
+| Slow down      | O                      | O                 |
+| Speed up       | P                      | P                 |
+| Skip cooldown  | K                      | K                 |
+| Quit           | Escape                 | Escape            |
+
+---
+
+## Project layout
+
+```
+AnimatedGameObject.*    Sprite-sheet animation helper
 RegularGameObject.*     Simple textured sprite wrapper
-Game.*                  Core game loop, input handling, scoring, collisions
-GameObject.h            Base interface (implied by usage) for drawable/movable objects
-main.cpp                Start menu + end screen loop; calls Game::run()
-resource_path.h         Defines resource_path = "elements//" for asset loading
-elements/               Asset root (images, audio, fonts, sprite sheets)
-content/                (Present but unused in current code – legacy folder)
-SkeletonCode.vcxproj*   Legacy Visual Studio project files (not used on macOS)
+Game.*                  Core game loop, input, scoring, collisions, network integration
+GameObject.h            Abstract entity interface
+NetworkManager.*        TCP host/client transport; PlayerInput/GameState wire format
+main.cpp                Start/end screen menus; mode selection (local/host/join)
+resource_path.{h,cpp}   Executable-relative asset root (initResourcePath)
+elements/               Asset root — images, audio, fonts
+CMakeLists.txt          CMake build (SFML 2.6.2 via FetchContent)
+SkeletonCode.vcxproj*   Legacy Visual Studio project (kept for reference; see issue #1)
 ```
-All asset loads are performed via `resource_path + filename`, meaning the **working directory must be the project root** (so that `elements/` resolves). If you run from another directory (e.g. inside `build/`), either copy the `elements/` folder next to the executable or adjust `resource_path.h`.
 
 ---
-## 2. SFML Modules Used
-The source includes and APIs from:
-- Graphics (`#include <SFML/Graphics.hpp>`) – windows, sprites, fonts, text
-- Audio (`sf::Music`, `sf::Sound`, `sf::SoundBuffer`)
-- Window / Events (`sf::RenderWindow`, `sf::Event`)
-- System (`sf::Clock`, `sf::Time`)
 
-You must link: `sfml-graphics sfml-window sfml-system sfml-audio`.
+## Tests
 
----
-## 3. Prerequisites (macOS)
-1. Install Homebrew (if not installed):
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+ctest --test-dir build --output-on-failure
 ```
-2. Install SFML:
+
+The test framework (Catch2 via FetchContent) and test sources are added in issue #7.
+
+---
+
+## Building on Linux
+
+Install SFML's system dev packages before configuring:
+
 ```bash
-brew install sfml@2
-```
-Homebrew places headers in `/opt/homebrew/include` or `/opt/homebrew/opt/sfml` (Apple Silicon) or `/usr/local/include` (Intel), and libs in the matching `lib` directory. Use `brew --prefix sfml@2` to confirm.
-
----
-## 4. Quick Build & Run (One‑liner)
-From the project root (so `elements/` is visible):
-```bash
-clang++ -std=c++17 \
-  main.cpp Game.cpp AnimatedGameObject.cpp RegularGameObject.cpp \
-  -I"$(brew --prefix sfml@2)/include" \
-  -L"$(brew --prefix sfml@2)/lib" \
-  -lsfml-graphics -lsfml-window -lsfml-system -lsfml-audio \
-  -Wl,-rpath,"$(brew --prefix sfml@2)/lib" \
-  -O2 -o dungeon_game
-
-./dungeon_game
-```
-
-
-<details>
-
-<summary>Everything further is ai gerated and untested</summary>
-
----
-## 5. Recommended: Separate Build Directory
-```bash
-mkdir -p build
-cd build
-clang++ -std=c++17 ../main.cpp ../Game.cpp ../AnimatedGameObject.cpp ../RegularGameObject.cpp \
-  -I"$(brew --prefix)/include" -L"$(brew --prefix)/lib" \
-  -lsfml-graphics -lsfml-window -lsfml-system -lsfml-audio \
-  -Wl,-rpath,"$(brew --prefix)/lib" \
-  -O2 -o dungeon_game
-
-# Copy assets or adjust resource_path
-cp -R ../elements ./
-./dungeon_game
-```
-Alternative: edit `resource_path.h` to `"../elements//"` when running from `build/`.
-
----
-## 6. CMake Support (Optional)
-Create `CMakeLists.txt` in the repo root:
-```cmake
-cmake_minimum_required(VERSION 3.15)
-project(DungeonGame LANGUAGES CXX)
-set(CMAKE_CXX_STANDARD 17)
-set(SOURCES
-    main.cpp
-    Game.cpp
-    AnimatedGameObject.cpp
-    RegularGameObject.cpp
-)
-
-# Find SFML (Homebrew install). Accept either 2.x or 3.x
-set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};$(brew --prefix sfml)")
-find_package(SFML REQUIRED COMPONENTS graphics window system audio)
-
-add_executable(dungeon_game ${SOURCES})
-
-target_link_libraries(dungeon_game PRIVATE sfml-graphics sfml-window sfml-system sfml-audio)
-
-# Ensure runtime finds dylibs (embed rpath)
-set_target_properties(dungeon_game PROPERTIES
-    INSTALL_RPATH "$(brew --prefix)/lib"
-    BUILD_RPATH   "$(brew --prefix)/lib"
-)
-```
-Build:
-```bash
-mkdir -p build
-cd build
-cmake ..
-cmake --build . --config Release
-cp -R ../elements ./
-./dungeon_game
-```
-If `find_package` fails, supply hints:
-```bash
-cmake -DSFML_DIR="$(brew --prefix sfml)/lib/cmake/SFML" ..
-```
-If you specifically need SFML 2.x, point `SFML_DIR` at the 2.x config dir you built/installed.
-
----
-## 7. Xcode IDE Setup (Manual Linking)
-1. Open Xcode, create a new macOS Command Line Tool project (C++). 
-2. Add existing source files (`main.cpp`, etc.) to the project.
-3. Drag in the `elements/` folder ("Create folder references" so PNG/TTF/WAV ship with build or copy manually later).
-4. In Build Settings:
-   - Header Search Paths: `$(brew --prefix)/include`
-   - Library Search Paths: `$(brew --prefix)/lib`
-5. In Build Phases > Link Binary With Libraries: Add
-   - `libsfml-graphics.dylib`
-   - `libsfml-window.dylib`
-   - `libsfml-system.dylib`
-   - `libsfml-audio.dylib`
-6. Set Runpath Search Paths (`LD_RUNPATH_SEARCH_PATHS`): `$(inherited) $(brew --prefix)/lib`
-7. Ensure working directory set to project root (Scheme > Run > Options) or resource paths updated accordingly.
-
----
-## 8. Runtime Asset Path
-`resource_path.h` hardcodes:
-```cpp
-const std::string resource_path = "elements//";
-```
-So the executable must see `./elements/…` at runtime. Options:
-- Run from repo root.
-- Copy `elements/` next to produced binary.
-- Change to an absolute path or use macOS bundle resource logic (future improvement).
-
----
-## 9. Controls (Observed From Source)
-Player 1 (Robot): Arrow keys (Right key triggers attack), Numpad 4/6/8/5 also mapped for movement.
-Player 2 (Rocket): WASD movement, Space triggers attack.
-Other keys:
-- `O` slow down movement speed.
-- `P` speed up movement speed.
-- `K` skip cooldown.
-- `Escape` closes the main game window.
-- Menu interactions: Mouse over Start/Quit images and click.
-
----
-## 10. Troubleshooting (macOS)
-| Issue | Cause | Fix |
-|-------|-------|-----|
-| `dyld: Library not loaded: libsfml-graphics.*.dylib` | Runtime loader can't locate SFML dylibs | Add runpath: compile with `-Wl,-rpath,"$(brew --prefix)/lib"` OR export `DYLD_LIBRARY_PATH=$(brew --prefix)/lib`. In CMake set `INSTALL_RPATH`. |
-| Black / empty window | Asset load failure or wrong working dir | Run from repo root or confirm `elements/` exists. Check console messages. |
-| Fonts/music not found | Wrong resource path | Verify filenames & case (macOS is usually case‑insensitive but Git may differ). |
-| High CPU usage | No frame limiting (game runs as fast as possible) | Add `sf::sleep` or `setFramerateLimit(60)` on the window. |
-| Window scaled oddly / blurry on Retina | Default coordinate scaling | Optionally call `window.setView(sf::View(sf::FloatRect(0,0,width,height)));` or let macOS scale; adjust assets if blurry. |
-| Input lag with key repeat | Using event + boolean toggles without handling key repeat intervals | Acceptable for prototype; to refine, handle `KeyPressed` vs `KeyReleased` distinctly and skip toggling on repeat. |
-| Start screen recursion (calling `startgame()` repeatedly) | Design uses recursive call after closing end screen | Acceptable for small scope; for long sessions consider refactoring to a single main loop to avoid deep recursion. |
-
-Additional diagnostics:
-```bash
-otool -L dungeon_game        # List linked dylibs
-brew info sfml               # Confirm install paths
+sudo apt-get install -y \
+  libx11-dev libxrandr-dev libxcursor-dev libxi-dev \
+  libudev-dev libgl1-mesa-dev libopenal-dev
 ```
 
 ---
-## 11. Suggested Improvements (Future Work)
-- Introduce a unified game state loop (menu, play, end) rather than recursive `startgame()` calls.
-- Replace hardcoded asset dimensions (sprite sheet frame calculations) with metadata.
-- Add frame limiting or vertical sync (`m_window.setFramerateLimit(60)` or `m_window.setVerticalSyncEnabled(true)`).
-- Convert to CMake + package config entirely and remove legacy `.vcxproj` files.
-- Introduce error handling / asserts for failed loads beyond `std::cout` messages.
-- Bundle resources using an app bundle (`.app`) and relative `Resources/` path for macOS distribution.
+
+## Windows
+
+Full Windows/MSVC verification and DLL packaging are tracked in issue #1. The legacy
+`SkeletonCode.vcxproj` is kept until CMake is confirmed working on Windows.
 
 ---
-## 12. License Notes
-Fonts and other third‑party assets inside `elements/` may carry their own licenses (e.g. SIL Open Font License). Review and preserve any included license files when distributing.
 
----
-## 13. Quick Reference Commands
-```bash
-# Install dependencies
-brew install sfml
+## License
 
-# Build (simple)
-clang++ -std=c++17 main.cpp Game.cpp AnimatedGameObject.cpp RegularGameObject.cpp \
-  -I"$(brew --prefix)/include" -L"$(brew --prefix)/lib" \
-  -lsfml-graphics -lsfml-window -lsfml-system -lsfml-audio \
-  -Wl,-rpath,"$(brew --prefix)/lib" \
-  -o dungeon_game
-
-# Run from project root
-./dungeon_game
-
-# If dylib not found
-export DYLD_LIBRARY_PATH="$(brew --prefix)/lib"
-./dungeon_game
-```
-</details>
-
-### Building Release
-```bash
-# 0. start clean
-mkdir -p dist
-cp dungeon_game dist/
-cp -R elements dist/
-cd dist
-
-# 1. put bundled dylibs in a subfolder (e.g., libs)
-mkdir -p libs
-
-# 2. bundle & rewrite load paths to @executable_path/libs
-#    (note: no -oD on "." — we're using ./libs)
-dylibbundler -b -x ./dungeon_game -d ./libs -p @executable_path/libs
-
-# 3. sanity check: all non-system deps should point at @executable_path/libs
-otool -L ./dungeon_game
-otool -L ./libs/libsfml-graphics*.dylib
-If the checks look good:
-
-
-cd ..
-zip -r dungeon_game_mac.zip dist
-```
+Fonts and other third-party assets inside `elements/` carry their own licenses (e.g. SIL Open
+Font License). Review and preserve any included license files when distributing.

--- a/main.cpp
+++ b/main.cpp
@@ -1,20 +1,30 @@
 //#pragma once
 #include <SFML/Graphics.hpp>
 #include "Game.h"
+#include "NetworkManager.h"
 #include <iostream>
 #include "AnimatedGameObject.h"
 #include "resource_path.h"
 #include <tuple>
 #include <cstdio>
+#include <memory>
 
 int highscore = 0;
 int p1score = 0;
 int p2score = 0;
 std::string clack = "";
 
-void startgame() {
-    Game game;
-    std::tuple<int,int,float,int,bool> tuple = game.run();
+void endscreen(NetworkMode mode, std::shared_ptr<NetworkManager> netManager);
+
+void startgame(NetworkMode mode = NetworkMode::LOCAL, std::shared_ptr<NetworkManager> netManager = nullptr) {
+    std::tuple<int,int,float,int,bool> tuple;
+    if (mode != NetworkMode::LOCAL && netManager) {
+        Game game(mode, netManager);
+        tuple = game.run();
+    } else {
+        Game game;
+        tuple = game.run();
+    }
     p1score = std::get<0>(tuple);
     p2score = std::get<1>(tuple);
     float tempM = std::get<2>(tuple);
@@ -161,7 +171,7 @@ void startgame() {
             srect.contains(endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen)))) {
             background.stop();
             endscreen.close();
-            startgame();
+            startgame(mode, netManager);
         }
         if (sf::Mouse::isButtonPressed(sf::Mouse::Left) &&
             qrect.contains(endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen)))) {
@@ -179,7 +189,7 @@ void startgame() {
                     if (event.key.code == sf::Keyboard::Y) {
                         background.stop();
                         endscreen.close();
-                        startgame();
+                        startgame(mode, netManager);
                     }
                     if (event.key.code == sf::Keyboard::N) {
                         background.stop();
@@ -189,138 +199,428 @@ void startgame() {
             }
         }
 }
-    int main()
-    {
 
-        RegularGameObject david = RegularGameObject();
-        david.load(resource_path + "david_background.png");
+enum MenuState {
+    MAIN_MENU,
+    HOST_WAITING,
+    JOIN_INPUT,
+    READY_TO_START
+};
 
-        sf::Music background;
-        if(!background.openFromFile(resource_path + "m_start_background.wav")){
-            std::cout << "your music is broken, go fix it" << std::endl;
+int main(int argc, char** argv)
+{
+    initResourcePath(argv[0]);
+    MenuState menuState = MAIN_MENU;
+    NetworkMode mode = NetworkMode::LOCAL;
+    std::shared_ptr<NetworkManager> netManager = nullptr;
+    std::string ipInput = "127.0.0.1";
+    std::string statusMessage = "";
+    std::string hostIpAddress = "";
+
+    // Load resources
+    RegularGameObject david = RegularGameObject();
+    david.load(resource_path + "david_background.png");
+
+    sf::Music background;
+    if(!background.openFromFile(resource_path + "m_start_background.wav")){
+        std::cout << "your music is broken, go fix it" << std::endl;
+    }
+
+    background.play();
+    background.setVolume(60);
+    background.setLoop(true);
+
+    sf::SoundBuffer down_buffer;
+    sf::SoundBuffer up_buffer;
+    if(!down_buffer.loadFromFile(resource_path + "ButtonOn.wav")) {
+        std::cout << "sound did not load";
+    }
+    if(!up_buffer.loadFromFile(resource_path + "ButtonOff.wav")) {
+        std::cout << "sound did not load";
+    }
+
+    sf::Sound press;
+    sf::Sound up;
+    press.setBuffer(down_buffer);
+    up.setBuffer(up_buffer);
+
+    // Load font for UI text
+    sf::Font font;
+    if(!font.loadFromFile(resource_path + "oswald.ttf")){
+        std::cout << "Font did not load" << std::endl;
+    }
+
+    bool start_updated = false;
+    bool quit_updated = false;
+    bool host_updated = false;
+    bool join_updated = false;
+    bool back_updated = false;
+    
+    sf::RenderWindow startscreen(sf::VideoMode(1024, 576), "Dungeon Game");
+    // Create button objects for main menu
+    GameObject* m_start = new AnimatedGameObject(1331, 300, 2,1,2,0);
+    m_start->load(resource_path + "start.png");
+    m_start->setOrigin();
+    m_start->setPosition(startscreen.getSize().x/2, 200);
+    m_start->setScale(.4f);
+
+    // Create host and join buttons (will use text labels with start button image)
+    GameObject* m_host = new AnimatedGameObject(1331, 300, 2,1,2,0);
+    m_host->load(resource_path + "start.png");
+    m_host->setOrigin();
+    m_host->setPosition(startscreen.getSize().x/2, 320);
+    m_host->setScale(.4f);
+
+    GameObject* m_join = new AnimatedGameObject(1331, 300, 2,1,2,0);
+    m_join->load(resource_path + "start.png");
+    m_join->setOrigin();
+    m_join->setPosition(startscreen.getSize().x/2, 440);
+    m_join->setScale(.4f);
+
+    GameObject* m_quit = new AnimatedGameObject(1332, 300, 2,1,2,0);
+    m_quit->load(resource_path+"quit.png");
+    m_quit->setOrigin();
+    m_quit->setPosition((startscreen.getSize().x/2), 520);
+    m_quit->setScale(.3f);
+    
+    // Back button (using quit button graphics)
+    GameObject* m_back = new AnimatedGameObject(1332, 300, 2,1,2,0);
+    m_back->load(resource_path+"quit.png");
+    m_back->setOrigin();
+    m_back->setPosition(100, 50);
+    m_back->setScale(.25f);
+
+    // Text labels for buttons
+    sf::Text localLabel("LOCAL", font, 40);
+    localLabel.setFillColor(sf::Color::White);
+    localLabel.setStyle(sf::Text::Bold);
+    
+    sf::Text hostLabel("HOST", font, 40);
+    hostLabel.setFillColor(sf::Color::Green);
+    hostLabel.setStyle(sf::Text::Bold);
+    
+    sf::Text joinLabel("JOIN", font, 40);
+    joinLabel.setFillColor(sf::Color::Blue);
+    joinLabel.setStyle(sf::Text::Bold);
+    
+    sf::Text backLabel("BACK", font, 20);
+    backLabel.setFillColor(sf::Color::White);
+
+    while (startscreen.isOpen()) {
+        sf::Event event;
+        while (startscreen.pollEvent(event)) {
+            if (event.type == sf::Event::Closed) {
+                background.stop();
+                startscreen.close();
+            }
+            
+            // Handle text input for IP address in JOIN_INPUT state
+            if (menuState == JOIN_INPUT && event.type == sf::Event::TextEntered) {
+                if (event.text.unicode == '\b' && !ipInput.empty()) {
+                    ipInput.pop_back();
+                } else if (event.text.unicode == '\r' || event.text.unicode == '\n') {
+                    // Try to connect
+                    netManager = std::make_shared<NetworkManager>();
+                    statusMessage = "Connecting...";
+                    
+                    if (netManager->connectToHost(ipInput)) {
+                        mode = NetworkMode::CLIENT;
+                        menuState = READY_TO_START;
+                        statusMessage = "Connected! Click START to begin";
+                    } else {
+                        statusMessage = "Failed to connect. Check IP and try again (Enter to retry)";
+                        netManager = nullptr;
+                    }
+                } else if (event.text.unicode < 128 && event.text.unicode != '\b' && ipInput.length() < 30) {
+                    char c = static_cast<char>(event.text.unicode);
+                    // Allow only valid IP characters
+                    if ((c >= '0' && c <= '9') || c == '.' || c == ':') {
+                        ipInput += c;
+                    }
+                }
+            }
         }
 
-        background.play();
-        background.setVolume(60);
-        //background.setLoop(true);
+        // Get mouse position
+        sf::Vector2f mousePos = startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen));
+        
+        // Define button rectangles
+        sf::Rect<float> startRect(m_start->getPosition().x - (m_start->getWidth()/4), 
+                                   m_start->getPosition().y - (m_start->getHeight()/4),
+                                   m_start->getWidth() * m_start->getScale().x, 
+                                   m_start->getHeight() * m_start->getScale().y);
+        
+        sf::Rect<float> hostRect(m_host->getPosition().x - (m_host->getWidth()/4),
+                                  m_host->getPosition().y - (m_host->getHeight()/4),
+                                  m_host->getWidth() * m_host->getScale().x,
+                                  m_host->getHeight() * m_host->getScale().y);
+        
+        sf::Rect<float> joinRect(m_join->getPosition().x - (m_join->getWidth()/4),
+                                  m_join->getPosition().y - (m_join->getHeight()/4),
+                                  m_join->getWidth() * m_join->getScale().x,
+                                  m_join->getHeight() * m_join->getScale().y);
+        
+        sf::Rect<float> quitRect(m_quit->getPosition().x - (m_quit->getWidth()/4),
+                                  m_quit->getPosition().y - (m_quit->getHeight()/4),
+                                  m_quit->getWidth() * m_quit->getScale().x,
+                                  m_quit->getHeight() * m_quit->getScale().y);
+        
+        sf::Rect<float> backRect(m_back->getPosition().x - (m_back->getWidth()/4),
+                                  m_back->getPosition().y - (m_back->getHeight()/4),
+                                  m_back->getWidth() * m_back->getScale().x,
+                                  m_back->getHeight() * m_back->getScale().y);
 
-        sf::SoundBuffer down_buffer;
-        sf::SoundBuffer up_buffer;
-        if(!down_buffer.loadFromFile(resource_path + "ButtonOn.wav")) {
-            std::cout << "sound did not load";
-        }
-        if(!up_buffer.loadFromFile(resource_path + "ButtonOff.wav")) {
-            std::cout << "sound did not load";
-        }
-
-        sf::Sound press;
-        sf::Sound up;
-        press.setBuffer(down_buffer);
-        up.setBuffer(up_buffer);
-
-        bool start_updated = false;
-        bool quit_updated = false;
-        sf::RenderWindow startscreen(sf::VideoMode(1024, 576), "gamestart");
-        /*
-        sf::Font font;
-        if (!font.loadFromFile("content\\font.ttf")) {
-            std::cout << "Font screwed up" << std::endl;
-        }
-        sf::Text text = sf::Text("PLAY? (Y)es/(N)o", font, 50 );
-        text.setFillColor(sf::Color::White);
-        text.setOrigin((text.getLocalBounds().width)/2, (text.getLocalBounds().height)/2);
-        text.setPosition(startscreen.getSize().x/2, startscreen.getSize().y/2);
-        */
-
-
-
-        GameObject* m_start = new AnimatedGameObject(1331, 300, 2,1,2,0);
-        m_start->load(resource_path + "start.png");
-        m_start->setOrigin();
-        m_start->setPosition(startscreen.getSize().x/2, startscreen.getSize().y / 3);
-        m_start->setScale(.5f);
-        //gamevec.push_back(m_start);
-
-
-        GameObject* m_quit = new AnimatedGameObject(1332, 300, 2,1,2,0);
-        m_quit->load(resource_path+"quit.png");
-        m_quit->setOrigin();
-        m_quit->setPosition((startscreen.getSize().x/2), 2*(startscreen.getSize().y / 3));
-        m_quit->setScale(.5f);
-        //gamevec.push_back(m_quit);
-
-        while (startscreen.isOpen()) {
-
-            //mouse.getPosition(startscreen);
-            startscreen.clear();
-            david.draw(startscreen);
-            m_start->draw(startscreen);
-            //std::cout << "draw" << std::endl;
-            m_quit->draw(startscreen);
-            sf::Event event;
-            sf::Mouse mouse;
-            //if (mouse.getPosition(startscreen).x > m_start->getPosition().x + (m_start->getWidth() / 2) && mouse.getPosition(startscreen).x < m_start->getPosition().x - (m_start->getWidth() / 2)) {
-            sf::Rect<float> srect;
-            // m_start->setOrigin();
-            srect = sf::Rect<float>(sf::Vector2f(m_start->getPosition().x-(m_start->getWidth()/4),m_start->getPosition().y-(m_start->getHeight()/4)), sf::Vector2f(m_start->getWidth()*m_start->getScale().x, m_start->getHeight()*m_start->getScale().y));
-            //m_start->setOrigin();
-            //std::cout << (srect.contains(startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen)))) << std::endl;
-            if (srect.contains(startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen))) && !start_updated) {
+        // Handle menu state logic
+        if (menuState == MAIN_MENU) {
+            // Start button hover
+            if (startRect.contains(mousePos) && !start_updated) {
                 m_start->update(0.0f);
                 start_updated = true;
                 press.play();
-            } else if (!srect.contains(startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen))) && start_updated){
+            } else if (!startRect.contains(mousePos) && start_updated) {
                 start_updated = false;
                 m_start->update(0.0f);
                 up.play();
             }
-
-            sf::Rect<float> qrect = sf::Rect<float>(sf::Vector2f(m_quit->getPosition().x-(m_quit->getWidth()/4),m_quit->getPosition().y-(m_quit->getHeight()/4)), sf::Vector2f(m_quit->getWidth()*m_quit->getScale().x, m_quit->getHeight()*m_quit->getScale().y));
-            //m_start->setOrigin();
-            //std::cout << (qrect.contains(startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen)))) << std::endl;
-            if (qrect.contains(startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen))) && !quit_updated) {
+            
+            // Host button hover
+            if (hostRect.contains(mousePos) && !host_updated) {
+                m_host->update(0.0f);
+                host_updated = true;
+                press.play();
+            } else if (!hostRect.contains(mousePos) && host_updated) {
+                host_updated = false;
+                m_host->update(0.0f);
+                up.play();
+            }
+            
+            // Join button hover
+            if (joinRect.contains(mousePos) && !join_updated) {
+                m_join->update(0.0f);
+                join_updated = true;
+                press.play();
+            } else if (!joinRect.contains(mousePos) && join_updated) {
+                join_updated = false;
+                m_join->update(0.0f);
+                up.play();
+            }
+            
+            // Quit button hover
+            if (quitRect.contains(mousePos) && !quit_updated) {
                 m_quit->update(0.0f);
                 quit_updated = true;
                 press.play();
-                //std::cout << "I am changing the button" << std::endl;
-            } else if (!qrect.contains(startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen))) && quit_updated){
+            } else if (!quitRect.contains(mousePos) && quit_updated) {
                 quit_updated = false;
                 m_quit->update(0.0f);
                 up.play();
-                //std::cout << "button?" << std::endl;
             }
-
-            if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && srect.contains(startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen)))) {
-                background.stop();
-                startscreen.close();
-                startgame();
-            }
-            if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && qrect.contains(startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen)))) {
-                background.stop();
-                startscreen.close();
-            }
-
-            while (startscreen.pollEvent(event)) {
-                if (event.type == sf::Event::Closed) {
+            
+            // Handle clicks
+            if (sf::Mouse::isButtonPressed(sf::Mouse::Left)) {
+                if (startRect.contains(mousePos)) {
+                    mode = NetworkMode::LOCAL;
+                    menuState = READY_TO_START;
+                    sf::sleep(sf::milliseconds(200)); // Prevent double-click
+                } else if (hostRect.contains(mousePos)) {
+                    netManager = std::make_shared<NetworkManager>();
+                    if (netManager->startHost()) {
+                        mode = NetworkMode::HOST;
+                        menuState = HOST_WAITING;
+                        hostIpAddress = sf::IpAddress::getLocalAddress().toString();
+                        statusMessage = "Waiting for player 2...";
+                    } else {
+                        statusMessage = "Failed to start host!";
+                        netManager = nullptr;
+                    }
+                    sf::sleep(sf::milliseconds(200));
+                } else if (joinRect.contains(mousePos)) {
+                    menuState = JOIN_INPUT;
+                    statusMessage = "Enter host IP address";
+                    sf::sleep(sf::milliseconds(200));
+                } else if (quitRect.contains(mousePos)) {
                     background.stop();
                     startscreen.close();
-
-
-                }if (event.type == sf::Event::KeyPressed){
-                    if (event.key.code == sf::Keyboard::Y) {
-                        std::cout << "OPEN GAME" << std::endl;
-                        background.stop();
-                        startscreen.close();
-                        startgame();
-
-                    }
-                    if (event.key.code == sf::Keyboard::N) {
-                        background.stop();
-                        startscreen.close();
-                    }
                 }
             }
-            startscreen.display();
         }
-        return 0;
+        else if (menuState == HOST_WAITING) {
+            // Check for client connection
+            if (netManager && netManager->waitForClient(sf::milliseconds(100))) {
+                menuState = READY_TO_START;
+                statusMessage = "Player 2 connected! Click START to begin";
+            }
+            
+            // Back button hover
+            if (backRect.contains(mousePos) && !back_updated) {
+                m_back->update(0.0f);
+                back_updated = true;
+                press.play();
+            } else if (!backRect.contains(mousePos) && back_updated) {
+                back_updated = false;
+                m_back->update(0.0f);
+                up.play();
+            }
+            
+            // Handle back button click
+            if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && backRect.contains(mousePos)) {
+                menuState = MAIN_MENU;
+                netManager = nullptr;
+                statusMessage = "";
+                sf::sleep(sf::milliseconds(200));
+            }
+        }
+        else if (menuState == JOIN_INPUT) {
+            // Back button hover
+            if (backRect.contains(mousePos) && !back_updated) {
+                m_back->update(0.0f);
+                back_updated = true;
+                press.play();
+            } else if (!backRect.contains(mousePos) && back_updated) {
+                back_updated = false;
+                m_back->update(0.0f);
+                up.play();
+            }
+            
+            // Handle back button click
+            if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && backRect.contains(mousePos)) {
+                menuState = MAIN_MENU;
+                ipInput = "127.0.0.1";
+                statusMessage = "";
+                sf::sleep(sf::milliseconds(200));
+            }
+        }
+        else if (menuState == READY_TO_START) {
+            // Start button hover
+            if (startRect.contains(mousePos) && !start_updated) {
+                m_start->update(0.0f);
+                start_updated = true;
+                press.play();
+            } else if (!startRect.contains(mousePos) && start_updated) {
+                start_updated = false;
+                m_start->update(0.0f);
+                up.play();
+            }
+            
+            // Handle start click
+            if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && startRect.contains(mousePos)) {
+                background.stop();
+                startscreen.close();
+                startgame(mode, netManager);
+                return 0;
+            }
+        }
+
+        // Render
+        startscreen.clear();
+        david.draw(startscreen);
+        
+        if (menuState == MAIN_MENU) {
+            // Draw all buttons
+            m_start->draw(startscreen);
+            m_host->draw(startscreen);
+            m_join->draw(startscreen);
+            m_quit->draw(startscreen);
+            
+            // Draw labels on buttons
+            localLabel.setOrigin(localLabel.getGlobalBounds().width/2, localLabel.getGlobalBounds().height/2);
+            localLabel.setPosition(m_start->getPosition().x, m_start->getPosition().y);
+            startscreen.draw(localLabel);
+            
+            hostLabel.setOrigin(hostLabel.getGlobalBounds().width/2, hostLabel.getGlobalBounds().height/2);
+            hostLabel.setPosition(m_host->getPosition().x, m_host->getPosition().y);
+            startscreen.draw(hostLabel);
+            
+            joinLabel.setOrigin(joinLabel.getGlobalBounds().width/2, joinLabel.getGlobalBounds().height/2);
+            joinLabel.setPosition(m_join->getPosition().x, m_join->getPosition().y);
+            startscreen.draw(joinLabel);
+        }
+        else if (menuState == HOST_WAITING) {
+            m_back->draw(startscreen);
+            backLabel.setOrigin(backLabel.getGlobalBounds().width/2, backLabel.getGlobalBounds().height/2);
+            backLabel.setPosition(m_back->getPosition().x, m_back->getPosition().y);
+            startscreen.draw(backLabel);
+            
+            sf::Text title("HOSTING GAME", font, 50);
+            title.setFillColor(sf::Color::Green);
+            title.setStyle(sf::Text::Bold);
+            title.setOrigin(title.getGlobalBounds().width/2, 0);
+            title.setPosition(startscreen.getSize().x/2, 150);
+            startscreen.draw(title);
+            
+            sf::Text ipText("Your IP: " + hostIpAddress, font, 35);
+            ipText.setFillColor(sf::Color::White);
+            ipText.setOrigin(ipText.getGlobalBounds().width/2, 0);
+            ipText.setPosition(startscreen.getSize().x/2, 250);
+            startscreen.draw(ipText);
+            
+            sf::Text statusText(statusMessage, font, 30);
+            statusText.setFillColor(sf::Color(200, 200, 200));
+            statusText.setOrigin(statusText.getGlobalBounds().width/2, 0);
+            statusText.setPosition(startscreen.getSize().x/2, 350);
+            startscreen.draw(statusText);
+        }
+        else if (menuState == JOIN_INPUT) {
+            m_back->draw(startscreen);
+            backLabel.setOrigin(backLabel.getGlobalBounds().width/2, backLabel.getGlobalBounds().height/2);
+            backLabel.setPosition(m_back->getPosition().x, m_back->getPosition().y);
+            startscreen.draw(backLabel);
+            
+            sf::Text title("JOIN GAME", font, 50);
+            title.setFillColor(sf::Color::Blue);
+            title.setStyle(sf::Text::Bold);
+            title.setOrigin(title.getGlobalBounds().width/2, 0);
+            title.setPosition(startscreen.getSize().x/2, 150);
+            startscreen.draw(title);
+            
+            sf::Text prompt("Enter Host IP Address:", font, 30);
+            prompt.setFillColor(sf::Color::White);
+            prompt.setOrigin(prompt.getGlobalBounds().width/2, 0);
+            prompt.setPosition(startscreen.getSize().x/2, 250);
+            startscreen.draw(prompt);
+            
+            sf::Text ipText(ipInput, font, 40);
+            ipText.setFillColor(sf::Color::Green);
+            ipText.setOrigin(ipText.getGlobalBounds().width/2, 0);
+            ipText.setPosition(startscreen.getSize().x/2, 320);
+            startscreen.draw(ipText);
+            
+            sf::Text instruct("Press ENTER to connect", font, 25);
+            instruct.setFillColor(sf::Color(200, 200, 200));
+            instruct.setOrigin(instruct.getGlobalBounds().width/2, 0);
+            instruct.setPosition(startscreen.getSize().x/2, 400);
+            startscreen.draw(instruct);
+            
+            if (!statusMessage.empty()) {
+                sf::Text statusText(statusMessage, font, 22);
+                if (statusMessage.find("Failed") != std::string::npos) {
+                    statusText.setFillColor(sf::Color::Red);
+                } else {
+                    statusText.setFillColor(sf::Color::Yellow);
+                }
+                statusText.setOrigin(statusText.getGlobalBounds().width/2, 0);
+                statusText.setPosition(startscreen.getSize().x/2, 460);
+                startscreen.draw(statusText);
+            }
+        }
+        else if (menuState == READY_TO_START) {
+            m_start->draw(startscreen);
+            localLabel.setString("START");
+            localLabel.setOrigin(localLabel.getGlobalBounds().width/2, localLabel.getGlobalBounds().height/2);
+            localLabel.setPosition(m_start->getPosition().x, m_start->getPosition().y);
+            startscreen.draw(localLabel);
+            
+            sf::Text statusText(statusMessage, font, 30);
+            statusText.setFillColor(sf::Color::Green);
+            statusText.setStyle(sf::Text::Bold);
+            statusText.setOrigin(statusText.getGlobalBounds().width/2, 0);
+            statusText.setPosition(startscreen.getSize().x/2, 350);
+            startscreen.draw(statusText);
+        }
+        
+        startscreen.display();
     }
+    
+    background.stop();
+    return 0;
+}

--- a/resource_path.cpp
+++ b/resource_path.cpp
@@ -1,0 +1,13 @@
+#include "resource_path.h"
+#include <filesystem>
+
+std::string resource_path = "elements/";
+
+void initResourcePath(const char* argv0) {
+    if (!argv0) return;
+    namespace fs = std::filesystem;
+    fs::path exeDir = fs::weakly_canonical(fs::path(argv0)).parent_path();
+    if (fs::exists(exeDir / "elements")) {
+        resource_path = (exeDir / "elements/").string();
+    }
+}

--- a/resource_path.cpp
+++ b/resource_path.cpp
@@ -8,6 +8,8 @@ void initResourcePath(const char* argv0) {
     namespace fs = std::filesystem;
     fs::path exeDir = fs::weakly_canonical(fs::path(argv0)).parent_path();
     if (fs::exists(exeDir / "elements")) {
-        resource_path = (exeDir / "elements/").string();
+        // Append the separator after .string() so the trailing slash survives on
+        // MSVC std::filesystem too (call sites do `resource_path + "file"`).
+        resource_path = (exeDir / "elements").string() + "/";
     }
 }

--- a/resource_path.h
+++ b/resource_path.h
@@ -1,8 +1,5 @@
-//
-// Created by Rohan Malik on 12/4/18.
-//
-
 #pragma once
 #include <string>
 
-const std::string resource_path = "elements//";
+extern std::string resource_path;
+void initResourcePath(const char* argv0);


### PR DESCRIPTION
Resolves #10.

Adds a cross-platform CMake build system — the foundation for CI (#6), tests (#7), and everything downstream. The game previously had no build system (only a legacy `.vcxproj` + hand-typed `clang++` in the README).

## What's here
- **`CMakeLists.txt`** — C++17; locates SFML via `find_package(SFML 2.5 …)` with a **FetchContent fallback pinned to SFML 2.6.2** (`GIT_SHALLOW`), so no system SFML install is needed and every machine/CI builds the same version. Static **`dungeon_lib`** (all game logic) + **`dungeon_game`** exe (`main.cpp`) + a guarded `tests/` seam for #7. Warnings (`-Wall -Wextra -Wpedantic` / `/W4`) scoped to our targets only.
- **Executable-relative asset resolution** — `elements/` is copied next to the binary at build time, and `initResourcePath(argv[0])` resolves the asset root from the executable's directory. The game now runs from **any** working directory (previously it only worked from the repo root). Verified from repo root and `/tmp`.
- **Online-multiplayer sources imported** as the build baseline (from the prior netcode work) so the full game compiles. Netcode **hardening is #2** (next PR) — this PR imports it verbatim and does not touch its logic.
- **`.clang-format` / `.editorconfig`** for consistent style (enforcement lands with #6).
- **`.github/workflows/ci.yml`** — build-only CI on ubuntu + macos (exact SFML dev-deps, cached `_deps`), protecting the intervening PRs until #6 adds format/tidy/test jobs.
- README updated to the CMake workflow.

## Notes
- **A full SFML 3 migration is out of scope** — the code targets the SFML 2.x API; 2.6.2 is pinned deliberately.
- `-Werror` is intentionally deferred to CI in #6 (the pre-refactor code emits 13 warnings, which feed #9's cleanup); local builds surface but don't fail on them.
- Verified locally: configure+build succeeds (SFML fetched, system SFML 3 correctly skipped), assets load CWD-independently, `-DDUNGEON_BUILD_TESTS=OFF` configures with no `tests/` present.
