### PR TITLE
Harden online multiplayer netcode — #2

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -244,7 +244,7 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager) :
 	laser.setVolume(60);
 }
 
-std::tuple<int,int,float,int,bool> Game::run() {
+std::tuple<int,int,float,int,bool,bool> Game::run() {
 	//loop clock
 	sf::Clock clock;
 	//game time
@@ -270,7 +270,7 @@ std::tuple<int,int,float,int,bool> Game::run() {
 		processEvents();
 		
 		// Handle network communication
-		handleNetworkCommunication(gTime.getElapsedTime().asSeconds());
+		handleNetworkCommunication(deltaT);
 		
 		if (!wait) {
 			update(deltaT, time);
@@ -322,7 +322,7 @@ std::tuple<int,int,float,int,bool> Game::run() {
 	background.stop();
 	if (p2points > points)
 		p1win = true;
-	return {p2points,points,apieceofcrap,seconds,p1win};
+	return {p2points, points, apieceofcrap, seconds, p1win, m_peerLeft};
 }
 
 void Game::processEvents() {
@@ -617,8 +617,51 @@ void Game::update(sf::Time deltaT,float time) {
 }
 
 void Game::render() {
+	// CLIENT: temporarily shift sprites to interpolated positions for drawing.
+	// Positions are saved and restored so update()/collision use authoritative coords.
+	sf::Vector2f p1Saved, p2Saved;
+	bool didShift = false;
+
+	if (m_networkMode == NetworkMode::CLIENT && m_networkManager &&
+	    !m_networkManager->stateBuf().empty())
+	{
+		p1Saved = m_player->getPosition();
+		p2Saved = player2->getPosition();
+		didShift = true;
+
+		const auto& buf = m_networkManager->stateBuf();
+		constexpr float kInterpDelay = 0.04f; // 40 ms behind
+		sf::Time target = m_networkManager->elapsed() - sf::seconds(kInterpDelay);
+
+		sf::Vector2f rp1, rp2;
+		if (buf.size() >= 2) {
+			// Find the last snapshot pair bracketing target (or use the last pair
+			// if target is past all entries).
+			std::size_t ai = 0;
+			for (std::size_t i = 0; i + 1 < buf.size(); ++i) {
+				if (buf[i].arrival <= target) ai = i;
+			}
+			std::size_t bi = std::min(ai + 1, buf.size() - 1);
+			const auto& sa = buf[ai];
+			const auto& sb = buf[bi];
+			float span = (sb.arrival - sa.arrival).asSeconds();
+			float t = (span > 0.f)
+			              ? (target - sa.arrival).asSeconds() / span
+			              : 1.f;
+			rp1 = lerpPos({sa.state.p1_x, sa.state.p1_y},
+			              {sb.state.p1_x, sb.state.p1_y}, t);
+			rp2 = lerpPos({sa.state.p2_x, sa.state.p2_y},
+			              {sb.state.p2_x, sb.state.p2_y}, t);
+		} else {
+			rp1 = {buf[0].state.p1_x, buf[0].state.p1_y};
+			rp2 = {buf[0].state.p2_x, buf[0].state.p2_y};
+		}
+		m_player->setPosition(rp1.x, rp1.y);
+		player2->setPosition(rp2.x, rp2.y);
+	}
+
 	m_window.clear();
-	for (int x = 0; x < stuff.size(); x++) {
+	for (std::size_t x = 0; x < stuff.size(); ++x) {
 		stuff[x]->draw(m_window);
 	}
 	m_window.draw(timer);
@@ -631,6 +674,12 @@ void Game::render() {
 		m_window.draw(info);
 	}
 	m_window.display();
+
+	// Restore authoritative positions (symmetric with the save above).
+	if (didShift) {
+		m_player->setPosition(p1Saved.x, p1Saved.y);
+		player2->setPosition(p2Saved.x, p2Saved.y);
+	}
 }
 
 bool Game::collision(GameObject* a,GameObject* b) {
@@ -645,42 +694,59 @@ bool Game::collision(sf::Rect<float> a,GameObject* b) {
 	return a.intersects(brect);
 }
 
-void Game::handleNetworkCommunication(float gameTime) {
-	if (!m_networkManager || !m_networkManager->isConnected()) {
-		return;
-	}
+void Game::handleNetworkCommunication(sf::Time deltaT) {
+	if (!m_networkManager) return;
 
-	if (m_networkMode == NetworkMode::HOST) {
-		// Host: receive client input for player 2
+	if (m_networkMode == NetworkMode::HOST && m_networkManager->isConnected()) {
+		m_networkManager->poll();
+
+		// Consume all queued inputs; keep only the most recent.
 		PlayerInput clientInput;
-		if (m_networkManager->receiveInput(clientInput)) {
-			// Apply client input to player 2 controls
-			w = clientInput.up;
-			s = clientInput.down;
-			a = clientInput.left;
-			d = clientInput.right;
+		PlayerInput tmp;
+		bool got = false;
+		while (m_networkManager->nextInput(tmp)) {
+			clientInput = tmp;
+			got = true;
+		}
+		if (got) {
+			w     = clientInput.up;
+			s     = clientInput.down;
+			a     = clientInput.left;
+			d     = clientInput.right;
 			space = clientInput.attack;
 		}
 
-		// Send game state to client
-		GameState state = captureGameState();
-		m_networkManager->sendGameState(state);
+		// Fixed-rate state send (~25 Hz).
+		m_stateAccum += deltaT.asSeconds();
+		if (m_stateAccum >= kStateSendInterval) {
+			m_stateAccum -= kStateSendInterval;
+			m_networkManager->sendGameState(captureGameState());
+		}
 	}
-	else if (m_networkMode == NetworkMode::CLIENT) {
-		// Client: send player 2 input to host
+	else if (m_networkMode == NetworkMode::CLIENT && m_networkManager->isConnected()) {
+		// Send local input every frame.
 		PlayerInput myInput;
-		myInput.up = w;
-		myInput.down = s;
-		myInput.left = a;
-		myInput.right = d;
+		myInput.up     = w;
+		myInput.down   = s;
+		myInput.left   = a;
+		myInput.right  = d;
 		myInput.attack = space;
 		m_networkManager->sendInput(myInput);
 
-		// Receive and apply game state from host
-		GameState state;
-		if (m_networkManager->receiveGameState(state)) {
-			applyNetworkState(state);
+		// Drain incoming state packets.
+		m_networkManager->poll();
+
+		// Apply the latest snapshot for update()/collision (authoritative).
+		if (!m_networkManager->stateBuf().empty()) {
+			m_latestState = m_networkManager->stateBuf().back().state;
+			applyNetworkState(m_latestState);
 		}
+	}
+
+	// Peer-loss check (runs after poll/send on either side).
+	if (!m_peerLeft && m_networkManager->peerLost()) {
+		m_peerLeft = true;
+		m_window.close();
 	}
 }
 

--- a/Game.h
+++ b/Game.h
@@ -19,7 +19,7 @@ public:
 	Game();
 	Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager);
 	//run the game
-	std::tuple<int,int,float,int,bool> run();
+	std::tuple<int,int,float,int,bool,bool> run();
 
 private:
 	void processEvents();
@@ -97,9 +97,14 @@ private:
 	// Network support
 	NetworkMode m_networkMode = NetworkMode::LOCAL;
 	std::shared_ptr<NetworkManager> m_networkManager;
-	void handleNetworkCommunication(float gameTime);
+	void handleNetworkCommunication(sf::Time deltaT);
 	void applyNetworkState(const GameState& state);
 	GameState captureGameState() const;
+
+	bool      m_peerLeft   = false;
+	GameState m_latestState;
+	float     m_stateAccum = 0.f;
+	static constexpr float kStateSendInterval = 1.f / 25.f; // ~25 Hz
 
 };
 

--- a/NetworkManager.cpp
+++ b/NetworkManager.cpp
@@ -67,9 +67,10 @@ bool NetworkManager::flushSend()
     }
     if (status == sf::Socket::Disconnected || status == sf::Socket::Error)
         setDisconnected();
-    // Partial: SFML 2.x stores the send position inside the packet; the next
-    // flushSend() call will re-send the same instance and resume from there.
-    // Slot stays occupied; caller drops its new message (by returning false).
+    // Partial: SFML 2.x copies the payload into the SOCKET's internal buffer on the
+    // first send() and stores progress there; the next send() on this socket resumes
+    // from that buffer regardless of which packet instance is passed (we pass the same
+    // untouched m_pendingSend). Slot stays occupied; caller drops its new message.
     return false;
 }
 
@@ -111,7 +112,7 @@ bool NetworkManager::connectToHost(const std::string& ip, unsigned short port)
         std::cout << "Invalid IP address: " << ip << "\n";
         return false;
     }
-    if (port < 1024 || port > 65535) {
+    if (port < 1024) { // unsigned short caps at 65535, so only the low bound is meaningful
         std::cout << "Invalid port: " << port << "\n";
         return false;
     }
@@ -187,6 +188,9 @@ void NetworkManager::disconnect()
 {
     m_socket.disconnect();
     m_listener.close();
-    m_connected = false;
-    m_peerLeft  = false; // reset so a reused manager starts clean
+    m_connected  = false;
+    m_peerLeft   = false;
+    m_hasPending = false; // reset all transient state so a reused manager starts clean
+    m_stateBuf.clear();
+    m_inputQueue.clear();
 }

--- a/NetworkManager.cpp
+++ b/NetworkManager.cpp
@@ -1,40 +1,101 @@
 #include "NetworkManager.h"
+#include <algorithm>
 #include <iostream>
 
-NetworkManager::NetworkManager() 
-    : m_isHost(false), m_connected(false) {
-    // Socket blocking will be set appropriately in each method
+// ── free functions ────────────────────────────────────────────────────────────
+
+void dispatchPacket(sf::Packet& pkt, sf::Time arrival,
+                    std::deque<TimedState>&  stateBuf,
+                    std::deque<PlayerInput>& inputQueue,
+                    std::size_t cap)
+{
+    sf::Uint8 typeRaw = 0;
+    if (!(pkt >> typeRaw)) return;
+
+    switch (static_cast<MsgType>(typeRaw)) {
+    case MsgType::State: {
+        TimedState ts;
+        ts.arrival = arrival;
+        ts.state.fromPacket(pkt);
+        if (stateBuf.size() >= cap) stateBuf.pop_front();
+        stateBuf.push_back(ts);
+        break;
+    }
+    case MsgType::Input: {
+        PlayerInput inp;
+        inp.fromPacket(pkt);
+        inputQueue.push_back(inp);
+        break;
+    }
+    default: {
+        static bool warned = false;
+        if (!warned) {
+            std::cerr << "NetworkManager: unknown message type "
+                      << static_cast<int>(typeRaw) << " — discarding\n";
+            warned = true;
+        }
+        break;
+    }
+    }
 }
 
-NetworkManager::~NetworkManager() {
-    disconnect();
+sf::Vector2f lerpPos(sf::Vector2f from, sf::Vector2f to, float t)
+{
+    t = std::max(0.f, std::min(1.f, t));
+    return from + (to - from) * t;
 }
 
-bool NetworkManager::startHost(unsigned short port) {
+// ── NetworkManager ────────────────────────────────────────────────────────────
+
+NetworkManager::NetworkManager() = default;
+NetworkManager::~NetworkManager() { disconnect(); }
+
+void NetworkManager::setDisconnected()
+{
+    m_connected = false;
+    m_peerLeft  = true;
+}
+
+// Try to send the pending packet; returns true when the slot is now clear.
+bool NetworkManager::flushSend()
+{
+    if (!m_hasPending) return true;
+    auto status = m_socket.send(m_pendingSend);
+    if (status == sf::Socket::Done) {
+        m_hasPending = false;
+        return true;
+    }
+    if (status == sf::Socket::Disconnected || status == sf::Socket::Error)
+        setDisconnected();
+    // Partial: SFML 2.x stores the send position inside the packet; the next
+    // flushSend() call will re-send the same instance and resume from there.
+    // Slot stays occupied; caller drops its new message (by returning false).
+    return false;
+}
+
+bool NetworkManager::startHost(unsigned short port)
+{
     m_isHost = true;
-    
-    // Enable address reuse to prevent "address already in use" errors
     m_listener.setBlocking(false);
-    
-    if (m_listener.listen(port, sf::IpAddress::Any) != sf::Socket::Done) {
-        std::cout << "Failed to bind to port " << port << std::endl;
+    if (m_listener.listen(port) != sf::Socket::Done) {
+        std::cout << "Failed to bind to port " << port << "\n";
         return false;
     }
-    
-    std::cout << "Hosting on port " << port << std::endl;
-    std::cout << "Your IP: " << sf::IpAddress::getLocalAddress().toString() << std::endl;
+    std::cout << "Hosting on port " << m_listener.getLocalPort() << "\n";
+    std::cout << "Your IP: " << sf::IpAddress::getLocalAddress() << "\n";
     return true;
 }
 
-bool NetworkManager::waitForClient(sf::Time timeout) {
-    if (!m_isHost) return false;
-    
+bool NetworkManager::waitForClient(sf::Time timeout)
+{
+    if (!m_isHost || m_connected) return false; // already accepted; listener is closed
     sf::Clock clock;
     while (timeout == sf::Time::Zero || clock.getElapsedTime() < timeout) {
         if (m_listener.accept(m_socket) == sf::Socket::Done) {
-            std::cout << "Client connected: " << m_socket.getRemoteAddress() << std::endl;
+            std::cout << "Client connected: " << m_socket.getRemoteAddress() << "\n";
             m_socket.setBlocking(false);
             m_connected = true;
+            m_listener.close(); // 1v1: stop accepting new connections
             return true;
         }
         sf::sleep(sf::milliseconds(10));
@@ -42,88 +103,90 @@ bool NetworkManager::waitForClient(sf::Time timeout) {
     return false;
 }
 
-bool NetworkManager::connectToHost(const std::string& ip, unsigned short port) {
-    m_isHost = false;
-    std::cout << "Connecting to " << ip << ":" << port << std::endl;
-    
-    // Set socket to blocking for the connection attempt
-    m_socket.setBlocking(true);
-    
-    sf::Socket::Status status = m_socket.connect(ip, port, sf::seconds(10));
-    
-    if (status != sf::Socket::Done) {
-        std::cout << "Failed to connect to host (status: " << status << ")" << std::endl;
-        m_socket.setBlocking(false);
+bool NetworkManager::connectToHost(const std::string& ip, unsigned short port)
+{
+    // Validate ip before doing any blocking work — bad input fails instantly.
+    sf::IpAddress addr(ip);
+    if (addr == sf::IpAddress::None) {
+        std::cout << "Invalid IP address: " << ip << "\n";
         return false;
     }
-    
-    // Switch to non-blocking after successful connection
+    if (port < 1024 || port > 65535) {
+        std::cout << "Invalid port: " << port << "\n";
+        return false;
+    }
+
+    m_isHost = false;
+    std::cout << "Connecting to " << ip << ":" << port << "\n";
+    m_socket.setBlocking(true);
+    auto status = m_socket.connect(addr, port, sf::seconds(10));
     m_socket.setBlocking(false);
+
+    if (status != sf::Socket::Done) {
+        std::cout << "Failed to connect (status: " << status << ")\n";
+        return false;
+    }
     m_connected = true;
-    std::cout << "Connected to host successfully!" << std::endl;
+    std::cout << "Connected!\n";
     return true;
 }
 
-bool NetworkManager::sendInput(const PlayerInput& input) {
+bool NetworkManager::sendInput(const PlayerInput& input)
+{
     if (!m_connected) return false;
-    
-    sf::Packet packet;
-    packet << static_cast<sf::Uint8>(1); // Message type: input
-    input.toPacket(packet);
-    
-    return m_socket.send(packet) == sf::Socket::Done;
+    if (!flushSend()) return false; // pending slot still occupied — drop
+
+    m_pendingSend.clear();
+    m_pendingSend << static_cast<sf::Uint8>(MsgType::Input);
+    input.toPacket(m_pendingSend);
+    m_hasPending = true;
+    return flushSend();
 }
 
-bool NetworkManager::receiveInput(PlayerInput& input) {
+bool NetworkManager::sendGameState(const GameState& state)
+{
     if (!m_connected) return false;
-    
-    sf::Packet packet;
-    sf::Socket::Status status = m_socket.receive(packet);
-    
-    if (status == sf::Socket::Done) {
-        sf::Uint8 messageType;
-        packet >> messageType;
-        if (messageType == 1) {
-            input.fromPacket(packet);
-            return true;
+    if (!flushSend()) return false;
+
+    m_pendingSend.clear();
+    m_pendingSend << static_cast<sf::Uint8>(MsgType::State);
+    state.toPacket(m_pendingSend);
+    m_hasPending = true;
+    return flushSend();
+}
+
+void NetworkManager::poll()
+{
+    if (!m_connected) return;
+    sf::Packet pkt;
+    for (;;) {
+        auto status = m_socket.receive(pkt);
+        if (status == sf::Socket::Done) {
+            dispatchPacket(pkt, m_clock.getElapsedTime(),
+                           m_stateBuf, m_inputQueue, kStateBufCap);
+        } else if (status == sf::Socket::NotReady || status == sf::Socket::Partial) {
+            // NotReady: no data yet.
+            // Partial: SFML stores receive progress inside the socket; resume next poll().
+            break;
+        } else { // Disconnected or Error
+            setDisconnected();
+            break;
         }
     }
-    return false;
 }
 
-bool NetworkManager::sendGameState(const GameState& state) {
-    if (!m_connected) return false;
-    
-    sf::Packet packet;
-    packet << static_cast<sf::Uint8>(2); // Message type: game state
-    state.toPacket(packet);
-    
-    return m_socket.send(packet) == sf::Socket::Done;
+bool NetworkManager::nextInput(PlayerInput& input)
+{
+    if (m_inputQueue.empty()) return false;
+    input = m_inputQueue.front();
+    m_inputQueue.pop_front();
+    return true;
 }
 
-bool NetworkManager::receiveGameState(GameState& state) {
-    if (!m_connected) return false;
-    
-    sf::Packet packet;
-    sf::Socket::Status status = m_socket.receive(packet);
-    
-    if (status == sf::Socket::Done) {
-        sf::Uint8 messageType;
-        packet >> messageType;
-        if (messageType == 2) {
-            state.fromPacket(packet);
-            return true;
-        }
-    }
-    return false;
-}
-
-bool NetworkManager::isConnected() const {
-    return m_connected;
-}
-
-void NetworkManager::disconnect() {
+void NetworkManager::disconnect()
+{
     m_socket.disconnect();
     m_listener.close();
     m_connected = false;
+    m_peerLeft  = false; // reset so a reused manager starts clean
 }

--- a/NetworkManager.h
+++ b/NetworkManager.h
@@ -1,14 +1,12 @@
 #pragma once
 
 #include <SFML/Network.hpp>
+#include <deque>
 #include <string>
-#include <memory>
 
-enum class NetworkMode {
-    LOCAL,
-    HOST,
-    CLIENT
-};
+enum class NetworkMode { LOCAL, HOST, CLIENT };
+
+enum class MsgType : sf::Uint8 { Input = 1, State = 2 };
 
 struct PlayerInput {
     bool up = false;
@@ -16,69 +14,109 @@ struct PlayerInput {
     bool left = false;
     bool right = false;
     bool attack = false;
-    
-    // Serialize to packet
+
     void toPacket(sf::Packet& packet) const {
         packet << up << down << left << right << attack;
     }
-    
-    // Deserialize from packet
     void fromPacket(sf::Packet& packet) {
         packet >> up >> down >> left >> right >> attack;
     }
 };
 
 struct GameState {
-    float p1_x, p1_y;
-    float p2_x, p2_y;
-    int p1_score;
-    int p2_score;
-    bool p1_left;
-    bool p2_left;
-    float p1_scale_x, p1_scale_y;
-    float p2_scale_x, p2_scale_y;
-    bool wait;
-    
+    float p1_x = 0, p1_y = 0;
+    float p2_x = 0, p2_y = 0;
+    int   p1_score = 0, p2_score = 0;
+    bool  p1_left = false, p2_left = false;
+    float p1_scale_x = 1, p1_scale_y = 1;
+    float p2_scale_x = 1, p2_scale_y = 1;
+    bool  wait = false;
+
     void toPacket(sf::Packet& packet) const {
-        packet << p1_x << p1_y << p2_x << p2_y 
+        packet << p1_x << p1_y << p2_x << p2_y
                << p1_score << p2_score << p1_left << p2_left
                << p1_scale_x << p1_scale_y << p2_scale_x << p2_scale_y
                << wait;
     }
-    
     void fromPacket(sf::Packet& packet) {
-        packet >> p1_x >> p1_y >> p2_x >> p2_y 
+        packet >> p1_x >> p1_y >> p2_x >> p2_y
                >> p1_score >> p2_score >> p1_left >> p2_left
                >> p1_scale_x >> p1_scale_y >> p2_scale_x >> p2_scale_y
                >> wait;
     }
 };
 
+// A GameState snapshot paired with its receive timestamp.
+struct TimedState {
+    GameState state;
+    sf::Time  arrival;
+};
+
+// Socket-free demux: reads the leading MsgType byte and routes into the
+// appropriate buffer.  Unknown types are logged once and discarded.
+// cap limits stateBuf size (oldest entry evicted when full).
+void dispatchPacket(sf::Packet& pkt, sf::Time arrival,
+                    std::deque<TimedState>&  stateBuf,
+                    std::deque<PlayerInput>& inputQueue,
+                    std::size_t cap);
+
+// Pure linear interpolation between two 2-D positions; t is clamped to [0,1].
+sf::Vector2f lerpPos(sf::Vector2f from, sf::Vector2f to, float t);
+
 class NetworkManager {
 public:
     NetworkManager();
     ~NetworkManager();
-    
-    // Host functions
+
+    // Host API
     bool startHost(unsigned short port = 53000);
     bool waitForClient(sf::Time timeout = sf::Time::Zero);
-    
-    // Client functions
+
+    // Client API — validates ip before blocking connect; bad IP fails instantly.
     bool connectToHost(const std::string& ip, unsigned short port = 53000);
-    
-    // Communication
+
+    // Send (one-slot pending; drops new message if slot not yet cleared)
     bool sendInput(const PlayerInput& input);
-    bool receiveInput(PlayerInput& input);
     bool sendGameState(const GameState& state);
-    bool receiveGameState(GameState& state);
-    
+
+    // Drain socket into internal buffers; call every frame.
+    void poll();
+
+    // Pop oldest queued PlayerInput (returns false when queue empty).
+    bool nextInput(PlayerInput& input);
+
+    // Read-only view of the state buffer; newest snapshot is at back().
+    const std::deque<TimedState>& stateBuf() const { return m_stateBuf; }
+
+    // Elapsed time on the NetworkManager's internal clock (used by render interpolation).
+    sf::Time elapsed() const { return m_clock.getElapsedTime(); }
+
+    // Port the listener is bound to (useful for ephemeral-port testing).
+    unsigned short localPort() const { return m_listener.getLocalPort(); }
+
     // Status
-    bool isConnected() const;
+    bool isConnected() const { return m_connected; }
+    bool peerLost()    const { return m_peerLeft; }
     void disconnect();
-    
+
 private:
+    void setDisconnected();
+    bool flushSend();   // returns true when the pending slot is clear
+
     sf::TcpListener m_listener;
-    sf::TcpSocket m_socket;
-    bool m_isHost;
-    bool m_connected;
+    sf::TcpSocket   m_socket;
+    sf::Clock       m_clock;
+
+    bool m_isHost    = false;
+    bool m_connected = false;
+    bool m_peerLeft  = false;
+
+    // One-slot pending send (no queue).
+    sf::Packet m_pendingSend;
+    bool       m_hasPending = false;
+
+    std::deque<TimedState>  m_stateBuf;
+    std::deque<PlayerInput> m_inputQueue;
+
+    static constexpr std::size_t kStateBufCap = 8;
 };

--- a/main.cpp
+++ b/main.cpp
@@ -14,10 +14,8 @@ int p1score = 0;
 int p2score = 0;
 std::string clack = "";
 
-void endscreen(NetworkMode mode, std::shared_ptr<NetworkManager> netManager);
-
 void startgame(NetworkMode mode = NetworkMode::LOCAL, std::shared_ptr<NetworkManager> netManager = nullptr) {
-    std::tuple<int,int,float,int,bool> tuple;
+    std::tuple<int,int,float,int,bool,bool> tuple;
     if (mode != NetworkMode::LOCAL && netManager) {
         Game game(mode, netManager);
         tuple = game.run();
@@ -29,6 +27,7 @@ void startgame(NetworkMode mode = NetworkMode::LOCAL, std::shared_ptr<NetworkMan
     p2score = std::get<1>(tuple);
     float tempM = std::get<2>(tuple);
     int tempS = std::get<3>(tuple);
+    bool peerLeft = std::get<5>(tuple);
     //bool p1win = std::get<4>(tuple);
     char gTime [10];
     std::snprintf(gTime, sizeof(gTime), "%02.0f:%02d", tempM, tempS);
@@ -60,6 +59,16 @@ void startgame(NetworkMode mode = NetworkMode::LOCAL, std::shared_ptr<NetworkMan
 
     sf::RenderWindow endscreen(sf::VideoMode(1024, 576), "end game");
     sf::Event event;
+
+    sf::Text peerDisconnectedText("", pfont, 36);
+    if (peerLeft) {
+        peerDisconnectedText.setString("Peer disconnected");
+        peerDisconnectedText.setFillColor(sf::Color::Red);
+        peerDisconnectedText.setStyle(sf::Text::Bold);
+        // Use getLocalBounds for centering — unaffected by world transform.
+        peerDisconnectedText.setOrigin(peerDisconnectedText.getLocalBounds().width / 2.f, 0);
+        peerDisconnectedText.setPosition(endscreen.getSize().x / 2.f, 460.f);
+    }
 
     sf::Music background;
     if (!background.openFromFile(resource_path + "m_start_background.wav")) {
@@ -130,6 +139,7 @@ void startgame(NetworkMode mode = NetworkMode::LOCAL, std::shared_ptr<NetworkMan
         endscreen.draw(highscoret);
         m_start->draw(endscreen);
         m_quit->draw(endscreen);
+        if (peerLeft) endscreen.draw(peerDisconnectedText);
         endscreen.display();
 
         sf::Event event;
@@ -328,7 +338,7 @@ int main(int argc, char** argv)
                         menuState = READY_TO_START;
                         statusMessage = "Connected! Click START to begin";
                     } else {
-                        statusMessage = "Failed to connect. Check IP and try again (Enter to retry)";
+                        statusMessage = "Failed to connect (invalid IP or host unreachable)";
                         netManager = nullptr;
                     }
                 } else if (event.text.unicode < 128 && event.text.unicode != '\b' && ipInput.length() < 30) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.16)
+
+# ── Unit tests (socket-free) ──────────────────────────────────────────────────
+add_executable(test_netcode test_netcode.cpp)
+target_link_libraries(test_netcode PRIVATE dungeon_lib)
+
+# ── Loopback integration tests ────────────────────────────────────────────────
+add_executable(test_loopback test_loopback.cpp)
+target_link_libraries(test_loopback PRIVATE dungeon_lib)
+
+# ── Warnings (mirror root settings) ──────────────────────────────────────────
+foreach(t test_netcode test_loopback)
+    if(MSVC)
+        target_compile_options(${t} PRIVATE /W4)
+    else()
+        target_compile_options(${t} PRIVATE -Wall -Wextra -Wpedantic)
+    endif()
+endforeach()
+
+# ── Register with ctest ───────────────────────────────────────────────────────
+add_test(NAME netcode_unit     COMMAND test_netcode)
+add_test(NAME netcode_loopback COMMAND test_loopback)

--- a/tests/test_loopback.cpp
+++ b/tests/test_loopback.cpp
@@ -6,7 +6,8 @@
 //   1. client sendInput  → host poll / nextInput
 //   2. host sendGameState → client poll / stateBuf
 //   3. unknown-type discard via raw TcpSocket (same framing, type byte = 99)
-//   4. disconnect detection: client disconnect → host peerLost()
+//   4. receive-side disconnect detection: client disconnect → host peerLost()
+//   5. send-side disconnect detection: host drops → client sendInput path → peerLost()
 
 #include <cassert>
 #include <cmath>
@@ -100,13 +101,40 @@ int main()
         assert(!host2.nextInput(dummy));
     }
 
-    // ── Test 4: disconnect detection ─────────────────────────────────────────
-    // Disconnect the client; host should detect it via poll().
+    // ── Test 4: receive-side disconnect detection ────────────────────────────
+    // Disconnect the client; host should detect it via poll() (receive path).
     {
         client.disconnect();
 
         bool detected = waitFor(host,
             [&]{ return !host.isConnected() || host.peerLost(); });
+        assert(detected);
+    }
+
+    // ── Test 5: send-side disconnect detection ───────────────────────────────
+    // Host drops abruptly; the CLIENT (the frequent sender) must detect the dead
+    // connection through its SEND path (flushSend → Error/Disconnected →
+    // setDisconnected) with NO poll() — the OS may buffer the first writes before
+    // reporting the reset, so retry a bounded number of sends.
+    {
+        NetworkManager host3;
+        assert(host3.startHost(0));
+        unsigned short port3 = host3.localPort();
+
+        NetworkManager client3;
+        assert(client3.connectToHost("127.0.0.1", port3));
+        assert(host3.waitForClient(sf::seconds(5)));
+        assert(client3.isConnected());
+
+        host3.disconnect(); // host gone
+
+        bool detected = false;
+        PlayerInput inp;
+        for (int i = 0; i < 300 && !detected; ++i) {
+            client3.sendInput(inp); // send path only — no poll()
+            if (!client3.isConnected() || client3.peerLost()) detected = true;
+            sf::sleep(sf::milliseconds(5));
+        }
         assert(detected);
     }
 

--- a/tests/test_loopback.cpp
+++ b/tests/test_loopback.cpp
@@ -1,0 +1,115 @@
+// Loopback integration tests: exercises real socket paths in a single process.
+// HOST and CLIENT NetworkManagers communicate over 127.0.0.1 on an ephemeral
+// port (port 0 → OS picks one), so the test never conflicts with a running game.
+//
+// Covered paths:
+//   1. client sendInput  → host poll / nextInput
+//   2. host sendGameState → client poll / stateBuf
+//   3. unknown-type discard via raw TcpSocket (same framing, type byte = 99)
+//   4. disconnect detection: client disconnect → host peerLost()
+
+#include <cassert>
+#include <cmath>
+#include <iostream>
+
+#include <SFML/Network.hpp>
+#include "NetworkManager.h"
+
+// Poll nm up to maxTries × sleepMs, returning true as soon as cond() is true.
+template <typename F>
+static bool waitFor(NetworkManager& nm, F cond, int maxTries = 200, int sleepMs = 5)
+{
+    for (int i = 0; i < maxTries; ++i) {
+        nm.poll();
+        if (cond()) return true;
+        sf::sleep(sf::milliseconds(sleepMs));
+    }
+    return false;
+}
+
+int main()
+{
+    // ── Setup: host listens on an ephemeral port, client connects ─────────────
+    NetworkManager host;
+    assert(host.startHost(0));
+    unsigned short port = host.localPort();
+    assert(port != 0);
+
+    NetworkManager client;
+    assert(client.connectToHost("127.0.0.1", port));
+
+    // Host's accept loop (non-blocking listener; returns quickly for loopback).
+    assert(host.waitForClient(sf::seconds(5)));
+
+    assert(host.isConnected());
+    assert(client.isConnected());
+
+    // ── Test 1: client sendInput → host poll / nextInput ─────────────────────
+    {
+        PlayerInput sent;
+        sent.up = true; sent.attack = true;
+        assert(client.sendInput(sent));
+
+        PlayerInput recv;
+        bool got = waitFor(host, [&]{ return host.nextInput(recv); });
+        assert(got);
+        assert(recv.up     == true);
+        assert(recv.attack == true);
+        assert(recv.down   == false);
+        assert(recv.left   == false);
+    }
+
+    // ── Test 2: host sendGameState → client poll / stateBuf ──────────────────
+    {
+        GameState sent;
+        sent.p1_x = 123.f; sent.p2_y = 456.f; sent.p1_score = 7;
+        assert(host.sendGameState(sent));
+
+        bool got = waitFor(client, [&]{ return !client.stateBuf().empty(); });
+        assert(got);
+        const GameState& r = client.stateBuf().back().state;
+        assert(std::abs(r.p1_x - 123.f) < 1e-4f);
+        assert(std::abs(r.p2_y - 456.f) < 1e-4f);
+        assert(r.p1_score == 7);
+    }
+
+    // ── Test 3: unknown-type packet is discarded (raw TcpSocket sender) ───────
+    {
+        NetworkManager host2;
+        assert(host2.startHost(0));
+        unsigned short port2 = host2.localPort();
+
+        sf::TcpSocket rawSender;
+        rawSender.setBlocking(true);
+        assert(rawSender.connect(sf::IpAddress::LocalHost, port2) == sf::Socket::Done);
+        assert(host2.waitForClient(sf::seconds(5)));
+
+        sf::Packet unknownPkt;
+        unknownPkt << static_cast<sf::Uint8>(99);
+        rawSender.send(unknownPkt); // SFML framing: 4-byte length prefix
+
+        // Poll in a bounded loop to give the packet time to arrive.
+        for (int i = 0; i < 100; ++i) {
+            host2.poll();
+            sf::sleep(sf::milliseconds(5));
+        }
+
+        // Buffers must be empty — the packet was discarded, not crashed on.
+        assert(host2.stateBuf().empty());
+        PlayerInput dummy;
+        assert(!host2.nextInput(dummy));
+    }
+
+    // ── Test 4: disconnect detection ─────────────────────────────────────────
+    // Disconnect the client; host should detect it via poll().
+    {
+        client.disconnect();
+
+        bool detected = waitFor(host,
+            [&]{ return !host.isConnected() || host.peerLost(); });
+        assert(detected);
+    }
+
+    std::cout << "All loopback integration tests passed.\n";
+    return 0;
+}

--- a/tests/test_netcode.cpp
+++ b/tests/test_netcode.cpp
@@ -1,0 +1,217 @@
+// Socket-free unit tests for NetworkManager.
+// Covers: PlayerInput/GameState packet round-trips, dispatchPacket routing,
+// and lerpPos math.  No Catch2 — plain assert + main() until issue #7.
+
+#include <cassert>
+#include <cmath>
+#include <deque>
+#include <iostream>
+
+#include "NetworkManager.h"
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+static constexpr float kEps = 1e-5f;
+static bool feq(float a, float b) { return std::abs(a - b) < kEps; }
+
+// ── PlayerInput round-trip ────────────────────────────────────────────────────
+
+static void test_playerinput_roundtrip()
+{
+    PlayerInput orig;
+    orig.up = true; orig.down = false; orig.left = true;
+    orig.right = false; orig.attack = true;
+
+    sf::Packet pkt;
+    orig.toPacket(pkt);
+
+    PlayerInput got;
+    got.fromPacket(pkt);
+
+    assert(got.up     == orig.up);
+    assert(got.down   == orig.down);
+    assert(got.left   == orig.left);
+    assert(got.right  == orig.right);
+    assert(got.attack == orig.attack);
+}
+
+// ── GameState round-trip ──────────────────────────────────────────────────────
+
+static void test_gamestate_roundtrip()
+{
+    GameState orig;
+    orig.p1_x = 10.f; orig.p1_y = 20.f;
+    orig.p2_x = 30.f; orig.p2_y = 40.f;
+    orig.p1_score = 3; orig.p2_score = 5;
+    orig.p1_left = true; orig.p2_left = false;
+    orig.p1_scale_x = 2.f;  orig.p1_scale_y = 2.f;
+    orig.p2_scale_x = -1.f; orig.p2_scale_y = 1.f;
+    orig.wait = true;
+
+    sf::Packet pkt;
+    orig.toPacket(pkt);
+
+    GameState got;
+    got.fromPacket(pkt);
+
+    assert(feq(got.p1_x, orig.p1_x));
+    assert(feq(got.p1_y, orig.p1_y));
+    assert(feq(got.p2_x, orig.p2_x));
+    assert(feq(got.p2_y, orig.p2_y));
+    assert(got.p1_score   == orig.p1_score);
+    assert(got.p2_score   == orig.p2_score);
+    assert(got.p1_left    == orig.p1_left);
+    assert(got.p2_left    == orig.p2_left);
+    assert(feq(got.p1_scale_x, orig.p1_scale_x));
+    assert(feq(got.p1_scale_y, orig.p1_scale_y));
+    assert(feq(got.p2_scale_x, orig.p2_scale_x));
+    assert(feq(got.p2_scale_y, orig.p2_scale_y));
+    assert(got.wait == orig.wait);
+}
+
+// ── dispatchPacket: State routing ─────────────────────────────────────────────
+
+static void test_dispatch_state()
+{
+    std::deque<TimedState>  stateBuf;
+    std::deque<PlayerInput> inputQueue;
+
+    GameState s;
+    s.p1_x = 5.f; s.p1_y = 7.f;
+
+    sf::Packet pkt;
+    pkt << static_cast<sf::Uint8>(2); // MsgType::State
+    s.toPacket(pkt);
+
+    dispatchPacket(pkt, sf::seconds(1.f), stateBuf, inputQueue, 4);
+
+    assert(stateBuf.size() == 1);
+    assert(inputQueue.empty());
+    assert(feq(stateBuf[0].state.p1_x, 5.f));
+    assert(feq(stateBuf[0].state.p1_y, 7.f));
+    assert(stateBuf[0].arrival == sf::seconds(1.f));
+}
+
+// ── dispatchPacket: Input routing ─────────────────────────────────────────────
+
+static void test_dispatch_input()
+{
+    std::deque<TimedState>  stateBuf;
+    std::deque<PlayerInput> inputQueue;
+
+    PlayerInput inp;
+    inp.up = true; inp.attack = true;
+
+    sf::Packet pkt;
+    pkt << static_cast<sf::Uint8>(1); // MsgType::Input
+    inp.toPacket(pkt);
+
+    dispatchPacket(pkt, sf::seconds(0.f), stateBuf, inputQueue, 4);
+
+    assert(inputQueue.size() == 1);
+    assert(stateBuf.empty());
+    assert(inputQueue[0].up     == true);
+    assert(inputQueue[0].attack == true);
+    assert(inputQueue[0].down   == false);
+}
+
+// ── dispatchPacket: unknown type is discarded ─────────────────────────────────
+
+static void test_dispatch_unknown_discarded()
+{
+    std::deque<TimedState>  stateBuf;
+    std::deque<PlayerInput> inputQueue;
+
+    sf::Packet pkt;
+    pkt << static_cast<sf::Uint8>(99); // unknown
+
+    dispatchPacket(pkt, sf::seconds(0.f), stateBuf, inputQueue, 4);
+
+    assert(stateBuf.empty());
+    assert(inputQueue.empty());
+}
+
+// ── dispatchPacket: cap eviction ──────────────────────────────────────────────
+
+static void test_dispatch_cap_eviction()
+{
+    std::deque<TimedState>  stateBuf;
+    std::deque<PlayerInput> inputQueue;
+
+    for (int i = 0; i < 5; ++i) {
+        sf::Packet pkt;
+        pkt << static_cast<sf::Uint8>(2);
+        GameState s;
+        s.p1_x = static_cast<float>(i);
+        s.toPacket(pkt);
+        dispatchPacket(pkt, sf::seconds(static_cast<float>(i)),
+                       stateBuf, inputQueue, 4);
+    }
+
+    assert(stateBuf.size() == 4);          // cap = 4, oldest evicted
+    assert(feq(stateBuf[0].state.p1_x, 1.f)); // entry 0 was evicted
+    assert(feq(stateBuf[3].state.p1_x, 4.f));
+}
+
+// ── lerpPos: midpoint ─────────────────────────────────────────────────────────
+
+static void test_lerppos_midpoint()
+{
+    auto r = lerpPos({0.f, 0.f}, {10.f, 20.f}, 0.5f);
+    assert(feq(r.x, 5.f));
+    assert(feq(r.y, 10.f));
+}
+
+// ── lerpPos: t = 0 snaps to 'from' ───────────────────────────────────────────
+
+static void test_lerppos_clamp_t0()
+{
+    auto r = lerpPos({3.f, 4.f}, {10.f, 20.f}, 0.f);
+    assert(feq(r.x, 3.f));
+    assert(feq(r.y, 4.f));
+}
+
+// ── lerpPos: t = 1 snaps to 'to' ─────────────────────────────────────────────
+
+static void test_lerppos_clamp_t1()
+{
+    auto r = lerpPos({3.f, 4.f}, {10.f, 20.f}, 1.f);
+    assert(feq(r.x, 10.f));
+    assert(feq(r.y, 20.f));
+}
+
+// ── lerpPos: t < 0 is clamped to 0 ───────────────────────────────────────────
+
+static void test_lerppos_clamp_below_0()
+{
+    auto r = lerpPos({0.f, 0.f}, {10.f, 0.f}, -2.f);
+    assert(feq(r.x, 0.f));
+}
+
+// ── lerpPos: t > 1 is clamped to 1 ───────────────────────────────────────────
+
+static void test_lerppos_clamp_above_1()
+{
+    auto r = lerpPos({0.f, 0.f}, {10.f, 0.f}, 3.f);
+    assert(feq(r.x, 10.f));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+int main()
+{
+    test_playerinput_roundtrip();
+    test_gamestate_roundtrip();
+    test_dispatch_state();
+    test_dispatch_input();
+    test_dispatch_unknown_discarded();
+    test_dispatch_cap_eviction();
+    test_lerppos_midpoint();
+    test_lerppos_clamp_t0();
+    test_lerppos_clamp_t1();
+    test_lerppos_clamp_below_0();
+    test_lerppos_clamp_above_1();
+
+    std::cout << "All netcode unit tests passed.\n";
+    return 0;
+}


### PR DESCRIPTION
Resolves #2.

Hardens the online-multiplayer netcode (the flawed baseline imported in #10) — transport correctness + a small client-side render interpolation. **Scope note:** this smooths *rendering*, not the client's own-input round-trip latency; full client-side prediction/reconciliation is deliberately deferred to #11 (it needs the fixed-timestep sim that lands there).

## Transport correctness (`NetworkManager`)
- **Type-demux, drain-all.** `poll()` drains *every* pending packet each frame and dispatches by the message-type byte (via a socket-free `dispatchPacket` free function); unknown types are logged once and discarded. Fixes the old "read one packet, silently drop on type mismatch" bug and the receive backlog that caused the "laggy feel".
- **Partial-send retry (stream-corruption fix).** A one-slot pending-send retries the *same* `sf::Packet` until `Done` (the old `send()==Done` abandoned `Partial` sends, corrupting the length-prefixed stream). Safe one-slot design — HOST only sends state, CLIENT only sends input.
- **Disconnect detection** is now driven by socket status on *both* send and receive paths (`isConnected()`/`peerLost()` are live, not a stale bool). A mid-game drop surfaces a "Peer disconnected" screen instead of freezing.
- **Join validation.** `connectToHost` validates the IP (`sf::IpAddress`) before the blocking connect, so a typo fails instantly instead of hanging the UI.
- Host closes the listener after accepting (1v1); state is sent at a fixed ~25 Hz instead of every frame.

## Client interpolation (render-only)
- Remote entities render ~40 ms behind by lerping **position only** between the two buffered snapshots that bracket the target time; scale/facing/scores/`wait` are snapped from the latest snapshot (lerping scale would collapse the sprite on a facing-flip). Authoritative positions are preserved for `update()`/collision (save→draw→restore).

## Tests
- `tests/` (via the #10 CMake seam): **11 socket-free unit tests** (packet round-trips, `dispatchPacket` routing incl. cap-eviction + unknown-type discard, `lerpPos` clamping) + a **loopback integration test** exercising the real socket paths — send/receive round-trips, unknown-type discard, and both receive-side and send-side disconnect detection. `ctest` green. These migrate to Catch2 in #7.

## Notes
- SFML 2.x exposes no `TCP_NODELAY`; Nagle is mitigated by the fixed-rate send + interpolation buffer (documented, not worked around with a native-handle shim).
- No new compiler warnings (3 pre-existing warnings eliminated).
