### PR TITLE
Add debug/playtest harness (fixed timestep + replay + screenshots) — #13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ add_library(dungeon_lib STATIC
     AnimatedGameObject.cpp
     RegularGameObject.cpp
     resource_path.cpp
+    replay.cpp
+    rng.cpp
 )
 
 target_include_directories(dungeon_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/Game.cpp
+++ b/Game.cpp
@@ -371,10 +371,15 @@ void Game::applyPlayerInput(const PlayerInput& in)
 
 void Game::captureIfDue()
 {
-    if (m_debug.screenshotEvery > 0 && m_steps > 0 &&
-        m_steps % static_cast<long long>(m_debug.screenshotEvery) == 0) {
+    if (m_debug.screenshotEvery <= 0) return;
+    if (m_nextShot == 0) m_nextShot = m_debug.screenshotEvery; // lazy init
+    // Threshold (not modulo) so a multi-step accumulator drain that jumps past a
+    // boundary still captures once; --frames mode (1 step/iter) lands exactly on
+    // each multiple, keeping frame_60/120/... filenames stable for determinism.
+    if (m_steps >= m_nextShot) {
         captureScreenshot(m_window,
                           m_debug.screenshotDir + "/frame_" + std::to_string(m_steps) + ".png");
+        while (m_nextShot <= m_steps) m_nextShot += m_debug.screenshotEvery;
     }
 }
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -4,778 +4,861 @@
 
 #include "Game.h"
 #include "resource_path.h"
-#include <iostream>
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <iostream>
 
-Game::Game() :
-		m_window(sf::VideoMode(1920, 1080), "Dungeon Game"),
-		m_networkMode(NetworkMode::LOCAL)
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+static void captureScreenshot(const sf::RenderWindow& w, const std::string& path)
+{
+    sf::Texture t;
+    t.create(w.getSize().x, w.getSize().y);
+    t.update(w);
+    t.copyToImage().saveToFile(path);
+}
+
+// ── constructors ──────────────────────────────────────────────────────────────
+
+Game::Game() : m_window(sf::VideoMode(1920, 1080), "Dungeon Game"), m_networkMode(NetworkMode::LOCAL)
 {
 
-	if(!background.openFromFile(resource_path + "background.wav")){
-		std::cout << "your music is broken, go fix it" << std::endl;
-	}
+    if (!background.openFromFile(resource_path + "background.wav")) {
+        std::cout << "your music is broken, go fix it" << std::endl;
+    }
 
-	//load the player
-	//m_player.load(resource_path + "Mario.png");
-	m_player->load(resource_path + "rocket.png");
-	m_player->setScale(2.0f);
-	//size him.  trial and error to get correct values
-	//m_player->setScale(-1.0f,1.0f);
-	m_player->setPosition(m_player->getWidth(),400);
+    // load the player
+    m_player->load(resource_path + "rocket.png");
+    m_player->setScale(2.0f);
+    m_player->setPosition(m_player->getWidth(), 400);
 
-	player2->load(resource_path + "robot.png");
-	player2->setScale(-1.0f,1.0f);
-	player2->setPosition(m_window.getSize().x-(m_player->getWidth()+150),400);
-/*
-	GameObject* asteroid = new AnimatedGameObject(360,280,5,4,19,0);
-	stuff.push_back(asteroid);
-	stuff[0]->load(resource_path + "asteroid.png");
-    stuff[0]->setPosition(300,200);
-*/
-/*	GameObject* fire = new AnimatedGameObject(216,216,5,3,10,0);
+    player2->load(resource_path + "robot.png");
+    player2->setScale(-1.0f, 1.0f);
+    player2->setPosition(m_window.getSize().x - (m_player->getWidth() + 150), 400);
+
+    GameObject* wall = new RegularGameObject();
+    stuff.push_back(wall);
+    stuff[0]->load(resource_path + "brick.png");
+    stuff[0]->setScale(2.0f);
+
+    GameObject* fire = new AnimatedGameObject(216, 216, 5, 3, 10, 0);
+    fire->load(resource_path + "fire.png");
+    fire->setScale(2.0f);
+    fire->setPosition(-15, 400);
     stuff.push_back(fire);
-    stuff[1]->load(resource_path + "fire.png");
-    stuff[1]->setPosition(200,900);*/
 
-	GameObject* wall = new RegularGameObject();
-	stuff.push_back(wall);
-	stuff[0]->load(resource_path + "brick.png");
-	//stuff[0]->setPosition(100,300);
-	stuff[0]->setScale(2.0f);
+    GameObject* fire2 = new AnimatedGameObject(216, 216, 5, 3, 10, 0);
+    fire2->load(resource_path + "fire.png");
+    fire2->setScale(2.0f);
+    fire2->setPosition((1920 / 2) - 5, 400);
+    stuff.push_back(fire2);
 
-	GameObject* fire = new AnimatedGameObject(216,216,5,3,10,0);
-	fire->load(resource_path + "fire.png");
-	fire->setScale(2.0f);
-	fire->setPosition(-15,400);
-	stuff.push_back(fire);
+    GameObject* fire3 = new AnimatedGameObject(216, 216, 5, 3, 10, 0);
+    fire3->load(resource_path + "fire.png");
+    fire3->setScale(2.0f);
+    fire3->setPosition(1820, 400);
+    stuff.push_back(fire3);
 
-	GameObject* fire2 = new AnimatedGameObject(216,216,5,3,10,0);
-	fire2->load(resource_path + "fire.png");
-	fire2->setScale(2.0f);
-	fire2->setPosition((1920/2)-5,400);
-	stuff.push_back(fire2);
+    if (!font.loadFromFile(resource_path + "oswald.ttf")) {
+        std::cout << "Font did not load" << std::endl;
+    }
+    if (!tfont.loadFromFile(resource_path + "timer.ttf")) {
+        std::cout << "Font did not load" << std::endl;
+    }
+    if (!block.loadFromFile(resource_path + "Blockt.ttf")) {
+        std::cout << "Font did not load" << std::endl;
+    }
 
-	GameObject* fire3 = new AnimatedGameObject(216,216,5,3,10,0);
-	fire3->load(resource_path + "fire.png");
-	fire3->setScale(2.0f);
-	fire3->setPosition(1820,400);
-	stuff.push_back(fire3);
-/*
-    GameObject* astro = new AnimatedGameObject(144,192,3,4,3,0);
-    stuff.push_back(astro);
-    stuff[1]->load(resource_path + "astro.png");
-    stuff[1]->setPosition(150,400);
+    pause_text = sf::Text("Cooldown", block, 400);
+    pause_text.setPosition(m_window.getSize().x / 2 - 850, 100);
+    pause_text.setFillColor(sf::Color::Black);
 
-    GameObject* laser = new RegularGameObject();
-    stuff.push_back(laser);
-    stuff[2]->load(resource_path + "laser.png");
-    stuff[2]->setPosition(100,300);
-    stuff[2]->setScale(.1f);
-*/
-	if(!font.loadFromFile(resource_path + "oswald.ttf")){
-		std::cout << "Font did not load" << std::endl;
-	}
-	if(!tfont.loadFromFile(resource_path + "timer.ttf")){
-		std::cout << "Font did not load" << std::endl;
-	}
-	if(!block.loadFromFile(resource_path + "Blockt.ttf")){
-		std::cout << "Font did not load" << std::endl;
-	}
+    info = sf::Text("a short intermission", font, 50);
+    info.setPosition(pause_text.getPosition().x + 150, pause_text.getPosition().y + 500);
+    info.setFillColor(sf::Color::Black);
 
-	pause_text = sf::Text("Cooldown",block,400);
-	pause_text.setPosition(m_window.getSize().x/2 - 850,100);
-	pause_text.setFillColor(sf::Color::Black);
+    text  = sf::Text("Rocket Score: 0", font, 40);
+    text2 = sf::Text("Robot Score: 0", font, 40);
+    timer = sf::Text("timer", tfont, 60);
+    timer.setPosition((m_window.getSize().x / 2) - 60, 0);
+    text.setPosition(10, 0);
+    text2.setPosition(m_window.getSize().x - text2.getGlobalBounds().width, 0);
+    text2.setFillColor(sf::Color::Green);
+    timer.setFillColor(sf::Color::Black);
+    text.setFillColor(sf::Color::Blue);
 
-	info = sf::Text("a short intermission",font,50);
-	info.setPosition(pause_text.getPosition().x + 150,pause_text.getPosition().y + 500);
-	info.setFillColor(sf::Color::Black);
-
-	text = sf::Text("Rocket Score: 0",font,40);
-	text2 = sf::Text("Robot Score: 0",font,40);
-	timer = sf::Text("timer",tfont,60);
-	timer.setPosition((m_window.getSize().x/2)-60,0);
-	text.setPosition(10,0);
-	text2.setPosition(m_window.getSize().x-text2.getGlobalBounds().width,0);
-	text2.setFillColor(sf::Color::Green);
-	timer.setFillColor(sf::Color::Black);
-	//text.setCharacterSize(300);
-	text.setFillColor(sf::Color::Blue);
-
-	if(!sbuffer.loadFromFile(resource_path + "sword_miss.wav")) {
-		std::cout << "sound did not load";
-	}
-	sword.setBuffer(sbuffer);
-	if(!p2hitbuffer.loadFromFile(resource_path + "skeleton.wav")) {
-		std::cout << "sound did not load";
-	}
-	p2hit.setBuffer(p2hitbuffer);
-	if(!laserbuffer.loadFromFile(resource_path + "new_laser.wav")) {
-		std::cout << "sound did not load";
-	}
-	laser.setBuffer(laserbuffer);
-	if(!metalbuffer.loadFromFile(resource_path + "metal_hit.wav")) {
-		std::cout << "sound did not load";
-	}
-	metal.setBuffer(metalbuffer);
-	if(!speedbuffer.loadFromFile(resource_path + "SpeedUp.wav")) {
-		std::cout << "sound did not load";
-	}
-	speed_up.setBuffer(speedbuffer);
-	if(!slowbuffer.loadFromFile(resource_path + "SlowDown.wav")) {
-		std::cout << "sound did not load";
-	}
-	slow_down.setBuffer(slowbuffer);
-	if(!burnbuffer.loadFromFile(resource_path + "burn.wav")) {
-		std::cout << "sound did not load";
-	}
-	burn.setBuffer(burnbuffer);
-	if(!gongbuffer.loadFromFile(resource_path + "gong.wav")) {
-		std::cout << "sound did not load";
-	}
-	gong.setBuffer(gongbuffer);
-	laser.setVolume(60);
-
+    if (!sbuffer.loadFromFile(resource_path + "sword_miss.wav")) {
+        std::cout << "sound did not load";
+    }
+    sword.setBuffer(sbuffer);
+    if (!p2hitbuffer.loadFromFile(resource_path + "skeleton.wav")) {
+        std::cout << "sound did not load";
+    }
+    p2hit.setBuffer(p2hitbuffer);
+    if (!laserbuffer.loadFromFile(resource_path + "new_laser.wav")) {
+        std::cout << "sound did not load";
+    }
+    laser.setBuffer(laserbuffer);
+    if (!metalbuffer.loadFromFile(resource_path + "metal_hit.wav")) {
+        std::cout << "sound did not load";
+    }
+    metal.setBuffer(metalbuffer);
+    if (!speedbuffer.loadFromFile(resource_path + "SpeedUp.wav")) {
+        std::cout << "sound did not load";
+    }
+    speed_up.setBuffer(speedbuffer);
+    if (!slowbuffer.loadFromFile(resource_path + "SlowDown.wav")) {
+        std::cout << "sound did not load";
+    }
+    slow_down.setBuffer(slowbuffer);
+    if (!burnbuffer.loadFromFile(resource_path + "burn.wav")) {
+        std::cout << "sound did not load";
+    }
+    burn.setBuffer(burnbuffer);
+    if (!gongbuffer.loadFromFile(resource_path + "gong.wav")) {
+        std::cout << "sound did not load";
+    }
+    gong.setBuffer(gongbuffer);
+    laser.setVolume(60);
 }
 
-Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager) :
-		m_window(sf::VideoMode(1920, 1080), "Dungeon Game - " + 
-			(mode == NetworkMode::HOST ? std::string("Host") : std::string("Client"))),
-		m_networkMode(mode),
-		m_networkManager(netManager)
+Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
+    : m_window(sf::VideoMode(1920, 1080),
+               "Dungeon Game - " +
+                   (mode == NetworkMode::HOST ? std::string("Host") : std::string("Client"))),
+      m_networkMode(mode),
+      m_networkManager(netManager)
 {
-	if(!background.openFromFile(resource_path + "background.wav")){
-		std::cout << "your music is broken, go fix it" << std::endl;
-	}
+    if (!background.openFromFile(resource_path + "background.wav")) {
+        std::cout << "your music is broken, go fix it" << std::endl;
+    }
 
-	//load the player
-	m_player->load(resource_path + "rocket.png");
-	m_player->setScale(2.0f);
-	m_player->setPosition(m_player->getWidth(),400);
+    m_player->load(resource_path + "rocket.png");
+    m_player->setScale(2.0f);
+    m_player->setPosition(m_player->getWidth(), 400);
 
-	player2->load(resource_path + "robot.png");
-	player2->setScale(-1.0f,1.0f);
-	player2->setPosition(m_window.getSize().x-(m_player->getWidth()+150),400);
+    player2->load(resource_path + "robot.png");
+    player2->setScale(-1.0f, 1.0f);
+    player2->setPosition(m_window.getSize().x - (m_player->getWidth() + 150), 400);
 
-	GameObject* wall = new RegularGameObject();
-	stuff.push_back(wall);
-	stuff[0]->load(resource_path + "brick.png");
-	stuff[0]->setScale(2.0f);
+    GameObject* wall = new RegularGameObject();
+    stuff.push_back(wall);
+    stuff[0]->load(resource_path + "brick.png");
+    stuff[0]->setScale(2.0f);
 
-	GameObject* fire = new AnimatedGameObject(216,216,5,3,10,0);
-	fire->load(resource_path + "fire.png");
-	fire->setScale(2.0f);
-	fire->setPosition(-15,400);
-	stuff.push_back(fire);
+    GameObject* fire = new AnimatedGameObject(216, 216, 5, 3, 10, 0);
+    fire->load(resource_path + "fire.png");
+    fire->setScale(2.0f);
+    fire->setPosition(-15, 400);
+    stuff.push_back(fire);
 
-	GameObject* fire2 = new AnimatedGameObject(216,216,5,3,10,0);
-	fire2->load(resource_path + "fire.png");
-	fire2->setScale(2.0f);
-	fire2->setPosition((1920/2)-5,400);
-	stuff.push_back(fire2);
+    GameObject* fire2 = new AnimatedGameObject(216, 216, 5, 3, 10, 0);
+    fire2->load(resource_path + "fire.png");
+    fire2->setScale(2.0f);
+    fire2->setPosition((1920 / 2) - 5, 400);
+    stuff.push_back(fire2);
 
-	GameObject* fire3 = new AnimatedGameObject(216,216,5,3,10,0);
-	fire3->load(resource_path + "fire.png");
-	fire3->setScale(2.0f);
-	fire3->setPosition(1820,400);
-	stuff.push_back(fire3);
+    GameObject* fire3 = new AnimatedGameObject(216, 216, 5, 3, 10, 0);
+    fire3->load(resource_path + "fire.png");
+    fire3->setScale(2.0f);
+    fire3->setPosition(1820, 400);
+    stuff.push_back(fire3);
 
-	if(!font.loadFromFile(resource_path + "oswald.ttf")){
-		std::cout << "Font did not load" << std::endl;
-	}
-	if(!tfont.loadFromFile(resource_path + "timer.ttf")){
-		std::cout << "Font did not load" << std::endl;
-	}
-	if(!block.loadFromFile(resource_path + "Blockt.ttf")){
-		std::cout << "Font did not load" << std::endl;
-	}
+    if (!font.loadFromFile(resource_path + "oswald.ttf")) {
+        std::cout << "Font did not load" << std::endl;
+    }
+    if (!tfont.loadFromFile(resource_path + "timer.ttf")) {
+        std::cout << "Font did not load" << std::endl;
+    }
+    if (!block.loadFromFile(resource_path + "Blockt.ttf")) {
+        std::cout << "Font did not load" << std::endl;
+    }
 
-	pause_text = sf::Text("Cooldown",block,400);
-	pause_text.setPosition(m_window.getSize().x/2 - 850,100);
-	pause_text.setFillColor(sf::Color::Black);
+    pause_text = sf::Text("Cooldown", block, 400);
+    pause_text.setPosition(m_window.getSize().x / 2 - 850, 100);
+    pause_text.setFillColor(sf::Color::Black);
 
-	info = sf::Text("a short intermission",font,50);
-	info.setPosition(pause_text.getPosition().x + 150,pause_text.getPosition().y + 500);
-	info.setFillColor(sf::Color::Black);
+    info = sf::Text("a short intermission", font, 50);
+    info.setPosition(pause_text.getPosition().x + 150, pause_text.getPosition().y + 500);
+    info.setFillColor(sf::Color::Black);
 
-	text = sf::Text("Rocket Score: 0",font,40);
-	text2 = sf::Text("Robot Score: 0",font,40);
-	timer = sf::Text("timer",tfont,60);
-	timer.setPosition((m_window.getSize().x/2)-60,0);
-	text.setPosition(10,0);
-	text2.setPosition(m_window.getSize().x-text2.getGlobalBounds().width,0);
-	text2.setFillColor(sf::Color::Green);
-	timer.setFillColor(sf::Color::Black);
-	text.setFillColor(sf::Color::Blue);
+    text  = sf::Text("Rocket Score: 0", font, 40);
+    text2 = sf::Text("Robot Score: 0", font, 40);
+    timer = sf::Text("timer", tfont, 60);
+    timer.setPosition((m_window.getSize().x / 2) - 60, 0);
+    text.setPosition(10, 0);
+    text2.setPosition(m_window.getSize().x - text2.getGlobalBounds().width, 0);
+    text2.setFillColor(sf::Color::Green);
+    timer.setFillColor(sf::Color::Black);
+    text.setFillColor(sf::Color::Blue);
 
-	if(!sbuffer.loadFromFile(resource_path + "sword_miss.wav")) {
-		std::cout << "sound did not load";
-	}
-	sword.setBuffer(sbuffer);
-	if(!p2hitbuffer.loadFromFile(resource_path + "skeleton.wav")) {
-		std::cout << "sound did not load";
-	}
-	p2hit.setBuffer(p2hitbuffer);
-	if(!laserbuffer.loadFromFile(resource_path + "new_laser.wav")) {
-		std::cout << "sound did not load";
-	}
-	laser.setBuffer(laserbuffer);
-	if(!metalbuffer.loadFromFile(resource_path + "metal_hit.wav")) {
-		std::cout << "sound did not load";
-	}
-	metal.setBuffer(metalbuffer);
-	if(!speedbuffer.loadFromFile(resource_path + "SpeedUp.wav")) {
-		std::cout << "sound did not load";
-	}
-	speed_up.setBuffer(speedbuffer);
-	if(!slowbuffer.loadFromFile(resource_path + "SlowDown.wav")) {
-		std::cout << "sound did not load";
-	}
-	slow_down.setBuffer(slowbuffer);
-	if(!burnbuffer.loadFromFile(resource_path + "burn.wav")) {
-		std::cout << "sound did not load";
-	}
-	burn.setBuffer(burnbuffer);
-	if(!gongbuffer.loadFromFile(resource_path + "gong.wav")) {
-		std::cout << "sound did not load";
-	}
-	gong.setBuffer(gongbuffer);
-	laser.setVolume(60);
+    if (!sbuffer.loadFromFile(resource_path + "sword_miss.wav")) {
+        std::cout << "sound did not load";
+    }
+    sword.setBuffer(sbuffer);
+    if (!p2hitbuffer.loadFromFile(resource_path + "skeleton.wav")) {
+        std::cout << "sound did not load";
+    }
+    p2hit.setBuffer(p2hitbuffer);
+    if (!laserbuffer.loadFromFile(resource_path + "new_laser.wav")) {
+        std::cout << "sound did not load";
+    }
+    laser.setBuffer(laserbuffer);
+    if (!metalbuffer.loadFromFile(resource_path + "metal_hit.wav")) {
+        std::cout << "sound did not load";
+    }
+    metal.setBuffer(metalbuffer);
+    if (!speedbuffer.loadFromFile(resource_path + "SpeedUp.wav")) {
+        std::cout << "sound did not load";
+    }
+    speed_up.setBuffer(speedbuffer);
+    if (!slowbuffer.loadFromFile(resource_path + "SlowDown.wav")) {
+        std::cout << "sound did not load";
+    }
+    slow_down.setBuffer(slowbuffer);
+    if (!burnbuffer.loadFromFile(resource_path + "burn.wav")) {
+        std::cout << "sound did not load";
+    }
+    burn.setBuffer(burnbuffer);
+    if (!gongbuffer.loadFromFile(resource_path + "gong.wav")) {
+        std::cout << "sound did not load";
+    }
+    gong.setBuffer(gongbuffer);
+    laser.setVolume(60);
 }
 
-std::tuple<int,int,float,int,bool,bool> Game::run() {
-	//loop clock
-	sf::Clock clock;
-	//game time
-	sf::Clock gTime;
-	float time = 0;
-	background.play();
-	background.setLoop(true);
-	background.setVolume(40);
-	gong.setVolume(50);
-	//gong.play();
-	float apieceofcrap;
-	int seconds;
-	bool p1win = false;
-	while (m_window.isOpen()) {
-		char gClock [10];
-		apieceofcrap = (int) (floor(gTime.getElapsedTime().asSeconds()/60));
-		//apieceofcrap = apieceofcrap + 9;
-		seconds = ((int) gTime.getElapsedTime().asSeconds())%60;
-		std::snprintf(gClock, sizeof(gClock), "%02.0f:%02d", apieceofcrap, seconds);
-		timer.setString(gClock);
-		//std::cout << "time:  " << (gTime.getElapsedTime().asSeconds()) << std::endl;
-		sf::Time deltaT = clock.restart();
-		processEvents();
-		
-		// Handle network communication
-		handleNetworkCommunication(deltaT);
-		
-		if (!wait) {
-			update(deltaT, time);
-			temp_time = gTime.getElapsedTime().asSeconds() + 1.75;
-		} else if (gTime.getElapsedTime().asSeconds() > temp_time){
-			wait = false;
-			gong.play();
-		}
-		if (time > .1f){
-			time = 0;
-		}
-		time += deltaT.asSeconds();
+// ── debug config ──────────────────────────────────────────────────────────────
 
-		if (gTime.getElapsedTime().asSeconds() > p1_timeout){
-			p1_time_passed = true;
-		}
+void Game::setDebugConfig(const DebugConfig& cfg)
+{
+    m_debug = cfg;
+    if (!cfg.replayPath.empty()) {
+        m_replay    = loadReplay(cfg.replayPath);
+        m_replayIdx = 0;
+    }
+}
 
-		if (gTime.getElapsedTime().asSeconds() > p2_timeout){
-			p2_time_passed = true;
-		}
+// ── run ───────────────────────────────────────────────────────────────────────
 
+std::tuple<int, int, float, int, bool, bool> Game::run()
+{
+    sf::Clock clock;
+    background.play();
+    background.setLoop(true);
+    background.setVolume(40);
+    gong.setVolume(50);
 
-        for(int x = 1;x<stuff.size();x++){
-            if (collision(stuff[x],m_player) && p1_time_passed) {
-				//std::cout << "i can be harmed " << collision(stuff[x],m_player) << "  " << p1_time_passed << std::endl;
-				burn.play();
-                p2points--;
-                p1_time_passed = false;
-				p1_timeout = gTime.getElapsedTime().asSeconds() + 2.2;
-            } else {
-                //std::cout << "i can't be harmed " << collision(stuff[x],m_player) << "  " << p1_time_passed << std::endl;
-            }
-            if (collision(stuff[x],player2) && p2_time_passed) {
-                burn.play();
-                points--;
-                p2_time_passed = false;
-				p2_timeout = gTime.getElapsedTime().asSeconds() + 2.2;
-			}
+    float     apieceofcrap = 0.f;
+    int       seconds      = 0;
+    bool      p1win        = false;
+    int       framesLeft   = m_debug.frames;
+    const bool framesMode  = (framesLeft > 0);
+
+    while (m_window.isOpen()) {
+        // ── Timer display from step counter ──────────────────────────────────
+        {
+            int totalSecs  = static_cast<int>(gameSeconds());
+            apieceofcrap   = static_cast<float>(totalSecs / 60);
+            seconds        = totalSecs % 60;
+            char gClock[10];
+            std::snprintf(gClock, sizeof(gClock), "%02.0f:%02d", apieceofcrap, seconds);
+            timer.setString(gClock);
         }
 
-		if (points < 0)
-			points = 0;
-		if (p2points < 0)
-			p2points = 0;
+        float iterDt = std::min(clock.restart().asSeconds(), 0.25f);
 
-		//std::cout << points << std::endl;
-		render();
-	}
-	background.stop();
-	if (p2points > points)
-		p1win = true;
-	return {p2points, points, apieceofcrap, seconds, p1win, m_peerLeft};
+        processEvents();
+
+        // ── Network I/O: once per iteration (not per step) ───────────────────
+        if (m_networkManager) {
+            handleNetworkCommunication(sf::seconds(iterDt));
+        }
+
+        // ── Sim steps ────────────────────────────────────────────────────────
+        if (framesMode) {
+            simStep();
+        } else {
+            m_accumulator += iterDt;
+            while (m_accumulator >= kFixedDt) {
+                simStep();
+                m_accumulator -= kFixedDt;
+            }
+        }
+
+        // ── Render + capture (back buffer ready; swap comes last) ─────────────
+        render();
+        captureIfDue();
+        m_window.display();
+
+        // ── Frame-count exit ─────────────────────────────────────────────────
+        if (framesMode) {
+            --framesLeft;
+            if (framesLeft <= 0)
+                m_window.close();
+        }
+    }
+
+    background.stop();
+    p1win = (p2points > points);
+    return {p2points, points, apieceofcrap, seconds, p1win, m_peerLeft};
 }
 
-void Game::processEvents() {
-	sf::Event event;
-	while (m_window.pollEvent(event)) {
-		switch (event.type) {
+// ── simStep ───────────────────────────────────────────────────────────────────
 
-			case sf::Event::KeyPressed:
-				//handle key down here
-				handlePlayerInput(event.key.code, true);
-				break;
-			case sf::Event::KeyReleased:
-				handlePlayerInput(event.key.code, false);
-				break;
-			case sf::Event::Closed:
-				m_window.close();
-				break;
-			default:
-				break;
-		}
+void Game::simStep()
+{
+    // Apply replay input for P2 (before update so the flags are set when update() runs).
+    if (!m_replay.empty()) {
+        if (m_replayIdx < m_replay.size()) {
+            applyPlayerInput(m_replay[m_replayIdx++]);
+        } else {
+            applyPlayerInput(PlayerInput{}); // EOF → all-false
+        }
+    }
 
-	}
+    // Update or drain the cooldown wait.
+    if (!wait) {
+        update(sf::seconds(kFixedDt), m_animTime);
+        temp_time = static_cast<float>(gameSeconds()) + 1.75f;
+    } else if (gameSeconds() > static_cast<double>(temp_time)) {
+        wait = false;
+        gong.play();
+    }
+
+    // Animation accumulator (matches original pattern: reset-then-increment).
+    if (m_animTime > .1f)
+        m_animTime = 0;
+    m_animTime += kFixedDt;
+
+    // Timeout checks.
+    if (gameSeconds() > static_cast<double>(p1_timeout))
+        p1_time_passed = true;
+    if (gameSeconds() > static_cast<double>(p2_timeout))
+        p2_time_passed = true;
+
+    // Hazard collision + scoring.
+    for (int x = 1; x < static_cast<int>(stuff.size()); x++) {
+        if (collision(stuff[x], m_player) && p1_time_passed) {
+            burn.play();
+            p2points--;
+            p1_time_passed = false;
+            p1_timeout     = static_cast<float>(gameSeconds()) + 2.2f;
+        }
+        if (collision(stuff[x], player2) && p2_time_passed) {
+            burn.play();
+            points--;
+            p2_time_passed = false;
+            p2_timeout     = static_cast<float>(gameSeconds()) + 2.2f;
+        }
+    }
+
+    // Score clamps.
+    if (points < 0)
+        points = 0;
+    if (p2points < 0)
+        p2points = 0;
+
+    ++m_steps;
 }
 
-void Game::handlePlayerInput(sf::Keyboard::Key key, bool isDown) {
-	// In network mode, host controls player 1, client controls player 2
-	if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::HOST) {
-		// Player 1 controls (rocket - arrow keys)
-		if (key == sf::Keyboard::Numpad4)
-			m_left = isDown;
-		if (key == sf::Keyboard::Numpad6)
-			m_right = isDown;
-		if (key == sf::Keyboard::Numpad8)
-			m_up = isDown;
-		if (key == sf::Keyboard::Numpad5)
-			m_down = isDown;
-		if (key == sf::Keyboard::Right)
-			right = isDown;
-	}
-	
-	if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::CLIENT) {
-		// Player 2 controls (robot - WASD)
-		if (key == sf::Keyboard::W)
-			w = isDown;
-		if (key == sf::Keyboard::A)
-			a = isDown;
-		if (key == sf::Keyboard::S)
-			s = isDown;
-		if (key == sf::Keyboard::D)
-			d = isDown;
-		if (key == sf::Keyboard::Space)
-			space = !isDown;
-	}
-	
-	// Common controls
-	if (key == sf::Keyboard::O)
-		o = !isDown;
-	if (key == sf::Keyboard::P)
-		p = !isDown;
-	if (key == sf::Keyboard::Escape)
-		m_window.close();
-	if (key == sf::Keyboard::K) {
-		if(wait) {
-			wait = false;
-			gong.play();
-		}
-	}
+// ── applyPlayerInput / captureIfDue ──────────────────────────────────────────
+
+void Game::applyPlayerInput(const PlayerInput& in)
+{
+    applyInputTo(w, a, s, d, space, in);
 }
 
-//use time since last update to get smooth movement
-void Game::update(sf::Time deltaT,float time) {
-	bool reset = false;
-	//Look a vector class!
-	sf::Vector2f p1movement(0.0f, 0.0f);
-	sf::Vector2f p2movement(0.0f, 0.0f);
-
-	if (m_up) {
-		//std::cout << m_player->getPosition().y << "     " << -(m_player->getHeight()) << std::endl;
-		if (m_player->getPosition().y < -(m_player->getHeight())) {
-			m_player->setPosition(m_player->getPosition().x, (m_window.getSize().y) - m_player->getHeight());
-		}
-
-
-
-		if (collision(m_player,player2)){
-			m_player->setPosition(m_player->getPosition().x,m_player->getPosition().y + 40);
-			p2move = false;
-		}
-		else{
-			p2move = true;
-			p1movement.y -= m_speed;
-		}
-	}
-
-	if (m_down) {
-		if (m_player->getPosition().y > (m_window.getSize().y) - (m_player->getHeight())) {
-			m_player->setPosition(m_player->getPosition().x, -(m_player->getHeight()));
-		}
-
-
-
-		if (collision(m_player,player2)){
-			m_player->setPosition(m_player->getPosition().x,m_player->getPosition().y - 40);
-			p2move = false;
-		} else {
-			p2move = true;
-			p1movement.y += m_speed;
-		}
-	}if (m_left) {
-		if (m_player->getPosition().x < -(m_player->getWidth())) {
-			m_player->setPosition(m_window.getSize().x, m_player->getPosition().y);
-		}
-		if (!p1left){
-			m_player->setScale(-2.0f,2);
-			p1left = true;
-			m_player->setPosition(m_player->getPosition().x-(m_player->getWidth()*m_player->getScale().x),m_player->getPosition().y);
-		}
-
-		if (collision(m_player,player2)){
-			m_player->setPosition(m_player->getPosition().x + 40,m_player->getPosition().y);
-			p2move = false;
-		}else{
-			p2move = true;
-			p1movement.x -= m_speed;
-		}
-	}if (m_right) {
-		m_player->setScale(2.0f, 2);
-
-		if (m_player->getPosition().x > m_window.getSize().x) {
-			m_player->setPosition(-(m_player->getWidth()), m_player->getPosition().y);
-		}
-
-		if (p1left) {
-			p1left = false;
-			m_player->setPosition(m_player->getPosition().x-(m_player->getWidth()*m_player->getScale().x),m_player->getPosition().y);
-		}
-
-		if (collision(m_player,player2)){
-			m_player->setPosition(m_player->getPosition().x - 40,m_player->getPosition().y);
-			p2move = false;
-		} else {
-			p2move = true;
-			p1movement.x += m_speed;
-		}
-	}if (w) {
-		if (player2->getPosition().y < -(player2->getHeight())) {
-			player2->setPosition(player2->getPosition().x, (m_window.getSize().y) - player2->getHeight());
-		}
-
-
-		if (collision(m_player,player2)){
-			player2->setPosition(player2->getPosition().x,player2->getPosition().y + 40);
-		} else{
-			p2movement.y -= m_speed;
-		}
-
-	}
-	if (s) {
-		if (player2->getPosition().y > (m_window.getSize().y) - (player2->getHeight())) {
-			player2->setPosition(player2->getPosition().x, -(player2->getHeight()));
-		}
-
-
-		if (collision(m_player,player2)){
-			player2->setPosition(player2->getPosition().x,player2->getPosition().y - 40);
-		} else {
-			p2movement.y += m_speed;
-		}
-
-	}
-	if (a) {
-		if (player2->getPosition().x < -(player2->getWidth())) {
-			player2->setPosition(m_window.getSize().x, player2->getPosition().y);
-		}
-		player2->setScale(-1.0f,1.0f);
-		if (!p2left) {
-			p2left = true;
-			player2->setPosition(player2->getPosition().x-(player2->getWidth()*player2->getScale().x),player2->getPosition().y);
-		}
-		//if (p2move)
-
-
-		if (collision(m_player,player2)){
-			player2->setPosition(player2->getPosition().x + 40,player2->getPosition().y);
-		} else {
-			p2movement.x -= m_speed;
-		}
-
-	}
-	if (d) {
-		player2->setScale(1.0f,1.0f);
-		if (player2->getPosition().x > m_window.getSize().x) {
-			player2->setPosition(-(player2->getWidth()), player2->getPosition().y);
-		}
-		if (p2left) {
-			p2left = false;
-			player2->setPosition(player2->getPosition().x-(player2->getWidth()*player2->getScale().x),player2->getPosition().y);
-		}
-		p2left = false;
-		//if (p2move)
-
-
-		if (collision(m_player,player2)){
-			player2->setPosition(player2->getPosition().x - 40,player2->getPosition().y);
-		} else {
-			p2movement.x += m_speed;
-		}
-
-	}
-	if (space) {
-		sf::Rect<float> hit;
-		if (!p2left) {
-			hit = sf::Rect<float>(player2->getPosition(), sf::Vector2f(200 + ((player2->getWidth()) * (player2->getScale().x)),(player2->getHeight()) * (player2->getScale().y)));
-		}else {
-			hit = sf::Rect<float>(player2->getPosition(), sf::Vector2f(((player2->getWidth()) * (player2->getScale().x))-200, (player2->getHeight()) * (player2->getScale().y)));
-		}
-
-		if (collision(hit, m_player)) {
-			metal.play();
-			points++;
-			reset = true;
-		} else {
-			sword.play();
-		}
-
-		space = false;
-	}
-	if (right) {
-		sf::Rect<float> hit;
-		if (!p1left) {
-			hit = sf::Rect<float>(m_player->getPosition(), sf::Vector2f(200 + ((m_player->getWidth()) * (m_player->getScale().x)),(m_player->getHeight()) * (m_player->getScale().y)));
-		}else {
-			hit = sf::Rect<float>(m_player->getPosition(), sf::Vector2f(((m_player->getWidth()) * (m_player->getScale().x))-200, (m_player->getHeight()) * (m_player->getScale().y)));
-		}
-
-		if (collision(hit, player2)) {
-			p2points++;
-			reset = true;
-			p2hit.play();
-		} else {
-			laser.play();
-		}
-
-		right = false;
-	}
-	if (o){
-		m_speed = m_speed - 150.0f;
-		if (m_speed < 0)
-			m_speed = 1.0f;
-		o = false;
-		slow_down.play();
-	}
-	if (p) {
-		m_speed = m_speed + 150.0f;
-		p = false;
-		speed_up.play();
-	}
-
-	if ((m_up || m_down || m_left || m_right) & !collision(m_player,player2)) {
-		m_player->move(p1movement * deltaT.asSeconds());
-		m_player->update(time);
-	}
-
-	if ((w || a || s || d) & !collision(m_player,player2)) {
-		player2->move(p2movement * deltaT.asSeconds());
-		player2->update(time);
-	}
-	//m_player->move(p1movement * deltaT.asSeconds());
-	//m_player->update(time);
-	for(int x = 0;x<stuff.size();x++){
-		stuff[x]->update(time);
-	}
-
-	if(reset){
-		//gong.play();
-		//float temp_time = time;
-		m_player->setScale(2.0f, 2);
-		player2->setScale(-1.0f,1.0f);
-		player2->setPosition(m_window.getSize().x-(m_player->getWidth()+150),400);
-		m_player->setPosition(m_player->getWidth() + 20,400);
-		p1left = false;
-		p2left = true;
-		wait = true;
-		//points--;
-		//p2points--;
-	}
-
-	//std::cout << deltaT.asSeconds() << "  " << p1movement.y << std::endl;
-	text.setString("Rocket Score: " + std::to_string(p2points));
-	text2.setString("Robot Score: " + std::to_string(points));
-	text2.setPosition(m_window.getSize().x-text2.getGlobalBounds().width-20,0);
+void Game::captureIfDue()
+{
+    if (m_debug.screenshotEvery > 0 && m_steps > 0 &&
+        m_steps % static_cast<long long>(m_debug.screenshotEvery) == 0) {
+        captureScreenshot(m_window,
+                          m_debug.screenshotDir + "/frame_" + std::to_string(m_steps) + ".png");
+    }
 }
 
-void Game::render() {
-	// CLIENT: temporarily shift sprites to interpolated positions for drawing.
-	// Positions are saved and restored so update()/collision use authoritative coords.
-	sf::Vector2f p1Saved, p2Saved;
-	bool didShift = false;
+// ── processEvents ─────────────────────────────────────────────────────────────
 
-	if (m_networkMode == NetworkMode::CLIENT && m_networkManager &&
-	    !m_networkManager->stateBuf().empty())
-	{
-		p1Saved = m_player->getPosition();
-		p2Saved = player2->getPosition();
-		didShift = true;
-
-		const auto& buf = m_networkManager->stateBuf();
-		constexpr float kInterpDelay = 0.04f; // 40 ms behind
-		sf::Time target = m_networkManager->elapsed() - sf::seconds(kInterpDelay);
-
-		sf::Vector2f rp1, rp2;
-		if (buf.size() >= 2) {
-			// Find the last snapshot pair bracketing target (or use the last pair
-			// if target is past all entries).
-			std::size_t ai = 0;
-			for (std::size_t i = 0; i + 1 < buf.size(); ++i) {
-				if (buf[i].arrival <= target) ai = i;
-			}
-			std::size_t bi = std::min(ai + 1, buf.size() - 1);
-			const auto& sa = buf[ai];
-			const auto& sb = buf[bi];
-			float span = (sb.arrival - sa.arrival).asSeconds();
-			float t = (span > 0.f)
-			              ? (target - sa.arrival).asSeconds() / span
-			              : 1.f;
-			rp1 = lerpPos({sa.state.p1_x, sa.state.p1_y},
-			              {sb.state.p1_x, sb.state.p1_y}, t);
-			rp2 = lerpPos({sa.state.p2_x, sa.state.p2_y},
-			              {sb.state.p2_x, sb.state.p2_y}, t);
-		} else {
-			rp1 = {buf[0].state.p1_x, buf[0].state.p1_y};
-			rp2 = {buf[0].state.p2_x, buf[0].state.p2_y};
-		}
-		m_player->setPosition(rp1.x, rp1.y);
-		player2->setPosition(rp2.x, rp2.y);
-	}
-
-	m_window.clear();
-	for (std::size_t x = 0; x < stuff.size(); ++x) {
-		stuff[x]->draw(m_window);
-	}
-	m_window.draw(timer);
-	m_window.draw(text);
-	m_window.draw(text2);
-	m_player->draw(m_window);
-	player2->draw(m_window);
-	if (wait) {
-		m_window.draw(pause_text);
-		m_window.draw(info);
-	}
-	m_window.display();
-
-	// Restore authoritative positions (symmetric with the save above).
-	if (didShift) {
-		m_player->setPosition(p1Saved.x, p1Saved.y);
-		player2->setPosition(p2Saved.x, p2Saved.y);
-	}
+void Game::processEvents()
+{
+    sf::Event event;
+    while (m_window.pollEvent(event)) {
+        switch (event.type) {
+        case sf::Event::KeyPressed:
+            handlePlayerInput(event.key.code, true);
+            break;
+        case sf::Event::KeyReleased:
+            handlePlayerInput(event.key.code, false);
+            break;
+        case sf::Event::Closed:
+            m_window.close();
+            break;
+        default:
+            break;
+        }
+    }
 }
 
-bool Game::collision(GameObject* a,GameObject* b) {
-	sf::Rect<float> arect = sf::Rect<float>(a->getPosition(),sf::Vector2f(a->getWidth()*(a->getScale().x),a->getHeight()*(a->getScale().y)));
-	sf::Rect<float> brect = sf::Rect<float>(b->getPosition(),sf::Vector2f(b->getWidth()*(b->getScale().x),b->getHeight()*(b->getScale().y)));
-    //std::cout << (arect.intersects(brect)) << std::endl;
-	return arect.intersects(brect);
+// ── handlePlayerInput ─────────────────────────────────────────────────────────
+
+void Game::handlePlayerInput(sf::Keyboard::Key key, bool isDown)
+{
+    // Gate all game-key bindings when the harness is active so that live
+    // keyboard cannot perturb a --frames / --replay run.
+    if (!m_debug.active()) {
+        // Player 1 controls (rocket — numpad)
+        if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::HOST) {
+            if (key == sf::Keyboard::Numpad4)
+                m_left = isDown;
+            if (key == sf::Keyboard::Numpad6)
+                m_right = isDown;
+            if (key == sf::Keyboard::Numpad8)
+                m_up = isDown;
+            if (key == sf::Keyboard::Numpad5)
+                m_down = isDown;
+            if (key == sf::Keyboard::Right)
+                right = isDown;
+        }
+
+        // Player 2 controls (robot — WASD)
+        if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::CLIENT) {
+            if (key == sf::Keyboard::W)
+                w = isDown;
+            if (key == sf::Keyboard::A)
+                a = isDown;
+            if (key == sf::Keyboard::S)
+                s = isDown;
+            if (key == sf::Keyboard::D)
+                d = isDown;
+            if (key == sf::Keyboard::Space)
+                space = !isDown;
+        }
+
+        // Speed tweaks and wait-skip
+        if (key == sf::Keyboard::O)
+            o = !isDown;
+        if (key == sf::Keyboard::P)
+            p = !isDown;
+        if (key == sf::Keyboard::K) {
+            if (wait) {
+                wait = false;
+                gong.play();
+            }
+        }
+    }
+
+    // Always-active: window close and manual screenshot.
+    if (key == sf::Keyboard::Escape)
+        m_window.close();
+    if (key == sf::Keyboard::F12 && isDown)
+        captureScreenshot(m_window,
+                          m_debug.screenshotDir + "/manual_" + std::to_string(m_steps) + ".png");
 }
 
-bool Game::collision(sf::Rect<float> a,GameObject* b) {
-	sf::Rect<float> brect = sf::Rect<float>(b->getPosition(),sf::Vector2f(b->getWidth()*(b->getScale().x),b->getHeight()*(b->getScale().y)));
-	return a.intersects(brect);
+// ── update ────────────────────────────────────────────────────────────────────
+
+void Game::update(sf::Time deltaT, float time)
+{
+    bool reset = false;
+
+    sf::Vector2f p1movement(0.0f, 0.0f);
+    sf::Vector2f p2movement(0.0f, 0.0f);
+
+    if (m_up) {
+        if (m_player->getPosition().y < -(m_player->getHeight())) {
+            m_player->setPosition(m_player->getPosition().x,
+                                  (m_window.getSize().y) - m_player->getHeight());
+        }
+
+        if (collision(m_player, player2)) {
+            m_player->setPosition(m_player->getPosition().x, m_player->getPosition().y + 40);
+            p2move = false;
+        } else {
+            p2move = true;
+            p1movement.y -= m_speed;
+        }
+    }
+
+    if (m_down) {
+        if (m_player->getPosition().y > (m_window.getSize().y) - (m_player->getHeight())) {
+            m_player->setPosition(m_player->getPosition().x, -(m_player->getHeight()));
+        }
+
+        if (collision(m_player, player2)) {
+            m_player->setPosition(m_player->getPosition().x, m_player->getPosition().y - 40);
+            p2move = false;
+        } else {
+            p2move = true;
+            p1movement.y += m_speed;
+        }
+    }
+    if (m_left) {
+        if (m_player->getPosition().x < -(m_player->getWidth())) {
+            m_player->setPosition(m_window.getSize().x, m_player->getPosition().y);
+        }
+        if (!p1left) {
+            m_player->setScale(-2.0f, 2);
+            p1left = true;
+            m_player->setPosition(
+                m_player->getPosition().x -
+                    (m_player->getWidth() * m_player->getScale().x),
+                m_player->getPosition().y);
+        }
+
+        if (collision(m_player, player2)) {
+            m_player->setPosition(m_player->getPosition().x + 40, m_player->getPosition().y);
+            p2move = false;
+        } else {
+            p2move = true;
+            p1movement.x -= m_speed;
+        }
+    }
+    if (m_right) {
+        m_player->setScale(2.0f, 2);
+
+        if (m_player->getPosition().x > m_window.getSize().x) {
+            m_player->setPosition(-(m_player->getWidth()), m_player->getPosition().y);
+        }
+
+        if (p1left) {
+            p1left = false;
+            m_player->setPosition(
+                m_player->getPosition().x -
+                    (m_player->getWidth() * m_player->getScale().x),
+                m_player->getPosition().y);
+        }
+
+        if (collision(m_player, player2)) {
+            m_player->setPosition(m_player->getPosition().x - 40, m_player->getPosition().y);
+            p2move = false;
+        } else {
+            p2move = true;
+            p1movement.x += m_speed;
+        }
+    }
+    if (w) {
+        if (player2->getPosition().y < -(player2->getHeight())) {
+            player2->setPosition(player2->getPosition().x,
+                                 (m_window.getSize().y) - player2->getHeight());
+        }
+
+        if (collision(m_player, player2)) {
+            player2->setPosition(player2->getPosition().x, player2->getPosition().y + 40);
+        } else {
+            p2movement.y -= m_speed;
+        }
+    }
+    if (s) {
+        if (player2->getPosition().y > (m_window.getSize().y) - (player2->getHeight())) {
+            player2->setPosition(player2->getPosition().x, -(player2->getHeight()));
+        }
+
+        if (collision(m_player, player2)) {
+            player2->setPosition(player2->getPosition().x, player2->getPosition().y - 40);
+        } else {
+            p2movement.y += m_speed;
+        }
+    }
+    if (a) {
+        if (player2->getPosition().x < -(player2->getWidth())) {
+            player2->setPosition(m_window.getSize().x, player2->getPosition().y);
+        }
+        player2->setScale(-1.0f, 1.0f);
+        if (!p2left) {
+            p2left = true;
+            player2->setPosition(
+                player2->getPosition().x -
+                    (player2->getWidth() * player2->getScale().x),
+                player2->getPosition().y);
+        }
+
+        if (collision(m_player, player2)) {
+            player2->setPosition(player2->getPosition().x + 40, player2->getPosition().y);
+        } else {
+            p2movement.x -= m_speed;
+        }
+    }
+    if (d) {
+        player2->setScale(1.0f, 1.0f);
+        if (player2->getPosition().x > m_window.getSize().x) {
+            player2->setPosition(-(player2->getWidth()), player2->getPosition().y);
+        }
+        if (p2left) {
+            p2left = false;
+            player2->setPosition(
+                player2->getPosition().x -
+                    (player2->getWidth() * player2->getScale().x),
+                player2->getPosition().y);
+        }
+        p2left = false;
+
+        if (collision(m_player, player2)) {
+            player2->setPosition(player2->getPosition().x - 40, player2->getPosition().y);
+        } else {
+            p2movement.x += m_speed;
+        }
+    }
+    if (space) {
+        sf::Rect<float> hit;
+        if (!p2left) {
+            hit = sf::Rect<float>(
+                player2->getPosition(),
+                sf::Vector2f(200 + ((player2->getWidth()) * (player2->getScale().x)),
+                             (player2->getHeight()) * (player2->getScale().y)));
+        } else {
+            hit = sf::Rect<float>(
+                player2->getPosition(),
+                sf::Vector2f(((player2->getWidth()) * (player2->getScale().x)) - 200,
+                             (player2->getHeight()) * (player2->getScale().y)));
+        }
+
+        if (collision(hit, m_player)) {
+            metal.play();
+            points++;
+            reset = true;
+        } else {
+            sword.play();
+        }
+
+        space = false;
+    }
+    if (right) {
+        sf::Rect<float> hit;
+        if (!p1left) {
+            hit = sf::Rect<float>(
+                m_player->getPosition(),
+                sf::Vector2f(200 + ((m_player->getWidth()) * (m_player->getScale().x)),
+                             (m_player->getHeight()) * (m_player->getScale().y)));
+        } else {
+            hit = sf::Rect<float>(
+                m_player->getPosition(),
+                sf::Vector2f(((m_player->getWidth()) * (m_player->getScale().x)) - 200,
+                             (m_player->getHeight()) * (m_player->getScale().y)));
+        }
+
+        if (collision(hit, player2)) {
+            p2points++;
+            reset = true;
+            p2hit.play();
+        } else {
+            laser.play();
+        }
+
+        right = false;
+    }
+    if (o) {
+        m_speed = m_speed - 150.0f;
+        if (m_speed < 0)
+            m_speed = 1.0f;
+        o = false;
+        slow_down.play();
+    }
+    if (p) {
+        m_speed = m_speed + 150.0f;
+        p       = false;
+        speed_up.play();
+    }
+
+    if ((m_up || m_down || m_left || m_right) & !collision(m_player, player2)) {
+        m_player->move(p1movement * deltaT.asSeconds());
+        m_player->update(time);
+    }
+
+    if ((w || a || s || d) & !collision(m_player, player2)) {
+        player2->move(p2movement * deltaT.asSeconds());
+        player2->update(time);
+    }
+    for (int x = 0; x < static_cast<int>(stuff.size()); x++) {
+        stuff[x]->update(time);
+    }
+
+    if (reset) {
+        m_player->setScale(2.0f, 2);
+        player2->setScale(-1.0f, 1.0f);
+        player2->setPosition(m_window.getSize().x - (m_player->getWidth() + 150), 400);
+        m_player->setPosition(m_player->getWidth() + 20, 400);
+        p1left = false;
+        p2left = true;
+        wait   = true;
+    }
+
+    text.setString("Rocket Score: " + std::to_string(p2points));
+    text2.setString("Robot Score: " + std::to_string(points));
+    text2.setPosition(m_window.getSize().x - text2.getGlobalBounds().width - 20, 0);
 }
 
-void Game::handleNetworkCommunication(sf::Time deltaT) {
-	if (!m_networkManager) return;
+// ── render ────────────────────────────────────────────────────────────────────
 
-	if (m_networkMode == NetworkMode::HOST && m_networkManager->isConnected()) {
-		m_networkManager->poll();
+void Game::render()
+{
+    // CLIENT: temporarily shift sprites to interpolated positions for drawing.
+    // Positions are saved and restored so update()/collision use authoritative coords.
+    sf::Vector2f p1Saved, p2Saved;
+    bool         didShift = false;
 
-		// Consume all queued inputs; keep only the most recent.
-		PlayerInput clientInput;
-		PlayerInput tmp;
-		bool got = false;
-		while (m_networkManager->nextInput(tmp)) {
-			clientInput = tmp;
-			got = true;
-		}
-		if (got) {
-			w     = clientInput.up;
-			s     = clientInput.down;
-			a     = clientInput.left;
-			d     = clientInput.right;
-			space = clientInput.attack;
-		}
+    if (m_networkMode == NetworkMode::CLIENT && m_networkManager &&
+        !m_networkManager->stateBuf().empty()) {
+        p1Saved  = m_player->getPosition();
+        p2Saved  = player2->getPosition();
+        didShift = true;
 
-		// Fixed-rate state send (~25 Hz).
-		m_stateAccum += deltaT.asSeconds();
-		if (m_stateAccum >= kStateSendInterval) {
-			m_stateAccum -= kStateSendInterval;
-			m_networkManager->sendGameState(captureGameState());
-		}
-	}
-	else if (m_networkMode == NetworkMode::CLIENT && m_networkManager->isConnected()) {
-		// Send local input every frame.
-		PlayerInput myInput;
-		myInput.up     = w;
-		myInput.down   = s;
-		myInput.left   = a;
-		myInput.right  = d;
-		myInput.attack = space;
-		m_networkManager->sendInput(myInput);
+        const auto& buf          = m_networkManager->stateBuf();
+        constexpr float kInterpDelay = 0.04f; // 40 ms behind
+        sf::Time        target   = m_networkManager->elapsed() - sf::seconds(kInterpDelay);
 
-		// Drain incoming state packets.
-		m_networkManager->poll();
+        sf::Vector2f rp1, rp2;
+        if (buf.size() >= 2) {
+            std::size_t ai = 0;
+            for (std::size_t i = 0; i + 1 < buf.size(); ++i) {
+                if (buf[i].arrival <= target)
+                    ai = i;
+            }
+            std::size_t bi  = std::min(ai + 1, buf.size() - 1);
+            const auto& sa  = buf[ai];
+            const auto& sb  = buf[bi];
+            float       span = (sb.arrival - sa.arrival).asSeconds();
+            float       t =
+                (span > 0.f) ? (target - sa.arrival).asSeconds() / span : 1.f;
+            rp1 = lerpPos({sa.state.p1_x, sa.state.p1_y}, {sb.state.p1_x, sb.state.p1_y}, t);
+            rp2 = lerpPos({sa.state.p2_x, sa.state.p2_y}, {sb.state.p2_x, sb.state.p2_y}, t);
+        } else {
+            rp1 = {buf[0].state.p1_x, buf[0].state.p1_y};
+            rp2 = {buf[0].state.p2_x, buf[0].state.p2_y};
+        }
+        m_player->setPosition(rp1.x, rp1.y);
+        player2->setPosition(rp2.x, rp2.y);
+    }
 
-		// Apply the latest snapshot for update()/collision (authoritative).
-		if (!m_networkManager->stateBuf().empty()) {
-			m_latestState = m_networkManager->stateBuf().back().state;
-			applyNetworkState(m_latestState);
-		}
-	}
+    m_window.clear();
+    for (std::size_t x = 0; x < stuff.size(); ++x) {
+        stuff[x]->draw(m_window);
+    }
+    m_window.draw(timer);
+    m_window.draw(text);
+    m_window.draw(text2);
+    m_player->draw(m_window);
+    player2->draw(m_window);
+    if (wait) {
+        m_window.draw(pause_text);
+        m_window.draw(info);
+    }
+    // NOTE: m_window.display() is called by run() so screenshots can be
+    // captured between draw and swap.
 
-	// Peer-loss check (runs after poll/send on either side).
-	if (!m_peerLeft && m_networkManager->peerLost()) {
-		m_peerLeft = true;
-		m_window.close();
-	}
+    // Restore authoritative positions (symmetric with the save above).
+    if (didShift) {
+        m_player->setPosition(p1Saved.x, p1Saved.y);
+        player2->setPosition(p2Saved.x, p2Saved.y);
+    }
 }
 
-GameState Game::captureGameState() const {
-	GameState state;
-	state.p1_x = m_player->getPosition().x;
-	state.p1_y = m_player->getPosition().y;
-	state.p2_x = player2->getPosition().x;
-	state.p2_y = player2->getPosition().y;
-	state.p1_score = p2points;
-	state.p2_score = points;
-	state.p1_left = p1left;
-	state.p2_left = p2left;
-	state.p1_scale_x = m_player->getScale().x;
-	state.p1_scale_y = m_player->getScale().y;
-	state.p2_scale_x = player2->getScale().x;
-	state.p2_scale_y = player2->getScale().y;
-	state.wait = wait;
-	return state;
+// ── collision ─────────────────────────────────────────────────────────────────
+
+bool Game::collision(GameObject* a, GameObject* b)
+{
+    sf::Rect<float> arect = sf::Rect<float>(
+        a->getPosition(),
+        sf::Vector2f(a->getWidth() * (a->getScale().x), a->getHeight() * (a->getScale().y)));
+    sf::Rect<float> brect = sf::Rect<float>(
+        b->getPosition(),
+        sf::Vector2f(b->getWidth() * (b->getScale().x), b->getHeight() * (b->getScale().y)));
+    return arect.intersects(brect);
 }
 
-void Game::applyNetworkState(const GameState& state) {
-	m_player->setPosition(state.p1_x, state.p1_y);
-	player2->setPosition(state.p2_x, state.p2_y);
-	p2points = state.p1_score;
-	points = state.p2_score;
-	p1left = state.p1_left;
-	p2left = state.p2_left;
-	m_player->setScale(state.p1_scale_x, state.p1_scale_y);
-	player2->setScale(state.p2_scale_x, state.p2_scale_y);
-	wait = state.wait;
+bool Game::collision(sf::Rect<float> a, GameObject* b)
+{
+    sf::Rect<float> brect = sf::Rect<float>(
+        b->getPosition(),
+        sf::Vector2f(b->getWidth() * (b->getScale().x), b->getHeight() * (b->getScale().y)));
+    return a.intersects(brect);
+}
+
+// ── handleNetworkCommunication ────────────────────────────────────────────────
+
+void Game::handleNetworkCommunication(sf::Time deltaT)
+{
+    if (!m_networkManager)
+        return;
+
+    if (m_networkMode == NetworkMode::HOST && m_networkManager->isConnected()) {
+        m_networkManager->poll();
+
+        // Consume all queued inputs; keep only the most recent.
+        PlayerInput clientInput;
+        PlayerInput tmp;
+        bool        got = false;
+        while (m_networkManager->nextInput(tmp)) {
+            clientInput = tmp;
+            got         = true;
+        }
+        if (got) {
+            applyPlayerInput(clientInput);
+        }
+
+        // Fixed-rate state send (~25 Hz).
+        m_stateAccum += deltaT.asSeconds();
+        if (m_stateAccum >= kStateSendInterval) {
+            m_stateAccum -= kStateSendInterval;
+            m_networkManager->sendGameState(captureGameState());
+        }
+    } else if (m_networkMode == NetworkMode::CLIENT && m_networkManager->isConnected()) {
+        // Send local input every frame.
+        PlayerInput myInput;
+        myInput.up     = w;
+        myInput.down   = s;
+        myInput.left   = a;
+        myInput.right  = d;
+        myInput.attack = space;
+        m_networkManager->sendInput(myInput);
+
+        // Drain incoming state packets.
+        m_networkManager->poll();
+
+        // Apply the latest snapshot — once per iteration, before the step-drain.
+        if (!m_networkManager->stateBuf().empty()) {
+            m_latestState = m_networkManager->stateBuf().back().state;
+            applyNetworkState(m_latestState);
+        }
+    }
+
+    // Peer-loss check (runs after poll/send on either side).
+    if (!m_peerLeft && m_networkManager->peerLost()) {
+        m_peerLeft = true;
+        m_window.close();
+    }
+}
+
+// ── captureGameState / applyNetworkState ──────────────────────────────────────
+
+GameState Game::captureGameState() const
+{
+    GameState state;
+    state.p1_x      = m_player->getPosition().x;
+    state.p1_y      = m_player->getPosition().y;
+    state.p2_x      = player2->getPosition().x;
+    state.p2_y      = player2->getPosition().y;
+    state.p1_score  = p2points;
+    state.p2_score  = points;
+    state.p1_left   = p1left;
+    state.p2_left   = p2left;
+    state.p1_scale_x = m_player->getScale().x;
+    state.p1_scale_y = m_player->getScale().y;
+    state.p2_scale_x = player2->getScale().x;
+    state.p2_scale_y = player2->getScale().y;
+    state.wait       = wait;
+    return state;
+}
+
+void Game::applyNetworkState(const GameState& state)
+{
+    m_player->setPosition(state.p1_x, state.p1_y);
+    player2->setPosition(state.p2_x, state.p2_y);
+    p2points = state.p1_score;
+    points   = state.p2_score;
+    p1left   = state.p1_left;
+    p2left   = state.p2_left;
+    m_player->setScale(state.p1_scale_x, state.p1_scale_y);
+    player2->setScale(state.p2_scale_x, state.p2_scale_y);
+    wait = state.wait;
 }

--- a/Game.h
+++ b/Game.h
@@ -5,58 +5,74 @@
 
 #include <SFML/Graphics.hpp>
 #include <SFML/Audio.hpp>
-#include <vector>
-#include "RegularGameObject.h"
-#include "GameObject.h"
-#include "AnimatedGameObject.h"
-#include "NetworkManager.h"
-#include <tuple>
 #include <memory>
+#include <tuple>
+#include <vector>
+#include "AnimatedGameObject.h"
+#include "debug.h"
+#include "GameObject.h"
+#include "NetworkManager.h"
+#include "RegularGameObject.h"
+#include "replay.h"
 
 class Game {
 public:
-	//use default screen size
-	Game();
-	Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager);
-	//run the game
-	std::tuple<int,int,float,int,bool,bool> run();
+    // use default screen size
+    Game();
+    Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager);
+
+    // Configure debug/harness options; call before run().
+    void setDebugConfig(const DebugConfig& cfg);
+
+    // Accessor for step count (useful for post-run reporting).
+    long long steps() const { return m_steps; }
+
+    // run the game
+    std::tuple<int, int, float, int, bool, bool> run();
 
 private:
-	void processEvents();
-	//update the game objects
-	void update(sf::Time deltaT,float time);
-	//draw the scene
-	void render();
-	//handle input from the user
-	void handlePlayerInput(sf::Keyboard::Key key, bool isDown);
-	//check collison with walls or other objects
-	bool collision(GameObject* a,GameObject* b);
-	bool collision(sf::Rect<float> a,GameObject* b);
+    void processEvents();
+    // update the game objects
+    void update(sf::Time deltaT, float time);
+    // draw the scene
+    void render();
+    // handle input from the user
+    void handlePlayerInput(sf::Keyboard::Key key, bool isDown);
+    // check collision with walls or other objects
+    bool collision(GameObject* a, GameObject* b);
+    bool collision(sf::Rect<float> a, GameObject* b);
 
-	sf::RenderWindow m_window;
+    // Fixed-timestep deterministic sim body.
+    void simStep();
+    // Apply a PlayerInput to the P2 bool state (w/a/s/d/space).
+    void applyPlayerInput(const PlayerInput& in);
+    // Capture a screenshot if the debug config says it is due this step.
+    void captureIfDue();
 
-	sf::SoundBuffer gongbuffer;
-	sf::SoundBuffer sbuffer;
+    sf::RenderWindow m_window;
+
+    sf::SoundBuffer gongbuffer;
+    sf::SoundBuffer sbuffer;
     sf::SoundBuffer p2hitbuffer;
     sf::SoundBuffer laserbuffer;
     sf::SoundBuffer metalbuffer;
     sf::SoundBuffer speedbuffer;
     sf::SoundBuffer slowbuffer;
     sf::SoundBuffer burnbuffer;
-    sf::Sound gong;
-	sf::Sound sword;
-	sf::Sound p2hit;
-	sf::Sound laser;
-	sf::Sound metal;
-	sf::Sound speed_up;
-	sf::Sound slow_down;
-	sf::Sound burn;
+    sf::Sound       gong;
+    sf::Sound       sword;
+    sf::Sound       p2hit;
+    sf::Sound       laser;
+    sf::Sound       metal;
+    sf::Sound       speed_up;
+    sf::Sound       slow_down;
+    sf::Sound       burn;
 
-	sf::Music background;
+    sf::Music background;
 
-	GameObject* m_player = new AnimatedGameObject(404,206,3,3,9,0);
-	GameObject* player2 = new AnimatedGameObject(959,180,8,1,8,0);
-	std::vector<GameObject*> stuff;
+    GameObject* m_player = new AnimatedGameObject(404, 206, 3, 3, 9, 0);
+    GameObject* player2  = new AnimatedGameObject(959, 180, 8, 1, 8, 0);
+    std::vector<GameObject*> stuff;
 
     sf::Font font;
     sf::Font tfont;
@@ -67,44 +83,54 @@ private:
     sf::Text pause_text;
     sf::Text info;
 
+    float m_speed          = 1200.0f;
+    float temp_time        = 0;
+    float p1_timeout       = 0;
+    float p2_timeout       = 0;
+    bool  m_left           = false;
+    bool  m_right          = false;
+    bool  m_up             = false;
+    bool  m_down           = false;
+    bool  w                = false;
+    bool  a                = false;
+    bool  s                = false;
+    bool  d                = false;
+    bool  space            = false;
+    int   points           = 0;
+    int   p2points         = 0;
+    int   right            = false;
+    bool  p1left           = false;
+    bool  p2left           = true;
+    bool  p1move           = true;
+    bool  p2move           = true;
+    bool  p                = false;
+    bool  o                = false;
+    bool  wait             = false;
+    bool  p1_time_passed   = true;
+    bool  p2_time_passed   = true;
 
-	float m_speed = 1200.0f;
-	float temp_time = 0;
-	float p1_timeout = 0;
-	float p2_timeout = 0;
-	bool m_left = false;
-	bool m_right = false;
-	bool m_up = false;
-	bool m_down = false;
-	bool w = false;
-	bool a = false;
-	bool s = false;
-	bool d = false;
-	bool space = false;
-	int points = 0;
-	int p2points = 0;
-	int right = false;
-	bool p1left = false;
-	bool p2left = true;
-	bool p1move = true;
-	bool p2move = true;
-	bool p = false;
-	bool o = false;
-	bool wait = false;
-	bool p1_time_passed = true;
-	bool p2_time_passed = true;
+    // Fixed-timestep state
+    static constexpr float kFixedDt = 1.f / 60.f;
+    long long              m_steps      = 0;
+    float                  m_accumulator = 0.f;
+    float                  m_animTime   = 0.f;
 
-	// Network support
-	NetworkMode m_networkMode = NetworkMode::LOCAL;
-	std::shared_ptr<NetworkManager> m_networkManager;
-	void handleNetworkCommunication(sf::Time deltaT);
-	void applyNetworkState(const GameState& state);
-	GameState captureGameState() const;
+    double gameSeconds() const { return m_steps * static_cast<double>(kFixedDt); }
 
-	bool      m_peerLeft   = false;
-	GameState m_latestState;
-	float     m_stateAccum = 0.f;
-	static constexpr float kStateSendInterval = 1.f / 25.f; // ~25 Hz
+    // Debug / harness configuration
+    DebugConfig              m_debug;
+    std::vector<PlayerInput> m_replay;
+    std::size_t              m_replayIdx = 0;
 
+    // Network support
+    NetworkMode                      m_networkMode = NetworkMode::LOCAL;
+    std::shared_ptr<NetworkManager>  m_networkManager;
+    void      handleNetworkCommunication(sf::Time deltaT);
+    void      applyNetworkState(const GameState& state);
+    GameState captureGameState() const;
+
+    bool      m_peerLeft   = false;
+    GameState m_latestState;
+    float     m_stateAccum = 0.f;
+    static constexpr float kStateSendInterval = 1.f / 25.f; // ~25 Hz
 };
-

--- a/Game.h
+++ b/Game.h
@@ -121,6 +121,7 @@ private:
     DebugConfig              m_debug;
     std::vector<PlayerInput> m_replay;
     std::size_t              m_replayIdx = 0;
+    long long                m_nextShot  = 0; // next step at which to auto-screenshot
 
     // Network support
     NetworkMode                      m_networkMode = NetworkMode::LOCAL;

--- a/debug.h
+++ b/debug.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <string>
+
+struct DebugConfig {
+    int         frames          = 0;
+    std::string replayPath;
+    int         screenshotEvery = 0;
+    std::string screenshotDir   = ".";
+
+    bool active() const { return frames > 0 || !replayPath.empty() || screenshotEvery > 0; }
+};

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,14 +34,51 @@ ctest --test-dir build --output-on-failure               # 4. tests
 
 ## Automated playtesting
 
-Because SFML has no API to inject synthetic events, automated testing reuses the game's own input
-and rendering channels behind a debug flag/build (issue #13):
+The game supports a headless/scriptable harness activated by CLI flags (implemented in #13).
+Pass any flag listed below to bypass menus entirely; the game constructs directly in LOCAL mode,
+runs the specified number of steps, prints scores and step count, and exits.
 
-- **Scriptable input** — feed a sequence of `PlayerInput`s (`--replay <file>`) or drive player 2
-  over the network client path; deterministic and focus-independent.
-- **Screenshots** — capture the framebuffer to a file on a debug key and/or `--screenshot-every N`.
-- **Determinism** — fixed timestep + seedable RNG + `--frames N` (run N frames then exit) make
-  playthroughs reproducible: drive → capture → assess in a loop.
+```bash
+./build/dungeon_game \
+  --frames 300              \  # run exactly 300 sim steps then exit
+  --replay tests/data/demo.replay \  # drive P2 from replay script
+  --screenshot-every 60     \  # save PNG every 60 steps
+  --screenshot-dir /tmp/out \  # directory for screenshots (created if absent)
+  --seed 1                     # seed the RNG for reproducibility
+```
+
+### Replay format
+
+Text file, one line per sim step:
+
+```
+# Lines starting with '#' are comments (ignored).
+# Blank lines are ignored.
+# Each data line has exactly 5 space-separated 0/1 fields:
+#   up  down  left  right  attack
+0 0 0 1 0     # P2 moves right
+0 0 0 0 1     # P2 attacks
+0 0 0 0 0     # P2 idle
+```
+
+A malformed line (wrong field count or a value other than `0`/`1`) is skipped with a single
+`std::cerr` warning; parsing always completes. If the replay ends before `--frames N` steps are
+done, the remaining steps receive an all-zero `PlayerInput` (both players idle).
+
+### Determinism guarantee
+
+Two runs with the same `--replay`, `--frames`, and `--seed` produce byte-identical screenshots.
+Verified via `md5` / `shasum` on the output PNGs. The invariants are:
+
+- Fixed timestep (`kFixedDt = 1/60 s`) — no wall-clock randomness in the sim.
+- Replay script drives P2; keyboard is disabled when `--replay` / `--frames` is active.
+- `rng::seed()` seeds the shared `std::mt19937`; gameplay currently has no RNG, so the seed
+  matters only for future stochastic features (AI mistake-rate, etc.).
+
+### F12 manual screenshot
+
+Press **F12** at any time during a running game to save
+`<screenshotDir>/manual_<step>.png` to the configured screenshot directory (default: `.`).
 
 A scripted playthrough doubles as an integration test (#7).
 

--- a/main.cpp
+++ b/main.cpp
@@ -5,9 +5,13 @@
 #include <iostream>
 #include "AnimatedGameObject.h"
 #include "resource_path.h"
+#include "debug.h"
+#include "rng.h"
+#include <filesystem>
 #include <tuple>
 #include <cstdio>
 #include <memory>
+#include <string>
 
 int highscore = 0;
 int p1score = 0;
@@ -220,6 +224,58 @@ enum MenuState {
 int main(int argc, char** argv)
 {
     initResourcePath(argv[0]);
+
+    // ── CLI parsing ───────────────────────────────────────────────────────────
+    DebugConfig  config;
+    unsigned     seed     = 0;
+    bool         haveSeed = false;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg(argv[i]);
+        if (arg == "--frames" && i + 1 < argc) {
+            config.frames = std::stoi(argv[++i]);
+        } else if (arg == "--replay" && i + 1 < argc) {
+            config.replayPath = argv[++i];
+        } else if (arg == "--screenshot-every" && i + 1 < argc) {
+            config.screenshotEvery = std::stoi(argv[++i]);
+        } else if (arg == "--screenshot-dir" && i + 1 < argc) {
+            config.screenshotDir = argv[++i];
+        } else if (arg == "--seed" && i + 1 < argc) {
+            seed     = static_cast<unsigned>(std::stoul(argv[++i]));
+            haveSeed = true;
+        } else if (arg == "--help") {
+            std::cout
+                << "Usage: dungeon_game [options]\n"
+                << "  --frames N             Run N sim steps then exit\n"
+                << "  --replay <file>        Drive P2 from replay file\n"
+                << "  --screenshot-every N   Save screenshot every N steps\n"
+                << "  --screenshot-dir <d>   Directory for screenshots (default: .)\n"
+                << "  --seed <n>             Seed the RNG\n"
+                << "\n"
+                << "Replay format: one line per step — 'up down left right attack' (0 or 1)\n"
+                << "  Blank lines and lines starting with '#' are ignored.\n";
+            return 0;
+        }
+    }
+
+    // ── Debug / harness bypass ────────────────────────────────────────────────
+    if (config.active()) {
+        if (haveSeed)
+            rng::seed(seed);
+        if (config.screenshotEvery > 0)
+            std::filesystem::create_directories(config.screenshotDir);
+
+        Game game;
+        game.setDebugConfig(config);
+        auto result = game.run();
+
+        std::cout << "P1 score: " << std::get<0>(result) << "\n"
+                  << "P2 score: " << std::get<1>(result) << "\n"
+                  << "Steps:    " << game.steps() << "\n";
+        return 0;
+    }
+
+    // ── Normal menu flow (unchanged) ──────────────────────────────────────────
     MenuState menuState = MAIN_MENU;
     NetworkMode mode = NetworkMode::LOCAL;
     std::shared_ptr<NetworkManager> netManager = nullptr;

--- a/main.cpp
+++ b/main.cpp
@@ -12,6 +12,7 @@
 #include <cstdio>
 #include <memory>
 #include <string>
+#include <stdexcept>
 
 int highscore = 0;
 int p1score = 0;
@@ -230,31 +231,43 @@ int main(int argc, char** argv)
     unsigned     seed     = 0;
     bool         haveSeed = false;
 
+    auto needValue = [&](const std::string& flag, int& i) -> const char* {
+        if (i + 1 >= argc) throw std::runtime_error(flag + " requires a value");
+        return argv[++i];
+    };
     for (int i = 1; i < argc; ++i) {
         std::string arg(argv[i]);
-        if (arg == "--frames" && i + 1 < argc) {
-            config.frames = std::stoi(argv[++i]);
-        } else if (arg == "--replay" && i + 1 < argc) {
-            config.replayPath = argv[++i];
-        } else if (arg == "--screenshot-every" && i + 1 < argc) {
-            config.screenshotEvery = std::stoi(argv[++i]);
-        } else if (arg == "--screenshot-dir" && i + 1 < argc) {
-            config.screenshotDir = argv[++i];
-        } else if (arg == "--seed" && i + 1 < argc) {
-            seed     = static_cast<unsigned>(std::stoul(argv[++i]));
-            haveSeed = true;
-        } else if (arg == "--help") {
-            std::cout
-                << "Usage: dungeon_game [options]\n"
-                << "  --frames N             Run N sim steps then exit\n"
-                << "  --replay <file>        Drive P2 from replay file\n"
-                << "  --screenshot-every N   Save screenshot every N steps\n"
-                << "  --screenshot-dir <d>   Directory for screenshots (default: .)\n"
-                << "  --seed <n>             Seed the RNG\n"
-                << "\n"
-                << "Replay format: one line per step — 'up down left right attack' (0 or 1)\n"
-                << "  Blank lines and lines starting with '#' are ignored.\n";
-            return 0;
+        try {
+            if (arg == "--frames") {
+                config.frames = std::stoi(needValue(arg, i));
+            } else if (arg == "--replay") {
+                config.replayPath = needValue(arg, i);
+            } else if (arg == "--screenshot-every") {
+                config.screenshotEvery = std::stoi(needValue(arg, i));
+            } else if (arg == "--screenshot-dir") {
+                config.screenshotDir = needValue(arg, i);
+            } else if (arg == "--seed") {
+                seed     = static_cast<unsigned>(std::stoul(needValue(arg, i)));
+                haveSeed = true;
+            } else if (arg == "--help") {
+                std::cout
+                    << "Usage: dungeon_game [options]\n"
+                    << "  --frames N             Run N sim steps then exit\n"
+                    << "  --replay <file>        Drive P2 from replay file\n"
+                    << "  --screenshot-every N   Save screenshot every N steps\n"
+                    << "  --screenshot-dir <d>   Directory for screenshots (default: .)\n"
+                    << "  --seed <n>             Seed the RNG\n"
+                    << "\n"
+                    << "Replay format: one line per step — 'up down left right attack' (0 or 1)\n"
+                    << "  Everything from '#' to end-of-line is ignored; blank lines skipped.\n";
+                return 0;
+            } else {
+                std::cerr << "Error: unknown option '" << arg << "' (try --help)\n";
+                return 1;
+            }
+        } catch (const std::exception& e) {
+            std::cerr << "Error: " << e.what() << " (option '" << arg << "')\n";
+            return 1;
         }
     }
 

--- a/replay.cpp
+++ b/replay.cpp
@@ -1,0 +1,75 @@
+#include "replay.h"
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+void applyInputTo(bool& w, bool& a, bool& s, bool& d, bool& space, const PlayerInput& in)
+{
+    w     = in.up;
+    a     = in.left;
+    s     = in.down;
+    d     = in.right;
+    space = in.attack;
+}
+
+std::vector<PlayerInput> loadReplay(const std::string& path)
+{
+    std::vector<PlayerInput> result;
+    std::ifstream            f(path);
+    if (!f.is_open()) {
+        std::cerr << "replay: cannot open '" << path << "'\n";
+        return result;
+    }
+
+    std::string line;
+    int         lineNum = 0;
+    while (std::getline(f, line)) {
+        ++lineNum;
+
+        // Strip trailing comment
+        auto hash = line.find('#');
+        if (hash != std::string::npos)
+            line = line.substr(0, hash);
+
+        // Skip blank / whitespace-only lines
+        bool blank = true;
+        for (char c : line)
+            if (!std::isspace(static_cast<unsigned char>(c))) {
+                blank = false;
+                break;
+            }
+        if (blank)
+            continue;
+
+        // Parse exactly 5 fields, each 0 or 1
+        std::istringstream ss(line);
+        int                vals[5];
+        bool               ok = true;
+        for (int i = 0; i < 5 && ok; ++i) {
+            if (!(ss >> vals[i]))
+                ok = false;
+            else if (vals[i] != 0 && vals[i] != 1)
+                ok = false;
+        }
+        // Reject lines with extra content
+        if (ok) {
+            std::string rest;
+            if (ss >> rest)
+                ok = false;
+        }
+
+        if (!ok) {
+            std::cerr << "replay: malformed line " << lineNum << " (skipped)\n";
+            continue;
+        }
+
+        PlayerInput inp;
+        inp.up     = (vals[0] != 0);
+        inp.down   = (vals[1] != 0);
+        inp.left   = (vals[2] != 0);
+        inp.right  = (vals[3] != 0);
+        inp.attack = (vals[4] != 0);
+        result.push_back(inp);
+    }
+    return result;
+}

--- a/replay.h
+++ b/replay.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <string>
+#include <vector>
+#include "NetworkManager.h"
+
+// Parse a replay file.  Text format: one line per sim step, five 0/1 fields
+// (up down left right attack), whitespace-separated.  Blank lines and lines
+// beginning with '#' (after optional leading whitespace) are ignored.  A
+// malformed line (wrong field count or a value that is not 0 or 1) is skipped
+// with a single std::cerr warning; parsing continues.  Never throws.
+std::vector<PlayerInput> loadReplay(const std::string& path);
+
+// Map a PlayerInput onto the five P2 bool variables.
+// Extracted as a free function so it can be unit-tested without a Game/window.
+void applyInputTo(bool& w, bool& a, bool& s, bool& d, bool& space, const PlayerInput& in);

--- a/replay.h
+++ b/replay.h
@@ -4,10 +4,10 @@
 #include "NetworkManager.h"
 
 // Parse a replay file.  Text format: one line per sim step, five 0/1 fields
-// (up down left right attack), whitespace-separated.  Blank lines and lines
-// beginning with '#' (after optional leading whitespace) are ignored.  A
-// malformed line (wrong field count or a value that is not 0 or 1) is skipped
-// with a single std::cerr warning; parsing continues.  Never throws.
+// (up down left right attack), whitespace-separated.  Everything from '#' to
+// end-of-line is ignored (both full-line and inline comments); blank lines are
+// skipped.  A malformed line (wrong field count or a value that is not 0 or 1)
+// is skipped with a single std::cerr warning; parsing continues.  Never throws.
 std::vector<PlayerInput> loadReplay(const std::string& path);
 
 // Map a PlayerInput onto the five P2 bool variables.

--- a/rng.cpp
+++ b/rng.cpp
@@ -1,0 +1,11 @@
+#include "rng.h"
+
+namespace rng {
+namespace {
+std::mt19937 s_engine; // NOLINT(cert-msc51-cpp) — seeded explicitly via rng::seed
+} // namespace
+
+void seed(unsigned s) { s_engine.seed(s); }
+
+std::mt19937& engine() { return s_engine; }
+} // namespace rng

--- a/rng.h
+++ b/rng.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <random>
+
+namespace rng {
+void         seed(unsigned s);
+std::mt19937& engine();
+} // namespace rng

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,8 +8,12 @@ target_link_libraries(test_netcode PRIVATE dungeon_lib)
 add_executable(test_loopback test_loopback.cpp)
 target_link_libraries(test_loopback PRIVATE dungeon_lib)
 
+# ── Harness unit tests (replay parser, applyInputTo, gameSeconds) ─────────────
+add_executable(test_harness test_harness.cpp)
+target_link_libraries(test_harness PRIVATE dungeon_lib)
+
 # ── Warnings (mirror root settings) ──────────────────────────────────────────
-foreach(t test_netcode test_loopback)
+foreach(t test_netcode test_loopback test_harness)
     if(MSVC)
         target_compile_options(${t} PRIVATE /W4)
     else()
@@ -20,3 +24,4 @@ endforeach()
 # ── Register with ctest ───────────────────────────────────────────────────────
 add_test(NAME netcode_unit     COMMAND test_netcode)
 add_test(NAME netcode_loopback COMMAND test_loopback)
+add_test(NAME harness_unit     COMMAND test_harness)

--- a/tests/data/demo.replay
+++ b/tests/data/demo.replay
@@ -1,0 +1,45 @@
+# demo.replay — determinism test replay for dungeon_game
+# format: up down left right attack  (one sim step per line, values 0 or 1)
+# P2 moves right 10 steps, attacks, moves left 10 steps, moves up+right 5 steps, idles.
+# EOF before --frames N limit → remaining steps receive all-false PlayerInput.
+
+# move right
+0 0 0 1 0
+0 0 0 1 0
+0 0 0 1 0
+0 0 0 1 0
+0 0 0 1 0
+0 0 0 1 0
+0 0 0 1 0
+0 0 0 1 0
+0 0 0 1 0
+0 0 0 1 0
+
+# attack
+0 0 0 0 1
+
+# move left
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+
+# move up-right
+1 0 0 1 0
+1 0 0 1 0
+1 0 0 1 0
+1 0 0 1 0
+1 0 0 1 0
+
+# move down
+0 1 0 0 0
+0 1 0 0 0
+0 1 0 0 0
+0 1 0 0 0
+0 1 0 0 0

--- a/tests/test_harness.cpp
+++ b/tests/test_harness.cpp
@@ -1,0 +1,190 @@
+// Socket-free unit tests for the debug harness.
+// Covers: loadReplay parser (valid/comment/blank/malformed/field-map),
+//         applyInputTo mapping, and gameSeconds step→seconds derivation.
+// No Catch2 — plain assert + main(), matching #2's style.
+
+#include <cassert>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+
+#include "NetworkManager.h"
+#include "replay.h"
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+static constexpr float kFixedDt = 1.f / 60.f;
+
+// ── loadReplay: valid lines + field mapping ────────────────────────────────────
+
+static void test_loadreplay_valid()
+{
+    const char* path = "/tmp/dg_test_valid.replay";
+    {
+        std::ofstream f(path);
+        f << "# header comment\n";
+        f << "\n";
+        f << "1 0 0 1 0\n";
+        f << "0 1 1 0 1\n";
+    }
+    auto result = loadReplay(path);
+    assert(result.size() == 2);
+    // Line 1: up=1 down=0 left=0 right=1 attack=0
+    assert(result[0].up     == true);
+    assert(result[0].down   == false);
+    assert(result[0].left   == false);
+    assert(result[0].right  == true);
+    assert(result[0].attack == false);
+    // Line 2: up=0 down=1 left=1 right=0 attack=1
+    assert(result[1].up     == false);
+    assert(result[1].down   == true);
+    assert(result[1].left   == true);
+    assert(result[1].right  == false);
+    assert(result[1].attack == true);
+}
+
+// ── loadReplay: comment stripping and blank lines ────────────────────────────
+
+static void test_loadreplay_comments_blanks()
+{
+    const char* path = "/tmp/dg_test_comments.replay";
+    {
+        std::ofstream f(path);
+        f << "# full-line comment\n";
+        f << "   \n";                        // whitespace-only
+        f << "0 0 0 0 0  # inline comment\n";
+        f << "\n";
+    }
+    auto result = loadReplay(path);
+    assert(result.size() == 1);
+    assert(result[0].up == false && result[0].attack == false);
+}
+
+// ── loadReplay: malformed — wrong field count (too few) ───────────────────────
+
+static void test_loadreplay_malformed_count_few()
+{
+    const char* path = "/tmp/dg_test_few.replay";
+    {
+        std::ofstream f(path);
+        f << "1 0 0 1\n";      // only 4 fields → malformed
+        f << "0 0 0 0 0\n";    // valid
+    }
+    auto result = loadReplay(path);
+    assert(result.size() == 1);
+    assert(result[0].up == false);
+}
+
+// ── loadReplay: malformed — wrong field count (too many) ──────────────────────
+
+static void test_loadreplay_malformed_count_many()
+{
+    const char* path = "/tmp/dg_test_many.replay";
+    {
+        std::ofstream f(path);
+        f << "1 0 0 1 0 0\n";  // 6 fields → malformed
+        f << "1 0 0 0 1\n";    // valid
+    }
+    auto result = loadReplay(path);
+    assert(result.size() == 1);
+    assert(result[0].up == true && result[0].attack == true);
+}
+
+// ── loadReplay: malformed — invalid value (not 0 or 1) ───────────────────────
+
+static void test_loadreplay_malformed_value()
+{
+    const char* path = "/tmp/dg_test_val.replay";
+    {
+        std::ofstream f(path);
+        f << "1 0 2 0 1\n";    // '2' is invalid
+        f << "1 0 0 0 1\n";    // valid
+    }
+    auto result = loadReplay(path);
+    assert(result.size() == 1);
+    assert(result[0].up == true && result[0].attack == true);
+}
+
+// ── loadReplay: field order mapping ──────────────────────────────────────────
+
+static void test_loadreplay_field_mapping()
+{
+    const char* path = "/tmp/dg_test_fields.replay";
+    {
+        std::ofstream f(path);
+        f << "1 0 0 0 0\n";    // up only
+        f << "0 1 0 0 0\n";    // down only
+        f << "0 0 1 0 0\n";    // left only
+        f << "0 0 0 1 0\n";    // right only
+        f << "0 0 0 0 1\n";    // attack only
+    }
+    auto result = loadReplay(path);
+    assert(result.size() == 5);
+    assert(result[0].up     && !result[0].down && !result[0].left && !result[0].right && !result[0].attack);
+    assert(!result[1].up    && result[1].down  && !result[1].left && !result[1].right && !result[1].attack);
+    assert(!result[2].up    && !result[2].down && result[2].left  && !result[2].right && !result[2].attack);
+    assert(!result[3].up    && !result[3].down && !result[3].left && result[3].right  && !result[3].attack);
+    assert(!result[4].up    && !result[4].down && !result[4].left && !result[4].right && result[4].attack);
+}
+
+// ── applyInputTo: all five fields mapped correctly ────────────────────────────
+
+static void test_applyinputto_mapping()
+{
+    PlayerInput in;
+    in.up = true; in.down = false; in.left = true; in.right = false; in.attack = true;
+
+    bool w = false, a = false, s = true, d = true, space = false;
+    applyInputTo(w, a, s, d, space, in);
+
+    assert(w     == true);   // in.up
+    assert(a     == true);   // in.left
+    assert(s     == false);  // in.down
+    assert(d     == false);  // in.right
+    assert(space == true);   // in.attack
+}
+
+// ── gameSeconds: step × kFixedDt derivation ──────────────────────────────────
+
+static void test_gameseconds_derivation()
+{
+    // kFixedDt is a float (1.f/60.f), so tolerate float-precision rounding
+    // when it is widened to double for the multiply (~4e-8 error per step).
+    constexpr double kTol = 1e-5;
+
+    // 60 steps → ~1.0 s
+    {
+        long long steps = 60;
+        double    gs    = steps * static_cast<double>(kFixedDt);
+        assert(std::abs(gs - 1.0) < kTol);
+    }
+    // 300 steps → ~5.0 s
+    {
+        long long steps = 300;
+        double    gs    = steps * static_cast<double>(kFixedDt);
+        assert(std::abs(gs - 5.0) < kTol);
+    }
+    // 0 steps → exactly 0.0 s
+    {
+        long long steps = 0;
+        double    gs    = steps * static_cast<double>(kFixedDt);
+        assert(gs == 0.0);
+    }
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+
+int main()
+{
+    test_loadreplay_valid();
+    test_loadreplay_comments_blanks();
+    test_loadreplay_malformed_count_few();
+    test_loadreplay_malformed_count_many();
+    test_loadreplay_malformed_value();
+    test_loadreplay_field_mapping();
+    test_applyinputto_mapping();
+    test_gameseconds_derivation();
+
+    std::cout << "All harness unit tests passed.\n";
+    return 0;
+}

--- a/tests/test_harness.cpp
+++ b/tests/test_harness.cpp
@@ -172,6 +172,15 @@ static void test_gameseconds_derivation()
     }
 }
 
+// ── loadReplay: nonexistent file → empty, no throw ────────────────────────────
+
+static void test_loadreplay_missing_file()
+{
+    // The most common --replay misuse (wrong path): must return empty, not throw.
+    auto result = loadReplay("/tmp/dg_test_does_not_exist_98765.replay");
+    assert(result.empty());
+}
+
 // ── main ──────────────────────────────────────────────────────────────────────
 
 int main()
@@ -182,6 +191,7 @@ int main()
     test_loadreplay_malformed_count_many();
     test_loadreplay_malformed_value();
     test_loadreplay_field_mapping();
+    test_loadreplay_missing_file();
     test_applyinputto_mapping();
     test_gameseconds_derivation();
 


### PR DESCRIPTION
Resolves #13.

A debug/playtest harness so an automated agent or CI can drive the game, feed scripted input, capture screenshots, and get **deterministic, reproducible** playthroughs — reusing the game's own channels (SFML has no event-injection API).

## What's here
- **Fixed-timestep loop (now the default).** `run()` drains a clamped real-time accumulator into `kFixedDt = 1/60` sim steps and renders once per iteration. This makes the game frame-rate independent and reproducible; it also retires the old `time > .1f` animation hack. A wall-clock `sf::Clock` is gone — game-time is an integer step counter (`m_steps`), so the round timer, cooldown, and hazard-invincibility windows are all deterministic.
- **Scriptable input** via the shared `PlayerInput` path: `--replay <file>` drives player 2 one input per sim step (the same channel the netcode uses; a `applyPlayerInput`/`applyInputTo` extraction unifies HOST-netcode and replay). Text format, one `up down left right attack` line per step; `#` comments (full-line + inline) and blanks ignored; malformed lines skipped with a warning; EOF → idle.
- **Screenshots**: F12 (manual) and `--screenshot-every N` capture the framebuffer (`sf::Texture` path) **between draw and swap** so the back buffer is complete.
- **Determinism**: `--frames N` runs exactly N sim steps then exits; `--seed <n>` seeds a shared RNG utility (unused by gameplay today — forward-looking for #12's AI). All debug flags **bypass the menus** and construct `Game` directly; live keyboard is gated off in debug mode so it can't perturb a run.
- **Tests**: 9 socket-free unit tests (replay parse incl. malformed/comment/EOF/missing-file, `applyInputTo` mapping, `gameSeconds`) + a committed `tests/data/demo.replay`.

## Validation
- Build clean (no new warnings); `ctest` 3/3.
- **Determinism proof**: two runs of `--replay demo.replay --frames 300 --screenshot-every 60 --seed 1` produce **byte-identical** screenshots (all 5 frames), each exiting after exactly 300 steps. A captured frame visually confirms real gameplay (arena, both fighters, fire, HUD) renders correctly.
- CLI errors (missing value / unknown flag / non-numeric) print a message and exit 1.

## Scope / notes
- **`Game.cpp`/`Game.h` were reformatted tabs→spaces** to the repo's declared `.clang-format` style (added in #10). Review the *logic* via `git diff -w master -- Game.cpp Game.h` (~242/159 and ~34/8 real changes). The uniform format pass over the rest of the codebase lands with #6.
- Deliberately **out of scope (→ #11)**: vsync/frame-cap, resizable/fullscreen window + view scaling, key remap, pause menu, and the deeper animation-frame-from-game-time refactor. #13 lands only the fixed-timestep foundation those build on.
