### PR TITLE
Code quality: RAII, bug fixes, naming, clang-format, clang-tidy, -Werror — #9 #6

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,12 @@
+Checks: >
+  bugprone-*, performance-*,
+  modernize-use-override, modernize-use-nullptr, modernize-use-emplace,
+  modernize-loop-convert, modernize-make-unique, modernize-use-equals-default,
+  cppcoreguidelines-virtual-class-destructor, cppcoreguidelines-special-member-functions,
+  cppcoreguidelines-init-variables, cppcoreguidelines-slicing,
+  misc-unused-parameters, misc-redundant-expression,
+  readability-redundant-*, readability-container-size-empty,
+  readability-inconsistent-declaration-parameter-name, readability-misleading-indentation,
+  -bugprone-easily-swappable-parameters, -bugprone-narrowing-conversions
+WarningsAsErrors: ''
+HeaderFilterRegex: '(include|src)/'

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,8 @@ indent_style = space
 indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
+charset = utf-8
+end_of_line = lf
 
 [*.{yml,yaml,cmake}]
 indent_style = space

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y \
-            clang llvm clang-format clang-tidy xvfb \
+            clang llvm clang-format-18 clang-tidy-18 xvfb \
             libx11-dev libxrandr-dev libxcursor-dev libxi-dev \
             libudev-dev libgl-dev libopenal-dev \
             libfreetype-dev libflac-dev libvorbis-dev libogg-dev
@@ -35,7 +35,6 @@ jobs:
             -DCMAKE_C_COMPILER=clang \
             -DCMAKE_CXX_COMPILER=clang++ \
             -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DDUNGEON_BUILD_TESTS=ON \
             -DDUNGEON_COVERAGE=ON
 
@@ -58,14 +57,15 @@ jobs:
             -instr-profile=build/cov/merged.profdata \
             -ignore-filename-regex='main\.cpp|tests/'
 
-      - name: Check formatting (clang-format)
+      - name: Check formatting (clang-format-18)
         run: |
           git ls-files 'src/*.cpp' 'include/*.h' 'tests/*.cpp' \
-            | xargs clang-format --dry-run --Werror
+            | xargs clang-format-18 --dry-run --Werror
 
-      - name: Lint (clang-tidy)
+      - name: Lint (clang-tidy, advisory)
+        continue-on-error: true   # .clang-tidy is advisory (WarningsAsErrors: ''); -Werror is the hard gate
         run: |
-          clang-tidy -p build $(git ls-files 'src/*.cpp')
+          clang-tidy-18 -p build $(git ls-files 'src/*.cpp')
 
   # ── macOS: unit tests only (SFML windows on GH macOS runners are flaky) ───
   build-macos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y \
-            clang llvm xvfb \
+            clang llvm clang-format clang-tidy xvfb \
             libx11-dev libxrandr-dev libxcursor-dev libxi-dev \
             libudev-dev libgl-dev libopenal-dev \
             libfreetype-dev libflac-dev libvorbis-dev libogg-dev
@@ -35,6 +35,7 @@ jobs:
             -DCMAKE_C_COMPILER=clang \
             -DCMAKE_CXX_COMPILER=clang++ \
             -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DDUNGEON_BUILD_TESTS=ON \
             -DDUNGEON_COVERAGE=ON
 
@@ -56,6 +57,15 @@ jobs:
             -object build/dungeon_game \
             -instr-profile=build/cov/merged.profdata \
             -ignore-filename-regex='main\.cpp|tests/'
+
+      - name: Check formatting (clang-format)
+        run: |
+          git ls-files 'src/*.cpp' 'include/*.h' 'tests/*.cpp' \
+            | xargs clang-format --dry-run --Werror
+
+      - name: Lint (clang-tidy)
+        run: |
+          clang-tidy -p build $(git ls-files 'src/*.cpp')
 
   # ── macOS: unit tests only (SFML windows on GH macOS runners are flaky) ───
   build-macos:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,8 @@ if(MSVC)
     target_compile_options(dungeon_lib    PRIVATE /W4)
     target_compile_options(dungeon_game   PRIVATE /W4)
 else()
-    target_compile_options(dungeon_lib    PRIVATE -Wall -Wextra -Wpedantic)
-    target_compile_options(dungeon_game   PRIVATE -Wall -Wextra -Wpedantic)
+    target_compile_options(dungeon_lib    PRIVATE -Wall -Wextra -Wpedantic -Werror)
+    target_compile_options(dungeon_game   PRIVATE -Wall -Wextra -Wpedantic -Werror)
 endif()
 
 # ── Copy assets next to the binary at build time ────────────────────────────

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(dungeon_game CXX)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/include/AnimatedGameObject.h
+++ b/include/AnimatedGameObject.h
@@ -12,33 +12,33 @@ public:
 
     AnimatedGameObject(double x,double y,int nx,int ny,int howmany,int angle);
 
-    bool load(const std::string& filename);
+    bool load(const std::string& filename) override;
 
-    void draw(sf::RenderWindow& window);
+    void draw(sf::RenderWindow& window) override;
 
-    void update(float deltaT);
+    void update(float deltaT) override;
 
-    void setPosition(float x, float y);
+    void setPosition(float x, float y) override;
 
-    void move(sf::Vector2f);
+    void move(sf::Vector2f) override;
 
-    sf::Vector2f getPosition() const;
+    sf::Vector2f getPosition() const override;
 
-    float getHeight() const;
+    float getHeight() const override;
 
-    float getWidth() const;
+    float getWidth() const override;
 
-    void setScale(float scale);
+    void setScale(float scale) override;
 
-    void setScale(float x, float y);
+    void setScale(float x, float y) override;
 
-    sf::Vector2f getScale() const;
+    sf::Vector2f getScale() const override;
 
-    void changeValid(bool a);
+    void changeValid(bool a) override;
 
-    bool isValid();
+    bool isValid() override;
 
-    void setOrigin();
+    void setOrigin() override;
 
 private:
     sf::Sprite m_sprite;

--- a/include/AnimatedGameObject.h
+++ b/include/AnimatedGameObject.h
@@ -7,10 +7,9 @@
 
 class AnimatedGameObject : public GameObject {
 public:
-
     AnimatedGameObject();
 
-    AnimatedGameObject(double x,double y,int nx,int ny,int howmany,int angle);
+    AnimatedGameObject(double x, double y, int nx, int ny, int howmany, int angle);
 
     bool load(const std::string& filename) override;
 
@@ -53,4 +52,3 @@ private:
     int curr;
     sf::IntRect rect;
 };
-

--- a/include/Game.h
+++ b/include/Game.h
@@ -76,42 +76,42 @@ private:
 
     sf::Music background;
 
-    std::unique_ptr<GameObject> m_player = std::make_unique<AnimatedGameObject>(404, 206, 3, 3, 9, 0);
-    std::unique_ptr<GameObject> player2  = std::make_unique<AnimatedGameObject>(959, 180, 8, 1, 8, 0);
-    std::vector<std::unique_ptr<GameObject>> stuff;
+    std::unique_ptr<GameObject> m_rocket = std::make_unique<AnimatedGameObject>(404, 206, 3, 3, 9, 0);
+    std::unique_ptr<GameObject> m_robot  = std::make_unique<AnimatedGameObject>(959, 180, 8, 1, 8, 0);
+    std::vector<std::unique_ptr<GameObject>> m_arena;
 
     sf::Font font;
     sf::Font tfont;
     sf::Font block;
-    sf::Text text;
-    sf::Text text2;
+    sf::Text m_rocketScoreText;
+    sf::Text m_robotScoreText;
     sf::Text timer;
     sf::Text pause_text;
     sf::Text info;
 
     float m_speed          = 1200.0f;
-    float temp_time        = 0;
-    float p1_timeout       = 0;
-    float p2_timeout       = 0;
-    bool  m_left           = false;
-    bool  m_right          = false;
-    bool  m_up             = false;
-    bool  m_down           = false;
-    bool  w                = false;
-    bool  a                = false;
-    bool  s                = false;
-    bool  d                = false;
-    bool  space            = false;
-    int   points           = 0;
-    int   p2points         = 0;
-    bool  right            = false;
-    bool  p1left           = false;
-    bool  p2left           = true;
-    bool  p                = false;
-    bool  o                = false;
-    bool  wait             = false;
-    bool  p1_time_passed   = true;
-    bool  p2_time_passed   = true;
+    float m_cooldownEnd    = 0;
+    float m_p1HazardCooldownEnd       = 0;
+    float m_p2HazardCooldownEnd       = 0;
+    bool  m_p1Left           = false;
+    bool  m_p1Right          = false;
+    bool  m_p1Up             = false;
+    bool  m_p1Down           = false;
+    bool  m_p2Up           = false;
+    bool  m_p2Left         = false;
+    bool  m_p2Down         = false;
+    bool  m_p2Right        = false;
+    bool  m_p2Attack       = false;
+    int   m_robotScore     = 0;
+    int   m_rocketScore         = 0;
+    bool  m_p1Attack       = false;
+    bool  m_p1FacingLeft           = false;
+    bool  m_p2FacingLeft           = true;
+    bool  m_speedUpPressed   = false;
+    bool  m_slowDownPressed  = false;
+    bool  m_inCooldown     = false;
+    bool  m_p1HazardReady   = true;
+    bool  m_p2HazardReady   = true;
 
     // Fixed-timestep state
     static constexpr float kFixedDt = 1.f / 60.f;

--- a/include/Game.h
+++ b/include/Game.h
@@ -104,7 +104,7 @@ private:
     bool  space            = false;
     int   points           = 0;
     int   p2points         = 0;
-    int   right            = false;
+    bool  right            = false;
     bool  p1left           = false;
     bool  p2left           = true;
     bool  p                = false;

--- a/include/Game.h
+++ b/include/Game.h
@@ -3,17 +3,17 @@
 //
 #pragma once
 
-#include <SFML/Graphics.hpp>
-#include <SFML/Audio.hpp>
-#include <memory>
-#include <tuple>
-#include <vector>
 #include "AnimatedGameObject.h"
-#include "debug.h"
 #include "GameObject.h"
 #include "NetworkManager.h"
 #include "RegularGameObject.h"
+#include "debug.h"
 #include "replay.h"
+#include <SFML/Audio.hpp>
+#include <SFML/Graphics.hpp>
+#include <memory>
+#include <tuple>
+#include <vector>
 
 class Game {
 public:
@@ -31,7 +31,7 @@ public:
     GameState snapshot() const;
 
     // Apply a received network state (public so integration tests can verify round-trip).
-    void      applyNetworkState(const GameState& state);
+    void applyNetworkState(const GameState& state);
 
     // run the game
     std::tuple<int, int, float, int, bool, bool> run();
@@ -65,19 +65,21 @@ private:
     sf::SoundBuffer speedbuffer;
     sf::SoundBuffer slowbuffer;
     sf::SoundBuffer burnbuffer;
-    sf::Sound       gong;
-    sf::Sound       sword;
-    sf::Sound       p2hit;
-    sf::Sound       laser;
-    sf::Sound       metal;
-    sf::Sound       speed_up;
-    sf::Sound       slow_down;
-    sf::Sound       burn;
+    sf::Sound gong;
+    sf::Sound sword;
+    sf::Sound p2hit;
+    sf::Sound laser;
+    sf::Sound metal;
+    sf::Sound speed_up;
+    sf::Sound slow_down;
+    sf::Sound burn;
 
     sf::Music background;
 
-    std::unique_ptr<GameObject> m_rocket = std::make_unique<AnimatedGameObject>(404, 206, 3, 3, 9, 0);
-    std::unique_ptr<GameObject> m_robot  = std::make_unique<AnimatedGameObject>(959, 180, 8, 1, 8, 0);
+    std::unique_ptr<GameObject> m_rocket =
+        std::make_unique<AnimatedGameObject>(404, 206, 3, 3, 9, 0);
+    std::unique_ptr<GameObject> m_robot =
+        std::make_unique<AnimatedGameObject>(959, 180, 8, 1, 8, 0);
     std::vector<std::unique_ptr<GameObject>> m_arena;
 
     sf::Font font;
@@ -89,54 +91,54 @@ private:
     sf::Text pause_text;
     sf::Text info;
 
-    float m_speed          = 1200.0f;
-    float m_cooldownEnd    = 0;
-    float m_p1HazardCooldownEnd       = 0;
-    float m_p2HazardCooldownEnd       = 0;
-    bool  m_p1Left           = false;
-    bool  m_p1Right          = false;
-    bool  m_p1Up             = false;
-    bool  m_p1Down           = false;
-    bool  m_p2Up           = false;
-    bool  m_p2Left         = false;
-    bool  m_p2Down         = false;
-    bool  m_p2Right        = false;
-    bool  m_p2Attack       = false;
-    int   m_robotScore     = 0;
-    int   m_rocketScore         = 0;
-    bool  m_p1Attack       = false;
-    bool  m_p1FacingLeft           = false;
-    bool  m_p2FacingLeft           = true;
-    bool  m_speedUpPressed   = false;
-    bool  m_slowDownPressed  = false;
-    bool  m_inCooldown     = false;
-    bool  m_p1HazardReady   = true;
-    bool  m_p2HazardReady   = true;
+    float m_speed = 1200.0f;
+    float m_cooldownEnd = 0;
+    float m_p1HazardCooldownEnd = 0;
+    float m_p2HazardCooldownEnd = 0;
+    bool m_p1Left = false;
+    bool m_p1Right = false;
+    bool m_p1Up = false;
+    bool m_p1Down = false;
+    bool m_p2Up = false;
+    bool m_p2Left = false;
+    bool m_p2Down = false;
+    bool m_p2Right = false;
+    bool m_p2Attack = false;
+    int m_robotScore = 0;
+    int m_rocketScore = 0;
+    bool m_p1Attack = false;
+    bool m_p1FacingLeft = false;
+    bool m_p2FacingLeft = true;
+    bool m_speedUpPressed = false;
+    bool m_slowDownPressed = false;
+    bool m_inCooldown = false;
+    bool m_p1HazardReady = true;
+    bool m_p2HazardReady = true;
 
     // Fixed-timestep state
     static constexpr float kFixedDt = 1.f / 60.f;
-    long long              m_steps      = 0;
-    float                  m_accumulator = 0.f;
-    float                  m_animTime   = 0.f;
+    long long m_steps = 0;
+    float m_accumulator = 0.f;
+    float m_animTime = 0.f;
 
     double gameSeconds() const { return m_steps * static_cast<double>(kFixedDt); }
 
     // Debug / harness configuration
-    DebugConfig              m_debug;
+    DebugConfig m_debug;
     std::vector<PlayerInput> m_replay;
-    std::size_t              m_replayIdx = 0;
+    std::size_t m_replayIdx = 0;
     std::vector<PlayerInput> m_replayP1;
-    std::size_t              m_replayP1Idx = 0;
-    long long                m_nextShot  = 0; // next step at which to auto-screenshot
+    std::size_t m_replayP1Idx = 0;
+    long long m_nextShot = 0; // next step at which to auto-screenshot
 
     // Network support
-    NetworkMode                      m_networkMode = NetworkMode::LOCAL;
-    std::shared_ptr<NetworkManager>  m_networkManager;
-    void      handleNetworkCommunication(sf::Time deltaT);
+    NetworkMode m_networkMode = NetworkMode::LOCAL;
+    std::shared_ptr<NetworkManager> m_networkManager;
+    void handleNetworkCommunication(sf::Time deltaT);
     GameState captureGameState() const;
 
-    bool      m_peerLeft   = false;
+    bool m_peerLeft = false;
     GameState m_latestState;
-    float     m_stateAccum = 0.f;
+    float m_stateAccum = 0.f;
     static constexpr float kStateSendInterval = 1.f / 25.f; // ~25 Hz
 };

--- a/include/Game.h
+++ b/include/Game.h
@@ -107,8 +107,6 @@ private:
     int   right            = false;
     bool  p1left           = false;
     bool  p2left           = true;
-    bool  p1move           = true;
-    bool  p2move           = true;
     bool  p                = false;
     bool  o                = false;
     bool  wait             = false;

--- a/include/Game.h
+++ b/include/Game.h
@@ -45,8 +45,8 @@ private:
     // handle input from the user
     void handlePlayerInput(sf::Keyboard::Key key, bool isDown);
     // check collision with walls or other objects
-    bool collision(GameObject* a, GameObject* b);
-    bool collision(sf::Rect<float> a, GameObject* b);
+    bool collision(const GameObject& a, const GameObject& b);
+    bool collision(sf::Rect<float> a, const GameObject& b);
 
     // Fixed-timestep deterministic sim body.
     void simStep();
@@ -76,9 +76,9 @@ private:
 
     sf::Music background;
 
-    GameObject* m_player = new AnimatedGameObject(404, 206, 3, 3, 9, 0);
-    GameObject* player2  = new AnimatedGameObject(959, 180, 8, 1, 8, 0);
-    std::vector<GameObject*> stuff;
+    std::unique_ptr<GameObject> m_player = std::make_unique<AnimatedGameObject>(404, 206, 3, 3, 9, 0);
+    std::unique_ptr<GameObject> player2  = std::make_unique<AnimatedGameObject>(959, 180, 8, 1, 8, 0);
+    std::vector<std::unique_ptr<GameObject>> stuff;
 
     sf::Font font;
     sf::Font tfont;

--- a/include/GameObject.h
+++ b/include/GameObject.h
@@ -8,8 +8,14 @@
 
 class GameObject {
 public:
+    GameObject()                             = default;
+    virtual ~GameObject()                    = default;
+    GameObject(const GameObject&)            = delete;
+    GameObject& operator=(const GameObject&) = delete;
+    GameObject(GameObject&&)                 = delete;
+    GameObject& operator=(GameObject&&)      = delete;
 
-	virtual bool load(const std::string& filename) = 0;
+    virtual bool load(const std::string& filename) = 0;
 
 	virtual void draw(sf::RenderWindow& window) = 0;
 

--- a/include/GameObject.h
+++ b/include/GameObject.h
@@ -3,45 +3,43 @@
 //
 #pragma once
 
-#include <SFML/Graphics.hpp>
 #include <SFML/Audio.hpp>
+#include <SFML/Graphics.hpp>
 
 class GameObject {
 public:
-    GameObject()                             = default;
-    virtual ~GameObject()                    = default;
-    GameObject(const GameObject&)            = delete;
+    GameObject() = default;
+    virtual ~GameObject() = default;
+    GameObject(const GameObject&) = delete;
     GameObject& operator=(const GameObject&) = delete;
-    GameObject(GameObject&&)                 = delete;
-    GameObject& operator=(GameObject&&)      = delete;
+    GameObject(GameObject&&) = delete;
+    GameObject& operator=(GameObject&&) = delete;
 
     virtual bool load(const std::string& filename) = 0;
 
-	virtual void draw(sf::RenderWindow& window) = 0;
+    virtual void draw(sf::RenderWindow& window) = 0;
 
-	virtual void update(float deltaT) = 0;
+    virtual void update(float deltaT) = 0;
 
-	virtual void setPosition(float x, float y) = 0;
+    virtual void setPosition(float x, float y) = 0;
 
-	virtual void move(sf::Vector2f) = 0;
+    virtual void move(sf::Vector2f) = 0;
 
-	virtual sf::Vector2f getPosition() const = 0;
+    virtual sf::Vector2f getPosition() const = 0;
 
-	virtual float getHeight() const = 0;
+    virtual float getHeight() const = 0;
 
-	virtual float getWidth() const = 0;
+    virtual float getWidth() const = 0;
 
-	virtual void setScale(float scale) = 0;
+    virtual void setScale(float scale) = 0;
 
-	virtual void setScale(float x,float y) = 0;
+    virtual void setScale(float x, float y) = 0;
 
-	virtual sf::Vector2f getScale() const = 0;
+    virtual sf::Vector2f getScale() const = 0;
 
-	virtual void changeValid(bool valid) = 0;
+    virtual void changeValid(bool valid) = 0;
 
-	virtual bool isValid() = 0;
+    virtual bool isValid() = 0;
 
     virtual void setOrigin() = 0;
-
 };
-

--- a/include/GameObject.h
+++ b/include/GameObject.h
@@ -4,11 +4,7 @@
 #pragma once
 
 #include <SFML/Graphics.hpp>
-#include <SFML/Audio/Music.hpp>
 #include <SFML/Audio.hpp>
-#include <SFML/Audio/Music.hpp>
-#include <SFML/Audio/SoundSource.hpp>
-#include <SFML/Audio/Sound.hpp>
 
 class GameObject {
 public:

--- a/include/NetworkManager.h
+++ b/include/NetworkManager.h
@@ -15,50 +15,40 @@ struct PlayerInput {
     bool right = false;
     bool attack = false;
 
-    void toPacket(sf::Packet& packet) const {
-        packet << up << down << left << right << attack;
-    }
-    void fromPacket(sf::Packet& packet) {
-        packet >> up >> down >> left >> right >> attack;
-    }
+    void toPacket(sf::Packet& packet) const { packet << up << down << left << right << attack; }
+    void fromPacket(sf::Packet& packet) { packet >> up >> down >> left >> right >> attack; }
 };
 
 struct GameState {
     float p1_x = 0, p1_y = 0;
     float p2_x = 0, p2_y = 0;
-    int   p1_score = 0, p2_score = 0;
-    bool  p1_left = false, p2_left = false;
+    int p1_score = 0, p2_score = 0;
+    bool p1_left = false, p2_left = false;
     float p1_scale_x = 1, p1_scale_y = 1;
     float p2_scale_x = 1, p2_scale_y = 1;
-    bool  wait = false;
+    bool wait = false;
 
     void toPacket(sf::Packet& packet) const {
-        packet << p1_x << p1_y << p2_x << p2_y
-               << p1_score << p2_score << p1_left << p2_left
-               << p1_scale_x << p1_scale_y << p2_scale_x << p2_scale_y
-               << wait;
+        packet << p1_x << p1_y << p2_x << p2_y << p1_score << p2_score << p1_left << p2_left
+               << p1_scale_x << p1_scale_y << p2_scale_x << p2_scale_y << wait;
     }
     void fromPacket(sf::Packet& packet) {
-        packet >> p1_x >> p1_y >> p2_x >> p2_y
-               >> p1_score >> p2_score >> p1_left >> p2_left
-               >> p1_scale_x >> p1_scale_y >> p2_scale_x >> p2_scale_y
-               >> wait;
+        packet >> p1_x >> p1_y >> p2_x >> p2_y >> p1_score >> p2_score >> p1_left >> p2_left >>
+            p1_scale_x >> p1_scale_y >> p2_scale_x >> p2_scale_y >> wait;
     }
 };
 
 // A GameState snapshot paired with its receive timestamp.
 struct TimedState {
     GameState state;
-    sf::Time  arrival;
+    sf::Time arrival;
 };
 
 // Socket-free demux: reads the leading MsgType byte and routes into the
 // appropriate buffer.  Unknown types are logged once and discarded.
 // cap limits stateBuf size (oldest entry evicted when full).
-void dispatchPacket(sf::Packet& pkt, sf::Time arrival,
-                    std::deque<TimedState>&  stateBuf,
-                    std::deque<PlayerInput>& inputQueue,
-                    std::size_t cap);
+void dispatchPacket(sf::Packet& pkt, sf::Time arrival, std::deque<TimedState>& stateBuf,
+                    std::deque<PlayerInput>& inputQueue, std::size_t cap);
 
 // Pure linear interpolation between two 2-D positions; t is clamped to [0,1].
 sf::Vector2f lerpPos(sf::Vector2f from, sf::Vector2f to, float t);
@@ -96,26 +86,26 @@ public:
 
     // Status
     bool isConnected() const { return m_connected; }
-    bool peerLost()    const { return m_peerLeft; }
+    bool peerLost() const { return m_peerLeft; }
     void disconnect();
 
 private:
     void setDisconnected();
-    bool flushSend();   // returns true when the pending slot is clear
+    bool flushSend(); // returns true when the pending slot is clear
 
     sf::TcpListener m_listener;
-    sf::TcpSocket   m_socket;
-    sf::Clock       m_clock;
+    sf::TcpSocket m_socket;
+    sf::Clock m_clock;
 
-    bool m_isHost    = false;
+    bool m_isHost = false;
     bool m_connected = false;
-    bool m_peerLeft  = false;
+    bool m_peerLeft = false;
 
     // One-slot pending send (no queue).
     sf::Packet m_pendingSend;
-    bool       m_hasPending = false;
+    bool m_hasPending = false;
 
-    std::deque<TimedState>  m_stateBuf;
+    std::deque<TimedState> m_stateBuf;
     std::deque<PlayerInput> m_inputQueue;
 
     static constexpr std::size_t kStateBufCap = 8;

--- a/include/RegularGameObject.h
+++ b/include/RegularGameObject.h
@@ -9,33 +9,33 @@ class RegularGameObject : public GameObject {
 public:
     RegularGameObject();
 
-    bool load(const std::string& filename);
+    bool load(const std::string& filename) override;
 
-    void draw(sf::RenderWindow& window);
+    void draw(sf::RenderWindow& window) override;
 
-    void update(float deltaT);
+    void update(float deltaT) override;
 
-    void setPosition(float x, float y);
+    void setPosition(float x, float y) override;
 
-    void move(sf::Vector2f);
+    void move(sf::Vector2f) override;
 
-    sf::Vector2f getPosition() const;
+    sf::Vector2f getPosition() const override;
 
-    float getHeight() const;
+    float getHeight() const override;
 
-    float getWidth() const;
+    float getWidth() const override;
 
-    void setScale(float scale);
+    void setScale(float scale) override;
 
-    void setScale(float x,float y);
+    void setScale(float x,float y) override;
 
-    sf::Vector2f getScale() const;
+    sf::Vector2f getScale() const override;
 
-    void changeValid(bool a);
+    void changeValid(bool a) override;
 
-    bool isValid();
+    bool isValid() override;
 
-    void setOrigin();
+    void setOrigin() override;
 
 private:
     sf::Sprite m_sprite;

--- a/include/RegularGameObject.h
+++ b/include/RegularGameObject.h
@@ -27,7 +27,7 @@ public:
 
     void setScale(float scale) override;
 
-    void setScale(float x,float y) override;
+    void setScale(float x, float y) override;
 
     sf::Vector2f getScale() const override;
 
@@ -42,6 +42,4 @@ private:
     sf::Texture m_texture;
     std::string m_filename;
     bool m_valid = false;
-
 };
-

--- a/include/asset_load.h
+++ b/include/asset_load.h
@@ -1,0 +1,33 @@
+#pragma once
+#include <SFML/Audio.hpp>
+#include <SFML/Graphics.hpp>
+#include <stdexcept>
+#include <string>
+#include "GameObject.h"
+
+// Load helpers that throw std::runtime_error on failure instead of silently continuing.
+// sf::Music streams from disk so uses openFromFile; others use loadFromFile / .load().
+
+inline void loadOrThrow(sf::Font& f, const std::string& path)
+{
+    if (!f.loadFromFile(path))
+        throw std::runtime_error("failed to load asset: " + path);
+}
+
+inline void loadOrThrow(sf::SoundBuffer& b, const std::string& path)
+{
+    if (!b.loadFromFile(path))
+        throw std::runtime_error("failed to load asset: " + path);
+}
+
+inline void loadOrThrow(sf::Music& m, const std::string& path)
+{
+    if (!m.openFromFile(path))
+        throw std::runtime_error("failed to load asset: " + path);
+}
+
+inline void loadOrThrow(GameObject& obj, const std::string& path)
+{
+    if (!obj.load(path))
+        throw std::runtime_error("failed to load asset: " + path);
+}

--- a/include/asset_load.h
+++ b/include/asset_load.h
@@ -1,33 +1,29 @@
 #pragma once
+#include "GameObject.h"
 #include <SFML/Audio.hpp>
 #include <SFML/Graphics.hpp>
 #include <stdexcept>
 #include <string>
-#include "GameObject.h"
 
 // Load helpers that throw std::runtime_error on failure instead of silently continuing.
 // sf::Music streams from disk so uses openFromFile; others use loadFromFile / .load().
 
-inline void loadOrThrow(sf::Font& f, const std::string& path)
-{
+inline void loadOrThrow(sf::Font& f, const std::string& path) {
     if (!f.loadFromFile(path))
         throw std::runtime_error("failed to load asset: " + path);
 }
 
-inline void loadOrThrow(sf::SoundBuffer& b, const std::string& path)
-{
+inline void loadOrThrow(sf::SoundBuffer& b, const std::string& path) {
     if (!b.loadFromFile(path))
         throw std::runtime_error("failed to load asset: " + path);
 }
 
-inline void loadOrThrow(sf::Music& m, const std::string& path)
-{
+inline void loadOrThrow(sf::Music& m, const std::string& path) {
     if (!m.openFromFile(path))
         throw std::runtime_error("failed to load asset: " + path);
 }
 
-inline void loadOrThrow(GameObject& obj, const std::string& path)
-{
+inline void loadOrThrow(GameObject& obj, const std::string& path) {
     if (!obj.load(path))
         throw std::runtime_error("failed to load asset: " + path);
 }

--- a/include/debug.h
+++ b/include/debug.h
@@ -2,11 +2,11 @@
 #include <string>
 
 struct DebugConfig {
-    int         frames          = 0;
+    int frames = 0;
     std::string replayPath;
     std::string replayPathP1;
-    int         screenshotEvery = 0;
-    std::string screenshotDir   = ".";
+    int screenshotEvery = 0;
+    std::string screenshotDir = ".";
 
     bool active() const {
         return frames > 0 || !replayPath.empty() || !replayPathP1.empty() || screenshotEvery > 0;

--- a/include/replay.h
+++ b/include/replay.h
@@ -1,7 +1,7 @@
 #pragma once
+#include "NetworkManager.h"
 #include <string>
 #include <vector>
-#include "NetworkManager.h"
 
 // Parse a replay file.  Text format: one line per sim step, five 0/1 fields
 // (up down left right attack), whitespace-separated.  Everything from '#' to

--- a/include/replay.h
+++ b/include/replay.h
@@ -15,5 +15,4 @@ std::vector<PlayerInput> loadReplay(const std::string& path);
 void applyInputTo(bool& w, bool& a, bool& s, bool& d, bool& space, const PlayerInput& in);
 
 // Map a PlayerInput onto the five P1 variables.
-// The last parameter is int& (not bool&) because Game::right is declared int.
-void applyInputToP1(bool& w, bool& a, bool& s, bool& d, int& attack, const PlayerInput& in);
+void applyInputToP1(bool& w, bool& a, bool& s, bool& d, bool& attack, const PlayerInput& in);

--- a/include/rng.h
+++ b/include/rng.h
@@ -2,6 +2,6 @@
 #include <random>
 
 namespace rng {
-void         seed(unsigned s);
+void seed(unsigned s);
 std::mt19937& engine();
 } // namespace rng

--- a/src/AnimatedGameObject.cpp
+++ b/src/AnimatedGameObject.cpp
@@ -14,7 +14,7 @@ AnimatedGameObject::AnimatedGameObject() {
     curr = 1;
 }
 
-AnimatedGameObject::AnimatedGameObject(double x,double y,int nx,int ny,int n,int angle) {
+AnimatedGameObject::AnimatedGameObject(double x, double y, int nx, int ny, int n, int angle) {
     m_sprite.setRotation(angle);
     xsize = x;
     ysize = y;
@@ -28,7 +28,7 @@ bool AnimatedGameObject::load(const std::string& filename) {
     if (m_texture.loadFromFile(filename)) {
         m_filename = filename;
         m_sprite.setTexture(m_texture);
-        rect = sf::IntRect(0,0,floor(xsize/(double)howmanyx),floor(ysize/(double)howmanyy));
+        rect = sf::IntRect(0, 0, floor(xsize / (double)howmanyx), floor(ysize / (double)howmanyy));
         m_sprite.setTextureRect(rect);
         m_valid = true;
         return true;
@@ -42,13 +42,12 @@ void AnimatedGameObject::update(float Tsec) {
     if (Tsec > .1f || Tsec == 0) {
         work = true;
     }
-    if (work){
+    if (work) {
         auto res = advanceFrameRect(rect, curr, howmanyx, howmanyy, howmany, xsize, ysize);
         rect = res.rect;
         curr = res.curr;
         m_sprite.setTextureRect(rect);
     }
-
 }
 
 void AnimatedGameObject::draw(sf::RenderWindow& window) {
@@ -74,22 +73,18 @@ sf::Vector2f AnimatedGameObject::getPosition() const {
         return sf::Vector2f(0, 0);
 }
 
-float AnimatedGameObject::getHeight() const {
-    return m_sprite.getLocalBounds().height;
-}
+float AnimatedGameObject::getHeight() const { return m_sprite.getLocalBounds().height; }
 
-float AnimatedGameObject::getWidth() const {
-    return m_sprite.getLocalBounds().width;
-}
+float AnimatedGameObject::getWidth() const { return m_sprite.getLocalBounds().width; }
 
 void AnimatedGameObject::setScale(float scale) {
     if (m_valid)
         m_sprite.setScale(scale, scale);
 }
 
-void AnimatedGameObject::setScale(float x,float y) {
+void AnimatedGameObject::setScale(float x, float y) {
     if (m_valid)
-        m_sprite.setScale(x,y);
+        m_sprite.setScale(x, y);
 }
 
 sf::Vector2f AnimatedGameObject::getScale() const {
@@ -99,19 +94,15 @@ sf::Vector2f AnimatedGameObject::getScale() const {
         return sf::Vector2f(0, 0);
 }
 
-void AnimatedGameObject::changeValid(bool a) {
-    m_valid = a;
-}
+void AnimatedGameObject::changeValid(bool a) { m_valid = a; }
 
-bool AnimatedGameObject::isValid() {
-    return m_valid;
-}
+bool AnimatedGameObject::isValid() { return m_valid; }
 
 void AnimatedGameObject::setOrigin() {
     if (m_sprite.getOrigin().x == 0) {
-        m_sprite.setOrigin((m_sprite.getLocalBounds().width) / 2, (m_sprite.getLocalBounds().height) / 2);
-    }
-    else {
+        m_sprite.setOrigin((m_sprite.getLocalBounds().width) / 2,
+                           (m_sprite.getLocalBounds().height) / 2);
+    } else {
         m_sprite.setOrigin(0, 0);
     }
 }

--- a/src/AnimatedGameObject.cpp
+++ b/src/AnimatedGameObject.cpp
@@ -28,7 +28,6 @@ bool AnimatedGameObject::load(const std::string& filename) {
     if (m_texture.loadFromFile(filename)) {
         m_filename = filename;
         m_sprite.setTexture(m_texture);
-        //std::cout << floor(xsize/(double)howmanyx) << "   " << floor(ysize/(double)howmanyy) << std::endl;
         rect = sf::IntRect(0,0,floor(xsize/(double)howmanyx),floor(ysize/(double)howmanyy));
         m_sprite.setTextureRect(rect);
         m_valid = true;
@@ -55,7 +54,6 @@ void AnimatedGameObject::update(float Tsec) {
 void AnimatedGameObject::draw(sf::RenderWindow& window) {
     if (m_valid) {
         window.draw(m_sprite);
-        //std::cout << "i am drawn  " << m_filename << std::endl;
     }
 }
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -400,9 +400,7 @@ void Game::update(sf::Time deltaT, float time)
 
         if (collision(m_player, player2)) {
             m_player->setPosition(m_player->getPosition().x, m_player->getPosition().y + 40);
-            p2move = false;
         } else {
-            p2move = true;
             p1movement.y -= m_speed;
         }
     }
@@ -414,9 +412,7 @@ void Game::update(sf::Time deltaT, float time)
 
         if (collision(m_player, player2)) {
             m_player->setPosition(m_player->getPosition().x, m_player->getPosition().y - 40);
-            p2move = false;
         } else {
-            p2move = true;
             p1movement.y += m_speed;
         }
     }
@@ -435,9 +431,7 @@ void Game::update(sf::Time deltaT, float time)
 
         if (collision(m_player, player2)) {
             m_player->setPosition(m_player->getPosition().x + 40, m_player->getPosition().y);
-            p2move = false;
         } else {
-            p2move = true;
             p1movement.x -= m_speed;
         }
     }
@@ -458,9 +452,7 @@ void Game::update(sf::Time deltaT, float time)
 
         if (collision(m_player, player2)) {
             m_player->setPosition(m_player->getPosition().x - 40, m_player->getPosition().y);
-            p2move = false;
         } else {
-            p2move = true;
             p1movement.x += m_speed;
         }
     }
@@ -518,7 +510,6 @@ void Game::update(sf::Time deltaT, float time)
                     (player2->getWidth() * player2->getScale().x),
                 player2->getPosition().y);
         }
-        p2left = false;
 
         if (collision(m_player, player2)) {
             player2->setPosition(player2->getPosition().x - 40, player2->getPosition().y);

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "Game.h"
+#include "asset_load.h"
 #include "geometry.h"
 #include "resource_path.h"
 #include <algorithm>
@@ -34,53 +35,45 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
       m_networkMode(mode),
       m_networkManager(netManager)
 {
-    if (!background.openFromFile(resource_path + "background.wav")) {
-        std::cout << "your music is broken, go fix it" << std::endl;
-    }
+    loadOrThrow(background, resource_path + "background.wav");
 
-    m_player->load(resource_path + "rocket.png");
+    loadOrThrow(*m_player, resource_path + "rocket.png");
     m_player->setScale(2.0f);
     m_player->setPosition(m_player->getWidth(), 400);
 
-    player2->load(resource_path + "robot.png");
+    loadOrThrow(*player2, resource_path + "robot.png");
     player2->setScale(-1.0f, 1.0f);
     player2->setPosition(m_window.getSize().x - (m_player->getWidth() + 150), 400);
 
     stuff.push_back(std::make_unique<RegularGameObject>());
-    stuff[0]->load(resource_path + "brick.png");
+    loadOrThrow(*stuff[0], resource_path + "brick.png");
     stuff[0]->setScale(2.0f);
 
     {
         auto fire = std::make_unique<AnimatedGameObject>(216, 216, 5, 3, 10, 0);
-        fire->load(resource_path + "fire.png");
+        loadOrThrow(*fire, resource_path + "fire.png");
         fire->setScale(2.0f);
         fire->setPosition(-15, 400);
         stuff.push_back(std::move(fire));
     }
     {
         auto fire2 = std::make_unique<AnimatedGameObject>(216, 216, 5, 3, 10, 0);
-        fire2->load(resource_path + "fire.png");
+        loadOrThrow(*fire2, resource_path + "fire.png");
         fire2->setScale(2.0f);
         fire2->setPosition((1920 / 2) - 5, 400);
         stuff.push_back(std::move(fire2));
     }
     {
         auto fire3 = std::make_unique<AnimatedGameObject>(216, 216, 5, 3, 10, 0);
-        fire3->load(resource_path + "fire.png");
+        loadOrThrow(*fire3, resource_path + "fire.png");
         fire3->setScale(2.0f);
         fire3->setPosition(1820, 400);
         stuff.push_back(std::move(fire3));
     }
 
-    if (!font.loadFromFile(resource_path + "oswald.ttf")) {
-        std::cout << "Font did not load" << std::endl;
-    }
-    if (!tfont.loadFromFile(resource_path + "timer.ttf")) {
-        std::cout << "Font did not load" << std::endl;
-    }
-    if (!block.loadFromFile(resource_path + "Blockt.ttf")) {
-        std::cout << "Font did not load" << std::endl;
-    }
+    loadOrThrow(font,  resource_path + "oswald.ttf");
+    loadOrThrow(tfont, resource_path + "timer.ttf");
+    loadOrThrow(block, resource_path + "Blockt.ttf");
 
     pause_text = sf::Text("Cooldown", block, 400);
     pause_text.setPosition(m_window.getSize().x / 2 - 850, 100);
@@ -100,37 +93,21 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
     timer.setFillColor(sf::Color::Black);
     text.setFillColor(sf::Color::Blue);
 
-    if (!sbuffer.loadFromFile(resource_path + "sword_miss.wav")) {
-        std::cout << "sound did not load";
-    }
+    loadOrThrow(sbuffer,     resource_path + "sword_miss.wav");
     sword.setBuffer(sbuffer);
-    if (!p2hitbuffer.loadFromFile(resource_path + "skeleton.wav")) {
-        std::cout << "sound did not load";
-    }
+    loadOrThrow(p2hitbuffer, resource_path + "skeleton.wav");
     p2hit.setBuffer(p2hitbuffer);
-    if (!laserbuffer.loadFromFile(resource_path + "new_laser.wav")) {
-        std::cout << "sound did not load";
-    }
+    loadOrThrow(laserbuffer, resource_path + "new_laser.wav");
     laser.setBuffer(laserbuffer);
-    if (!metalbuffer.loadFromFile(resource_path + "metal_hit.wav")) {
-        std::cout << "sound did not load";
-    }
+    loadOrThrow(metalbuffer, resource_path + "metal_hit.wav");
     metal.setBuffer(metalbuffer);
-    if (!speedbuffer.loadFromFile(resource_path + "SpeedUp.wav")) {
-        std::cout << "sound did not load";
-    }
+    loadOrThrow(speedbuffer, resource_path + "SpeedUp.wav");
     speed_up.setBuffer(speedbuffer);
-    if (!slowbuffer.loadFromFile(resource_path + "SlowDown.wav")) {
-        std::cout << "sound did not load";
-    }
+    loadOrThrow(slowbuffer,  resource_path + "SlowDown.wav");
     slow_down.setBuffer(slowbuffer);
-    if (!burnbuffer.loadFromFile(resource_path + "burn.wav")) {
-        std::cout << "sound did not load";
-    }
+    loadOrThrow(burnbuffer,  resource_path + "burn.wav");
     burn.setBuffer(burnbuffer);
-    if (!gongbuffer.loadFromFile(resource_path + "gong.wav")) {
-        std::cout << "sound did not load";
-    }
+    loadOrThrow(gongbuffer,  resource_path + "gong.wav");
     gong.setBuffer(gongbuffer);
     laser.setVolume(60);
 }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -14,8 +14,7 @@
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 // LCOV_EXCL_START — screenshot requires a live RenderWindow; not testable headless
-static void captureScreenshot(const sf::RenderWindow& w, const std::string& path)
-{
+static void captureScreenshot(const sf::RenderWindow& w, const std::string& path) {
     sf::Texture t;
     t.create(w.getSize().x, w.getSize().y);
     t.update(w);
@@ -28,13 +27,10 @@ static void captureScreenshot(const sf::RenderWindow& w, const std::string& path
 Game::Game() : Game(NetworkMode::LOCAL, nullptr) {}
 
 Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
-    : m_window(sf::VideoMode(1920, 1080),
-               mode == NetworkMode::LOCAL ? "Dungeon Game"
-               : mode == NetworkMode::HOST ? "Dungeon Game - Host"
-                                           : "Dungeon Game - Client"),
-      m_networkMode(mode),
-      m_networkManager(netManager)
-{
+    : m_window(sf::VideoMode(1920, 1080), mode == NetworkMode::LOCAL  ? "Dungeon Game"
+                                          : mode == NetworkMode::HOST ? "Dungeon Game - Host"
+                                                                      : "Dungeon Game - Client"),
+      m_networkMode(mode), m_networkManager(netManager) {
     loadOrThrow(background, resource_path + "background.wav");
 
     loadOrThrow(*m_rocket, resource_path + "rocket.png");
@@ -71,7 +67,7 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
         m_arena.push_back(std::move(fire3));
     }
 
-    loadOrThrow(font,  resource_path + "oswald.ttf");
+    loadOrThrow(font, resource_path + "oswald.ttf");
     loadOrThrow(tfont, resource_path + "timer.ttf");
     loadOrThrow(block, resource_path + "Blockt.ttf");
 
@@ -83,17 +79,18 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
     info.setPosition(pause_text.getPosition().x + 150, pause_text.getPosition().y + 500);
     info.setFillColor(sf::Color::Black);
 
-    m_rocketScoreText  = sf::Text("Rocket Score: 0", font, 40);
+    m_rocketScoreText = sf::Text("Rocket Score: 0", font, 40);
     m_robotScoreText = sf::Text("Robot Score: 0", font, 40);
     timer = sf::Text("timer", tfont, 60);
     timer.setPosition((m_window.getSize().x / 2) - 60, 0);
     m_rocketScoreText.setPosition(10, 0);
-    m_robotScoreText.setPosition(m_window.getSize().x - m_robotScoreText.getGlobalBounds().width, 0);
+    m_robotScoreText.setPosition(m_window.getSize().x - m_robotScoreText.getGlobalBounds().width,
+                                 0);
     m_robotScoreText.setFillColor(sf::Color::Green);
     timer.setFillColor(sf::Color::Black);
     m_rocketScoreText.setFillColor(sf::Color::Blue);
 
-    loadOrThrow(sbuffer,     resource_path + "sword_miss.wav");
+    loadOrThrow(sbuffer, resource_path + "sword_miss.wav");
     sword.setBuffer(sbuffer);
     loadOrThrow(p2hitbuffer, resource_path + "skeleton.wav");
     p2hit.setBuffer(p2hitbuffer);
@@ -103,52 +100,50 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
     metal.setBuffer(metalbuffer);
     loadOrThrow(speedbuffer, resource_path + "SpeedUp.wav");
     speed_up.setBuffer(speedbuffer);
-    loadOrThrow(slowbuffer,  resource_path + "SlowDown.wav");
+    loadOrThrow(slowbuffer, resource_path + "SlowDown.wav");
     slow_down.setBuffer(slowbuffer);
-    loadOrThrow(burnbuffer,  resource_path + "burn.wav");
+    loadOrThrow(burnbuffer, resource_path + "burn.wav");
     burn.setBuffer(burnbuffer);
-    loadOrThrow(gongbuffer,  resource_path + "gong.wav");
+    loadOrThrow(gongbuffer, resource_path + "gong.wav");
     gong.setBuffer(gongbuffer);
     laser.setVolume(60);
 }
 
 // ── debug config ──────────────────────────────────────────────────────────────
 
-void Game::setDebugConfig(const DebugConfig& cfg)
-{
+void Game::setDebugConfig(const DebugConfig& cfg) {
     m_debug = cfg;
     if (!cfg.replayPath.empty()) {
-        m_replay    = loadReplay(cfg.replayPath);
+        m_replay = loadReplay(cfg.replayPath);
         m_replayIdx = 0;
     }
     if (!cfg.replayPathP1.empty()) {
-        m_replayP1    = loadReplay(cfg.replayPathP1);
+        m_replayP1 = loadReplay(cfg.replayPathP1);
         m_replayP1Idx = 0;
     }
 }
 
 // ── run ───────────────────────────────────────────────────────────────────────
 
-std::tuple<int, int, float, int, bool, bool> Game::run()
-{
+std::tuple<int, int, float, int, bool, bool> Game::run() {
     sf::Clock clock;
     background.play();
     background.setLoop(true);
     background.setVolume(40);
     gong.setVolume(50);
 
-    float     minutes = 0.f;
-    int       seconds      = 0;
-    bool      p1win        = false;
-    int       framesLeft   = m_debug.frames;
-    const bool framesMode  = (framesLeft > 0);
+    float minutes = 0.f;
+    int seconds = 0;
+    bool p1win = false;
+    int framesLeft = m_debug.frames;
+    const bool framesMode = (framesLeft > 0);
 
     while (m_window.isOpen()) {
         // ── Timer display from step counter ──────────────────────────────────
         {
-            int totalSecs  = static_cast<int>(gameSeconds());
-            minutes   = static_cast<float>(totalSecs / 60);
-            seconds        = totalSecs % 60;
+            int totalSecs = static_cast<int>(gameSeconds());
+            minutes = static_cast<float>(totalSecs / 60);
+            seconds = totalSecs % 60;
             char gClock[10];
             std::snprintf(gClock, sizeof(gClock), "%02.0f:%02d", minutes, seconds);
             timer.setString(gClock);
@@ -194,8 +189,7 @@ std::tuple<int, int, float, int, bool, bool> Game::run()
 
 // ── simStep ───────────────────────────────────────────────────────────────────
 
-void Game::simStep()
-{
+void Game::simStep() {
     // Apply replay input for P2 (before update so the flags are set when update() runs).
     if (!m_replay.empty()) {
         if (m_replayIdx < m_replay.size()) {
@@ -208,7 +202,8 @@ void Game::simStep()
     // Apply replay input for P1.
     if (!m_replayP1.empty()) {
         if (m_replayP1Idx < m_replayP1.size()) {
-            applyInputToP1(m_p1Up, m_p1Left, m_p1Down, m_p1Right, m_p1Attack, m_replayP1[m_replayP1Idx++]);
+            applyInputToP1(m_p1Up, m_p1Left, m_p1Down, m_p1Right, m_p1Attack,
+                           m_replayP1[m_replayP1Idx++]);
         } else {
             PlayerInput empty{};
             applyInputToP1(m_p1Up, m_p1Left, m_p1Down, m_p1Right, m_p1Attack, empty);
@@ -241,13 +236,13 @@ void Game::simStep()
             burn.play();
             m_rocketScore--;
             m_p1HazardReady = false;
-            m_p1HazardCooldownEnd     = static_cast<float>(gameSeconds()) + 2.2f;
+            m_p1HazardCooldownEnd = static_cast<float>(gameSeconds()) + 2.2f;
         }
         if (collision(*m_arena[x], *m_robot) && m_p2HazardReady) {
             burn.play();
             m_robotScore--;
             m_p2HazardReady = false;
-            m_p2HazardCooldownEnd     = static_cast<float>(gameSeconds()) + 2.2f;
+            m_p2HazardCooldownEnd = static_cast<float>(gameSeconds()) + 2.2f;
         }
     }
 
@@ -262,29 +257,29 @@ void Game::simStep()
 
 // ── applyPlayerInput / captureIfDue ──────────────────────────────────────────
 
-void Game::applyPlayerInput(const PlayerInput& in)
-{
+void Game::applyPlayerInput(const PlayerInput& in) {
     applyInputTo(m_p2Up, m_p2Left, m_p2Down, m_p2Right, m_p2Attack, in);
 }
 
-void Game::captureIfDue()
-{
-    if (m_debug.screenshotEvery <= 0) return;
-    if (m_nextShot == 0) m_nextShot = m_debug.screenshotEvery; // lazy init
+void Game::captureIfDue() {
+    if (m_debug.screenshotEvery <= 0)
+        return;
+    if (m_nextShot == 0)
+        m_nextShot = m_debug.screenshotEvery; // lazy init
     // Threshold (not modulo) so a multi-step accumulator drain that jumps past a
     // boundary still captures once; --frames mode (1 step/iter) lands exactly on
     // each multiple, keeping frame_60/120/... filenames stable for determinism.
     if (m_steps >= m_nextShot) {
         captureScreenshot(m_window,
                           m_debug.screenshotDir + "/frame_" + std::to_string(m_steps) + ".png");
-        while (m_nextShot <= m_steps) m_nextShot += m_debug.screenshotEvery;
+        while (m_nextShot <= m_steps)
+            m_nextShot += m_debug.screenshotEvery;
     }
 }
 
 // ── processEvents ─────────────────────────────────────────────────────────────
 
-void Game::processEvents()
-{
+void Game::processEvents() {
     sf::Event event;
     while (m_window.pollEvent(event)) {
         switch (event.type) {
@@ -308,8 +303,7 @@ void Game::processEvents()
 // ── handlePlayerInput ─────────────────────────────────────────────────────────
 
 // LCOV_EXCL_START — keyboard glue; entirely gated off when the harness is active
-void Game::handlePlayerInput(sf::Keyboard::Key key, bool isDown)
-{
+void Game::handlePlayerInput(sf::Keyboard::Key key, bool isDown) {
     // Gate all game-key bindings when the harness is active so that live
     // keyboard cannot perturb a --frames / --replay run.
     if (!m_debug.active()) {
@@ -365,8 +359,7 @@ void Game::handlePlayerInput(sf::Keyboard::Key key, bool isDown)
 
 // ── update ────────────────────────────────────────────────────────────────────
 
-void Game::update(sf::Time deltaT, float time)
-{
+void Game::update(sf::Time deltaT, float time) {
     bool reset = false;
 
     sf::Vector2f p1movement(0.0f, 0.0f);
@@ -403,10 +396,9 @@ void Game::update(sf::Time deltaT, float time)
         if (!m_p1FacingLeft) {
             m_rocket->setScale(-2.0f, 2);
             m_p1FacingLeft = true;
-            m_rocket->setPosition(
-                m_rocket->getPosition().x -
-                    (m_rocket->getWidth() * m_rocket->getScale().x),
-                m_rocket->getPosition().y);
+            m_rocket->setPosition(m_rocket->getPosition().x -
+                                      (m_rocket->getWidth() * m_rocket->getScale().x),
+                                  m_rocket->getPosition().y);
         }
 
         if (collision(*m_rocket, *m_robot)) {
@@ -424,10 +416,9 @@ void Game::update(sf::Time deltaT, float time)
 
         if (m_p1FacingLeft) {
             m_p1FacingLeft = false;
-            m_rocket->setPosition(
-                m_rocket->getPosition().x -
-                    (m_rocket->getWidth() * m_rocket->getScale().x),
-                m_rocket->getPosition().y);
+            m_rocket->setPosition(m_rocket->getPosition().x -
+                                      (m_rocket->getWidth() * m_rocket->getScale().x),
+                                  m_rocket->getPosition().y);
         }
 
         if (collision(*m_rocket, *m_robot)) {
@@ -466,10 +457,9 @@ void Game::update(sf::Time deltaT, float time)
         m_robot->setScale(-1.0f, 1.0f);
         if (!m_p2FacingLeft) {
             m_p2FacingLeft = true;
-            m_robot->setPosition(
-                m_robot->getPosition().x -
-                    (m_robot->getWidth() * m_robot->getScale().x),
-                m_robot->getPosition().y);
+            m_robot->setPosition(m_robot->getPosition().x -
+                                     (m_robot->getWidth() * m_robot->getScale().x),
+                                 m_robot->getPosition().y);
         }
 
         if (collision(*m_rocket, *m_robot)) {
@@ -485,10 +475,9 @@ void Game::update(sf::Time deltaT, float time)
         }
         if (m_p2FacingLeft) {
             m_p2FacingLeft = false;
-            m_robot->setPosition(
-                m_robot->getPosition().x -
-                    (m_robot->getWidth() * m_robot->getScale().x),
-                m_robot->getPosition().y);
+            m_robot->setPosition(m_robot->getPosition().x -
+                                     (m_robot->getWidth() * m_robot->getScale().x),
+                                 m_robot->getPosition().y);
         }
 
         if (collision(*m_rocket, *m_robot)) {
@@ -578,33 +567,33 @@ void Game::update(sf::Time deltaT, float time)
         m_rocket->setPosition(m_rocket->getWidth() + 20, 400);
         m_p1FacingLeft = false;
         m_p2FacingLeft = true;
-        m_inCooldown   = true;
+        m_inCooldown = true;
     }
 
     m_rocketScoreText.setString("Rocket Score: " + std::to_string(m_rocketScore));
     m_robotScoreText.setString("Robot Score: " + std::to_string(m_robotScore));
-    m_robotScoreText.setPosition(m_window.getSize().x - m_robotScoreText.getGlobalBounds().width - 20, 0);
+    m_robotScoreText.setPosition(
+        m_window.getSize().x - m_robotScoreText.getGlobalBounds().width - 20, 0);
 }
 
 // ── render ────────────────────────────────────────────────────────────────────
 
-void Game::render()
-{
+void Game::render() {
     // CLIENT: temporarily shift sprites to interpolated positions for drawing.
     // Positions are saved and restored so update()/collision use authoritative coords.
     sf::Vector2f p1Saved, p2Saved;
-    bool         didShift = false;
+    bool didShift = false;
 
     // LCOV_EXCL_START — CLIENT interpolation; only runs in networked CLIENT mode
     if (m_networkMode == NetworkMode::CLIENT && m_networkManager &&
         !m_networkManager->stateBuf().empty()) {
-        p1Saved  = m_rocket->getPosition();
-        p2Saved  = m_robot->getPosition();
+        p1Saved = m_rocket->getPosition();
+        p2Saved = m_robot->getPosition();
         didShift = true;
 
-        const auto& buf          = m_networkManager->stateBuf();
+        const auto& buf = m_networkManager->stateBuf();
         constexpr float kInterpDelay = 0.04f; // 40 ms behind
-        sf::Time        target   = m_networkManager->elapsed() - sf::seconds(kInterpDelay);
+        sf::Time target = m_networkManager->elapsed() - sf::seconds(kInterpDelay);
 
         sf::Vector2f rp1, rp2;
         if (buf.size() >= 2) {
@@ -613,12 +602,11 @@ void Game::render()
                 if (buf[i].arrival <= target)
                     ai = i;
             }
-            std::size_t bi  = std::min(ai + 1, buf.size() - 1);
-            const auto& sa  = buf[ai];
-            const auto& sb  = buf[bi];
-            float       span = (sb.arrival - sa.arrival).asSeconds();
-            float       t =
-                (span > 0.f) ? (target - sa.arrival).asSeconds() / span : 1.f;
+            std::size_t bi = std::min(ai + 1, buf.size() - 1);
+            const auto& sa = buf[ai];
+            const auto& sb = buf[bi];
+            float span = (sb.arrival - sa.arrival).asSeconds();
+            float t = (span > 0.f) ? (target - sa.arrival).asSeconds() / span : 1.f;
             rp1 = lerpPos({sa.state.p1_x, sa.state.p1_y}, {sb.state.p1_x, sb.state.p1_y}, t);
             rp2 = lerpPos({sa.state.p2_x, sa.state.p2_y}, {sb.state.p2_x, sb.state.p2_y}, t);
         } else {
@@ -657,20 +645,17 @@ void Game::render()
 
 // ── collision ─────────────────────────────────────────────────────────────────
 
-bool Game::collision(const GameObject& a, const GameObject& b)
-{
+bool Game::collision(const GameObject& a, const GameObject& b) {
     return objectBounds(a).intersects(objectBounds(b));
 }
 
-bool Game::collision(sf::Rect<float> a, const GameObject& b)
-{
+bool Game::collision(sf::Rect<float> a, const GameObject& b) {
     return a.intersects(objectBounds(b));
 }
 
 // ── handleNetworkCommunication ────────────────────────────────────────────────
 
-void Game::handleNetworkCommunication(sf::Time deltaT)
-{
+void Game::handleNetworkCommunication(sf::Time deltaT) {
     if (!m_networkManager)
         return;
 
@@ -680,10 +665,10 @@ void Game::handleNetworkCommunication(sf::Time deltaT)
         // Consume all queued inputs; keep only the most recent.
         PlayerInput clientInput;
         PlayerInput tmp;
-        bool        got = false;
+        bool got = false;
         while (m_networkManager->nextInput(tmp)) {
             clientInput = tmp;
-            got         = true;
+            got = true;
         }
         if (got) {
             applyPlayerInput(clientInput);
@@ -698,10 +683,10 @@ void Game::handleNetworkCommunication(sf::Time deltaT)
     } else if (m_networkMode == NetworkMode::CLIENT && m_networkManager->isConnected()) {
         // Send local input every frame.
         PlayerInput myInput;
-        myInput.up     = m_p2Up;
-        myInput.down   = m_p2Down;
-        myInput.left   = m_p2Left;
-        myInput.right  = m_p2Right;
+        myInput.up = m_p2Up;
+        myInput.down = m_p2Down;
+        myInput.left = m_p2Left;
+        myInput.right = m_p2Right;
         myInput.attack = m_p2Attack;
         m_networkManager->sendInput(myInput);
 
@@ -726,33 +711,31 @@ void Game::handleNetworkCommunication(sf::Time deltaT)
 
 GameState Game::snapshot() const { return captureGameState(); }
 
-GameState Game::captureGameState() const
-{
+GameState Game::captureGameState() const {
     GameState state;
-    state.p1_x      = m_rocket->getPosition().x;
-    state.p1_y      = m_rocket->getPosition().y;
-    state.p2_x      = m_robot->getPosition().x;
-    state.p2_y      = m_robot->getPosition().y;
-    state.p1_score  = m_rocketScore;
-    state.p2_score  = m_robotScore;
-    state.p1_left   = m_p1FacingLeft;
-    state.p2_left   = m_p2FacingLeft;
+    state.p1_x = m_rocket->getPosition().x;
+    state.p1_y = m_rocket->getPosition().y;
+    state.p2_x = m_robot->getPosition().x;
+    state.p2_y = m_robot->getPosition().y;
+    state.p1_score = m_rocketScore;
+    state.p2_score = m_robotScore;
+    state.p1_left = m_p1FacingLeft;
+    state.p2_left = m_p2FacingLeft;
     state.p1_scale_x = m_rocket->getScale().x;
     state.p1_scale_y = m_rocket->getScale().y;
     state.p2_scale_x = m_robot->getScale().x;
     state.p2_scale_y = m_robot->getScale().y;
-    state.wait       = m_inCooldown;
+    state.wait = m_inCooldown;
     return state;
 }
 
-void Game::applyNetworkState(const GameState& state)
-{
+void Game::applyNetworkState(const GameState& state) {
     m_rocket->setPosition(state.p1_x, state.p1_y);
     m_robot->setPosition(state.p2_x, state.p2_y);
     m_rocketScore = state.p1_score;
-    m_robotScore   = state.p2_score;
-    m_p1FacingLeft   = state.p1_left;
-    m_p2FacingLeft   = state.p2_left;
+    m_robotScore = state.p2_score;
+    m_p1FacingLeft = state.p1_left;
+    m_p2FacingLeft = state.p2_left;
     m_rocket->setScale(state.p1_scale_x, state.p1_scale_y);
     m_robot->setScale(state.p2_scale_x, state.p2_scale_y);
     m_inCooldown = state.wait;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -46,28 +46,31 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
     player2->setScale(-1.0f, 1.0f);
     player2->setPosition(m_window.getSize().x - (m_player->getWidth() + 150), 400);
 
-    GameObject* wall = new RegularGameObject();
-    stuff.push_back(wall);
+    stuff.push_back(std::make_unique<RegularGameObject>());
     stuff[0]->load(resource_path + "brick.png");
     stuff[0]->setScale(2.0f);
 
-    GameObject* fire = new AnimatedGameObject(216, 216, 5, 3, 10, 0);
-    fire->load(resource_path + "fire.png");
-    fire->setScale(2.0f);
-    fire->setPosition(-15, 400);
-    stuff.push_back(fire);
-
-    GameObject* fire2 = new AnimatedGameObject(216, 216, 5, 3, 10, 0);
-    fire2->load(resource_path + "fire.png");
-    fire2->setScale(2.0f);
-    fire2->setPosition((1920 / 2) - 5, 400);
-    stuff.push_back(fire2);
-
-    GameObject* fire3 = new AnimatedGameObject(216, 216, 5, 3, 10, 0);
-    fire3->load(resource_path + "fire.png");
-    fire3->setScale(2.0f);
-    fire3->setPosition(1820, 400);
-    stuff.push_back(fire3);
+    {
+        auto fire = std::make_unique<AnimatedGameObject>(216, 216, 5, 3, 10, 0);
+        fire->load(resource_path + "fire.png");
+        fire->setScale(2.0f);
+        fire->setPosition(-15, 400);
+        stuff.push_back(std::move(fire));
+    }
+    {
+        auto fire2 = std::make_unique<AnimatedGameObject>(216, 216, 5, 3, 10, 0);
+        fire2->load(resource_path + "fire.png");
+        fire2->setScale(2.0f);
+        fire2->setPosition((1920 / 2) - 5, 400);
+        stuff.push_back(std::move(fire2));
+    }
+    {
+        auto fire3 = std::make_unique<AnimatedGameObject>(216, 216, 5, 3, 10, 0);
+        fire3->load(resource_path + "fire.png");
+        fire3->setScale(2.0f);
+        fire3->setPosition(1820, 400);
+        stuff.push_back(std::move(fire3));
+    }
 
     if (!font.loadFromFile(resource_path + "oswald.ttf")) {
         std::cout << "Font did not load" << std::endl;
@@ -257,13 +260,13 @@ void Game::simStep()
 
     // Hazard collision + scoring.
     for (int x = 1; x < static_cast<int>(stuff.size()); x++) {
-        if (collision(stuff[x], m_player) && p1_time_passed) {
+        if (collision(*stuff[x], *m_player) && p1_time_passed) {
             burn.play();
             p2points--;
             p1_time_passed = false;
             p1_timeout     = static_cast<float>(gameSeconds()) + 2.2f;
         }
-        if (collision(stuff[x], player2) && p2_time_passed) {
+        if (collision(*stuff[x], *player2) && p2_time_passed) {
             burn.play();
             points--;
             p2_time_passed = false;
@@ -398,7 +401,7 @@ void Game::update(sf::Time deltaT, float time)
                                   (m_window.getSize().y) - m_player->getHeight());
         }
 
-        if (collision(m_player, player2)) {
+        if (collision(*m_player, *player2)) {
             m_player->setPosition(m_player->getPosition().x, m_player->getPosition().y + 40);
         } else {
             p1movement.y -= m_speed;
@@ -410,7 +413,7 @@ void Game::update(sf::Time deltaT, float time)
             m_player->setPosition(m_player->getPosition().x, -(m_player->getHeight()));
         }
 
-        if (collision(m_player, player2)) {
+        if (collision(*m_player, *player2)) {
             m_player->setPosition(m_player->getPosition().x, m_player->getPosition().y - 40);
         } else {
             p1movement.y += m_speed;
@@ -429,7 +432,7 @@ void Game::update(sf::Time deltaT, float time)
                 m_player->getPosition().y);
         }
 
-        if (collision(m_player, player2)) {
+        if (collision(*m_player, *player2)) {
             m_player->setPosition(m_player->getPosition().x + 40, m_player->getPosition().y);
         } else {
             p1movement.x -= m_speed;
@@ -450,7 +453,7 @@ void Game::update(sf::Time deltaT, float time)
                 m_player->getPosition().y);
         }
 
-        if (collision(m_player, player2)) {
+        if (collision(*m_player, *player2)) {
             m_player->setPosition(m_player->getPosition().x - 40, m_player->getPosition().y);
         } else {
             p1movement.x += m_speed;
@@ -462,7 +465,7 @@ void Game::update(sf::Time deltaT, float time)
                                  (m_window.getSize().y) - player2->getHeight());
         }
 
-        if (collision(m_player, player2)) {
+        if (collision(*m_player, *player2)) {
             player2->setPosition(player2->getPosition().x, player2->getPosition().y + 40);
         } else {
             p2movement.y -= m_speed;
@@ -473,7 +476,7 @@ void Game::update(sf::Time deltaT, float time)
             player2->setPosition(player2->getPosition().x, -(player2->getHeight()));
         }
 
-        if (collision(m_player, player2)) {
+        if (collision(*m_player, *player2)) {
             player2->setPosition(player2->getPosition().x, player2->getPosition().y - 40);
         } else {
             p2movement.y += m_speed;
@@ -492,7 +495,7 @@ void Game::update(sf::Time deltaT, float time)
                 player2->getPosition().y);
         }
 
-        if (collision(m_player, player2)) {
+        if (collision(*m_player, *player2)) {
             player2->setPosition(player2->getPosition().x + 40, player2->getPosition().y);
         } else {
             p2movement.x -= m_speed;
@@ -511,7 +514,7 @@ void Game::update(sf::Time deltaT, float time)
                 player2->getPosition().y);
         }
 
-        if (collision(m_player, player2)) {
+        if (collision(*m_player, *player2)) {
             player2->setPosition(player2->getPosition().x - 40, player2->getPosition().y);
         } else {
             p2movement.x += m_speed;
@@ -531,7 +534,7 @@ void Game::update(sf::Time deltaT, float time)
                              (player2->getHeight()) * (player2->getScale().y)));
         }
 
-        if (collision(hit, m_player)) {
+        if (collision(hit, *m_player)) {
             metal.play();
             points++;
             reset = true;
@@ -555,7 +558,7 @@ void Game::update(sf::Time deltaT, float time)
                              (m_player->getHeight()) * (m_player->getScale().y)));
         }
 
-        if (collision(hit, player2)) {
+        if (collision(hit, *player2)) {
             p2points++;
             reset = true;
             p2hit.play();
@@ -578,12 +581,12 @@ void Game::update(sf::Time deltaT, float time)
         speed_up.play();
     }
 
-    if ((m_up || m_down || m_left || m_right) && !collision(m_player, player2)) {
+    if ((m_up || m_down || m_left || m_right) && !collision(*m_player, *player2)) {
         m_player->move(p1movement * deltaT.asSeconds());
         m_player->update(time);
     }
 
-    if ((w || a || s || d) && !collision(m_player, player2)) {
+    if ((w || a || s || d) && !collision(*m_player, *player2)) {
         player2->move(p2movement * deltaT.asSeconds());
         player2->update(time);
     }
@@ -677,14 +680,14 @@ void Game::render()
 
 // ── collision ─────────────────────────────────────────────────────────────────
 
-bool Game::collision(GameObject* a, GameObject* b)
+bool Game::collision(const GameObject& a, const GameObject& b)
 {
-    return objectBounds(*a).intersects(objectBounds(*b));
+    return objectBounds(a).intersects(objectBounds(b));
 }
 
-bool Game::collision(sf::Rect<float> a, GameObject* b)
+bool Game::collision(sf::Rect<float> a, const GameObject& b)
 {
-    return a.intersects(objectBounds(*b));
+    return a.intersects(objectBounds(b));
 }
 
 // ── handleNetworkCommunication ────────────────────────────────────────────────

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -37,38 +37,38 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
 {
     loadOrThrow(background, resource_path + "background.wav");
 
-    loadOrThrow(*m_player, resource_path + "rocket.png");
-    m_player->setScale(2.0f);
-    m_player->setPosition(m_player->getWidth(), 400);
+    loadOrThrow(*m_rocket, resource_path + "rocket.png");
+    m_rocket->setScale(2.0f);
+    m_rocket->setPosition(m_rocket->getWidth(), 400);
 
-    loadOrThrow(*player2, resource_path + "robot.png");
-    player2->setScale(-1.0f, 1.0f);
-    player2->setPosition(m_window.getSize().x - (m_player->getWidth() + 150), 400);
+    loadOrThrow(*m_robot, resource_path + "robot.png");
+    m_robot->setScale(-1.0f, 1.0f);
+    m_robot->setPosition(m_window.getSize().x - (m_rocket->getWidth() + 150), 400);
 
-    stuff.push_back(std::make_unique<RegularGameObject>());
-    loadOrThrow(*stuff[0], resource_path + "brick.png");
-    stuff[0]->setScale(2.0f);
+    m_arena.push_back(std::make_unique<RegularGameObject>());
+    loadOrThrow(*m_arena[0], resource_path + "brick.png");
+    m_arena[0]->setScale(2.0f);
 
     {
         auto fire = std::make_unique<AnimatedGameObject>(216, 216, 5, 3, 10, 0);
         loadOrThrow(*fire, resource_path + "fire.png");
         fire->setScale(2.0f);
         fire->setPosition(-15, 400);
-        stuff.push_back(std::move(fire));
+        m_arena.push_back(std::move(fire));
     }
     {
         auto fire2 = std::make_unique<AnimatedGameObject>(216, 216, 5, 3, 10, 0);
         loadOrThrow(*fire2, resource_path + "fire.png");
         fire2->setScale(2.0f);
         fire2->setPosition((1920 / 2) - 5, 400);
-        stuff.push_back(std::move(fire2));
+        m_arena.push_back(std::move(fire2));
     }
     {
         auto fire3 = std::make_unique<AnimatedGameObject>(216, 216, 5, 3, 10, 0);
         loadOrThrow(*fire3, resource_path + "fire.png");
         fire3->setScale(2.0f);
         fire3->setPosition(1820, 400);
-        stuff.push_back(std::move(fire3));
+        m_arena.push_back(std::move(fire3));
     }
 
     loadOrThrow(font,  resource_path + "oswald.ttf");
@@ -83,15 +83,15 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
     info.setPosition(pause_text.getPosition().x + 150, pause_text.getPosition().y + 500);
     info.setFillColor(sf::Color::Black);
 
-    text  = sf::Text("Rocket Score: 0", font, 40);
-    text2 = sf::Text("Robot Score: 0", font, 40);
+    m_rocketScoreText  = sf::Text("Rocket Score: 0", font, 40);
+    m_robotScoreText = sf::Text("Robot Score: 0", font, 40);
     timer = sf::Text("timer", tfont, 60);
     timer.setPosition((m_window.getSize().x / 2) - 60, 0);
-    text.setPosition(10, 0);
-    text2.setPosition(m_window.getSize().x - text2.getGlobalBounds().width, 0);
-    text2.setFillColor(sf::Color::Green);
+    m_rocketScoreText.setPosition(10, 0);
+    m_robotScoreText.setPosition(m_window.getSize().x - m_robotScoreText.getGlobalBounds().width, 0);
+    m_robotScoreText.setFillColor(sf::Color::Green);
     timer.setFillColor(sf::Color::Black);
-    text.setFillColor(sf::Color::Blue);
+    m_rocketScoreText.setFillColor(sf::Color::Blue);
 
     loadOrThrow(sbuffer,     resource_path + "sword_miss.wav");
     sword.setBuffer(sbuffer);
@@ -137,7 +137,7 @@ std::tuple<int, int, float, int, bool, bool> Game::run()
     background.setVolume(40);
     gong.setVolume(50);
 
-    float     apieceofcrap = 0.f;
+    float     minutes = 0.f;
     int       seconds      = 0;
     bool      p1win        = false;
     int       framesLeft   = m_debug.frames;
@@ -147,10 +147,10 @@ std::tuple<int, int, float, int, bool, bool> Game::run()
         // ── Timer display from step counter ──────────────────────────────────
         {
             int totalSecs  = static_cast<int>(gameSeconds());
-            apieceofcrap   = static_cast<float>(totalSecs / 60);
+            minutes   = static_cast<float>(totalSecs / 60);
             seconds        = totalSecs % 60;
             char gClock[10];
-            std::snprintf(gClock, sizeof(gClock), "%02.0f:%02d", apieceofcrap, seconds);
+            std::snprintf(gClock, sizeof(gClock), "%02.0f:%02d", minutes, seconds);
             timer.setString(gClock);
         }
 
@@ -188,8 +188,8 @@ std::tuple<int, int, float, int, bool, bool> Game::run()
     }
 
     background.stop();
-    p1win = (p2points > points);
-    return {p2points, points, apieceofcrap, seconds, p1win, m_peerLeft};
+    p1win = (m_rocketScore > m_robotScore);
+    return {m_rocketScore, m_robotScore, minutes, seconds, p1win, m_peerLeft};
 }
 
 // ── simStep ───────────────────────────────────────────────────────────────────
@@ -208,19 +208,19 @@ void Game::simStep()
     // Apply replay input for P1.
     if (!m_replayP1.empty()) {
         if (m_replayP1Idx < m_replayP1.size()) {
-            applyInputToP1(m_up, m_left, m_down, m_right, right, m_replayP1[m_replayP1Idx++]);
+            applyInputToP1(m_p1Up, m_p1Left, m_p1Down, m_p1Right, m_p1Attack, m_replayP1[m_replayP1Idx++]);
         } else {
             PlayerInput empty{};
-            applyInputToP1(m_up, m_left, m_down, m_right, right, empty);
+            applyInputToP1(m_p1Up, m_p1Left, m_p1Down, m_p1Right, m_p1Attack, empty);
         }
     }
 
     // Update or drain the cooldown wait.
-    if (!wait) {
+    if (!m_inCooldown) {
         update(sf::seconds(kFixedDt), m_animTime);
-        temp_time = static_cast<float>(gameSeconds()) + 1.75f;
-    } else if (gameSeconds() > static_cast<double>(temp_time)) {
-        wait = false;
+        m_cooldownEnd = static_cast<float>(gameSeconds()) + 1.75f;
+    } else if (gameSeconds() > static_cast<double>(m_cooldownEnd)) {
+        m_inCooldown = false;
         gong.play();
     }
 
@@ -230,32 +230,32 @@ void Game::simStep()
     m_animTime += kFixedDt;
 
     // Timeout checks.
-    if (gameSeconds() > static_cast<double>(p1_timeout))
-        p1_time_passed = true;
-    if (gameSeconds() > static_cast<double>(p2_timeout))
-        p2_time_passed = true;
+    if (gameSeconds() > static_cast<double>(m_p1HazardCooldownEnd))
+        m_p1HazardReady = true;
+    if (gameSeconds() > static_cast<double>(m_p2HazardCooldownEnd))
+        m_p2HazardReady = true;
 
     // Hazard collision + scoring.
-    for (int x = 1; x < static_cast<int>(stuff.size()); x++) {
-        if (collision(*stuff[x], *m_player) && p1_time_passed) {
+    for (int x = 1; x < static_cast<int>(m_arena.size()); x++) {
+        if (collision(*m_arena[x], *m_rocket) && m_p1HazardReady) {
             burn.play();
-            p2points--;
-            p1_time_passed = false;
-            p1_timeout     = static_cast<float>(gameSeconds()) + 2.2f;
+            m_rocketScore--;
+            m_p1HazardReady = false;
+            m_p1HazardCooldownEnd     = static_cast<float>(gameSeconds()) + 2.2f;
         }
-        if (collision(*stuff[x], *player2) && p2_time_passed) {
+        if (collision(*m_arena[x], *m_robot) && m_p2HazardReady) {
             burn.play();
-            points--;
-            p2_time_passed = false;
-            p2_timeout     = static_cast<float>(gameSeconds()) + 2.2f;
+            m_robotScore--;
+            m_p2HazardReady = false;
+            m_p2HazardCooldownEnd     = static_cast<float>(gameSeconds()) + 2.2f;
         }
     }
 
     // Score clamps.
-    if (points < 0)
-        points = 0;
-    if (p2points < 0)
-        p2points = 0;
+    if (m_robotScore < 0)
+        m_robotScore = 0;
+    if (m_rocketScore < 0)
+        m_rocketScore = 0;
 
     ++m_steps;
 }
@@ -264,7 +264,7 @@ void Game::simStep()
 
 void Game::applyPlayerInput(const PlayerInput& in)
 {
-    applyInputTo(w, a, s, d, space, in);
+    applyInputTo(m_p2Up, m_p2Left, m_p2Down, m_p2Right, m_p2Attack, in);
 }
 
 void Game::captureIfDue()
@@ -316,39 +316,39 @@ void Game::handlePlayerInput(sf::Keyboard::Key key, bool isDown)
         // Player 1 controls (rocket — numpad)
         if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::HOST) {
             if (key == sf::Keyboard::Numpad4)
-                m_left = isDown;
+                m_p1Left = isDown;
             if (key == sf::Keyboard::Numpad6)
-                m_right = isDown;
+                m_p1Right = isDown;
             if (key == sf::Keyboard::Numpad8)
-                m_up = isDown;
+                m_p1Up = isDown;
             if (key == sf::Keyboard::Numpad5)
-                m_down = isDown;
+                m_p1Down = isDown;
             if (key == sf::Keyboard::Right)
-                right = isDown;
+                m_p1Attack = isDown;
         }
 
         // Player 2 controls (robot — WASD)
         if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::CLIENT) {
             if (key == sf::Keyboard::W)
-                w = isDown;
+                m_p2Up = isDown;
             if (key == sf::Keyboard::A)
-                a = isDown;
+                m_p2Left = isDown;
             if (key == sf::Keyboard::S)
-                s = isDown;
+                m_p2Down = isDown;
             if (key == sf::Keyboard::D)
-                d = isDown;
+                m_p2Right = isDown;
             if (key == sf::Keyboard::Space)
-                space = !isDown;
+                m_p2Attack = !isDown;
         }
 
         // Speed tweaks and wait-skip
         if (key == sf::Keyboard::O)
-            o = !isDown;
+            m_slowDownPressed = !isDown;
         if (key == sf::Keyboard::P)
-            p = !isDown;
+            m_speedUpPressed = !isDown;
         if (key == sf::Keyboard::K) {
-            if (wait) {
-                wait = false;
+            if (m_inCooldown) {
+                m_inCooldown = false;
                 gong.play();
             }
         }
@@ -372,218 +372,218 @@ void Game::update(sf::Time deltaT, float time)
     sf::Vector2f p1movement(0.0f, 0.0f);
     sf::Vector2f p2movement(0.0f, 0.0f);
 
-    if (m_up) {
-        if (m_player->getPosition().y < -(m_player->getHeight())) {
-            m_player->setPosition(m_player->getPosition().x,
-                                  (m_window.getSize().y) - m_player->getHeight());
+    if (m_p1Up) {
+        if (m_rocket->getPosition().y < -(m_rocket->getHeight())) {
+            m_rocket->setPosition(m_rocket->getPosition().x,
+                                  (m_window.getSize().y) - m_rocket->getHeight());
         }
 
-        if (collision(*m_player, *player2)) {
-            m_player->setPosition(m_player->getPosition().x, m_player->getPosition().y + 40);
+        if (collision(*m_rocket, *m_robot)) {
+            m_rocket->setPosition(m_rocket->getPosition().x, m_rocket->getPosition().y + 40);
         } else {
             p1movement.y -= m_speed;
         }
     }
 
-    if (m_down) {
-        if (m_player->getPosition().y > (m_window.getSize().y) - (m_player->getHeight())) {
-            m_player->setPosition(m_player->getPosition().x, -(m_player->getHeight()));
+    if (m_p1Down) {
+        if (m_rocket->getPosition().y > (m_window.getSize().y) - (m_rocket->getHeight())) {
+            m_rocket->setPosition(m_rocket->getPosition().x, -(m_rocket->getHeight()));
         }
 
-        if (collision(*m_player, *player2)) {
-            m_player->setPosition(m_player->getPosition().x, m_player->getPosition().y - 40);
+        if (collision(*m_rocket, *m_robot)) {
+            m_rocket->setPosition(m_rocket->getPosition().x, m_rocket->getPosition().y - 40);
         } else {
             p1movement.y += m_speed;
         }
     }
-    if (m_left) {
-        if (m_player->getPosition().x < -(m_player->getWidth())) {
-            m_player->setPosition(m_window.getSize().x, m_player->getPosition().y);
+    if (m_p1Left) {
+        if (m_rocket->getPosition().x < -(m_rocket->getWidth())) {
+            m_rocket->setPosition(m_window.getSize().x, m_rocket->getPosition().y);
         }
-        if (!p1left) {
-            m_player->setScale(-2.0f, 2);
-            p1left = true;
-            m_player->setPosition(
-                m_player->getPosition().x -
-                    (m_player->getWidth() * m_player->getScale().x),
-                m_player->getPosition().y);
+        if (!m_p1FacingLeft) {
+            m_rocket->setScale(-2.0f, 2);
+            m_p1FacingLeft = true;
+            m_rocket->setPosition(
+                m_rocket->getPosition().x -
+                    (m_rocket->getWidth() * m_rocket->getScale().x),
+                m_rocket->getPosition().y);
         }
 
-        if (collision(*m_player, *player2)) {
-            m_player->setPosition(m_player->getPosition().x + 40, m_player->getPosition().y);
+        if (collision(*m_rocket, *m_robot)) {
+            m_rocket->setPosition(m_rocket->getPosition().x + 40, m_rocket->getPosition().y);
         } else {
             p1movement.x -= m_speed;
         }
     }
-    if (m_right) {
-        m_player->setScale(2.0f, 2);
+    if (m_p1Right) {
+        m_rocket->setScale(2.0f, 2);
 
-        if (m_player->getPosition().x > m_window.getSize().x) {
-            m_player->setPosition(-(m_player->getWidth()), m_player->getPosition().y);
+        if (m_rocket->getPosition().x > m_window.getSize().x) {
+            m_rocket->setPosition(-(m_rocket->getWidth()), m_rocket->getPosition().y);
         }
 
-        if (p1left) {
-            p1left = false;
-            m_player->setPosition(
-                m_player->getPosition().x -
-                    (m_player->getWidth() * m_player->getScale().x),
-                m_player->getPosition().y);
+        if (m_p1FacingLeft) {
+            m_p1FacingLeft = false;
+            m_rocket->setPosition(
+                m_rocket->getPosition().x -
+                    (m_rocket->getWidth() * m_rocket->getScale().x),
+                m_rocket->getPosition().y);
         }
 
-        if (collision(*m_player, *player2)) {
-            m_player->setPosition(m_player->getPosition().x - 40, m_player->getPosition().y);
+        if (collision(*m_rocket, *m_robot)) {
+            m_rocket->setPosition(m_rocket->getPosition().x - 40, m_rocket->getPosition().y);
         } else {
             p1movement.x += m_speed;
         }
     }
-    if (w) {
-        if (player2->getPosition().y < -(player2->getHeight())) {
-            player2->setPosition(player2->getPosition().x,
-                                 (m_window.getSize().y) - player2->getHeight());
+    if (m_p2Up) {
+        if (m_robot->getPosition().y < -(m_robot->getHeight())) {
+            m_robot->setPosition(m_robot->getPosition().x,
+                                 (m_window.getSize().y) - m_robot->getHeight());
         }
 
-        if (collision(*m_player, *player2)) {
-            player2->setPosition(player2->getPosition().x, player2->getPosition().y + 40);
+        if (collision(*m_rocket, *m_robot)) {
+            m_robot->setPosition(m_robot->getPosition().x, m_robot->getPosition().y + 40);
         } else {
             p2movement.y -= m_speed;
         }
     }
-    if (s) {
-        if (player2->getPosition().y > (m_window.getSize().y) - (player2->getHeight())) {
-            player2->setPosition(player2->getPosition().x, -(player2->getHeight()));
+    if (m_p2Down) {
+        if (m_robot->getPosition().y > (m_window.getSize().y) - (m_robot->getHeight())) {
+            m_robot->setPosition(m_robot->getPosition().x, -(m_robot->getHeight()));
         }
 
-        if (collision(*m_player, *player2)) {
-            player2->setPosition(player2->getPosition().x, player2->getPosition().y - 40);
+        if (collision(*m_rocket, *m_robot)) {
+            m_robot->setPosition(m_robot->getPosition().x, m_robot->getPosition().y - 40);
         } else {
             p2movement.y += m_speed;
         }
     }
-    if (a) {
-        if (player2->getPosition().x < -(player2->getWidth())) {
-            player2->setPosition(m_window.getSize().x, player2->getPosition().y);
+    if (m_p2Left) {
+        if (m_robot->getPosition().x < -(m_robot->getWidth())) {
+            m_robot->setPosition(m_window.getSize().x, m_robot->getPosition().y);
         }
-        player2->setScale(-1.0f, 1.0f);
-        if (!p2left) {
-            p2left = true;
-            player2->setPosition(
-                player2->getPosition().x -
-                    (player2->getWidth() * player2->getScale().x),
-                player2->getPosition().y);
+        m_robot->setScale(-1.0f, 1.0f);
+        if (!m_p2FacingLeft) {
+            m_p2FacingLeft = true;
+            m_robot->setPosition(
+                m_robot->getPosition().x -
+                    (m_robot->getWidth() * m_robot->getScale().x),
+                m_robot->getPosition().y);
         }
 
-        if (collision(*m_player, *player2)) {
-            player2->setPosition(player2->getPosition().x + 40, player2->getPosition().y);
+        if (collision(*m_rocket, *m_robot)) {
+            m_robot->setPosition(m_robot->getPosition().x + 40, m_robot->getPosition().y);
         } else {
             p2movement.x -= m_speed;
         }
     }
-    if (d) {
-        player2->setScale(1.0f, 1.0f);
-        if (player2->getPosition().x > m_window.getSize().x) {
-            player2->setPosition(-(player2->getWidth()), player2->getPosition().y);
+    if (m_p2Right) {
+        m_robot->setScale(1.0f, 1.0f);
+        if (m_robot->getPosition().x > m_window.getSize().x) {
+            m_robot->setPosition(-(m_robot->getWidth()), m_robot->getPosition().y);
         }
-        if (p2left) {
-            p2left = false;
-            player2->setPosition(
-                player2->getPosition().x -
-                    (player2->getWidth() * player2->getScale().x),
-                player2->getPosition().y);
+        if (m_p2FacingLeft) {
+            m_p2FacingLeft = false;
+            m_robot->setPosition(
+                m_robot->getPosition().x -
+                    (m_robot->getWidth() * m_robot->getScale().x),
+                m_robot->getPosition().y);
         }
 
-        if (collision(*m_player, *player2)) {
-            player2->setPosition(player2->getPosition().x - 40, player2->getPosition().y);
+        if (collision(*m_rocket, *m_robot)) {
+            m_robot->setPosition(m_robot->getPosition().x - 40, m_robot->getPosition().y);
         } else {
             p2movement.x += m_speed;
         }
     }
-    if (space) {
+    if (m_p2Attack) {
         sf::Rect<float> hit;
-        if (!p2left) {
+        if (!m_p2FacingLeft) {
             hit = sf::Rect<float>(
-                player2->getPosition(),
-                sf::Vector2f(200 + ((player2->getWidth()) * (player2->getScale().x)),
-                             (player2->getHeight()) * (player2->getScale().y)));
+                m_robot->getPosition(),
+                sf::Vector2f(200 + ((m_robot->getWidth()) * (m_robot->getScale().x)),
+                             (m_robot->getHeight()) * (m_robot->getScale().y)));
         } else {
             hit = sf::Rect<float>(
-                player2->getPosition(),
-                sf::Vector2f(((player2->getWidth()) * (player2->getScale().x)) - 200,
-                             (player2->getHeight()) * (player2->getScale().y)));
+                m_robot->getPosition(),
+                sf::Vector2f(((m_robot->getWidth()) * (m_robot->getScale().x)) - 200,
+                             (m_robot->getHeight()) * (m_robot->getScale().y)));
         }
 
-        if (collision(hit, *m_player)) {
+        if (collision(hit, *m_rocket)) {
             metal.play();
-            points++;
+            m_robotScore++;
             reset = true;
         } else {
             sword.play();
         }
 
-        space = false;
+        m_p2Attack = false;
     }
-    if (right) {
+    if (m_p1Attack) {
         sf::Rect<float> hit;
-        if (!p1left) {
+        if (!m_p1FacingLeft) {
             hit = sf::Rect<float>(
-                m_player->getPosition(),
-                sf::Vector2f(200 + ((m_player->getWidth()) * (m_player->getScale().x)),
-                             (m_player->getHeight()) * (m_player->getScale().y)));
+                m_rocket->getPosition(),
+                sf::Vector2f(200 + ((m_rocket->getWidth()) * (m_rocket->getScale().x)),
+                             (m_rocket->getHeight()) * (m_rocket->getScale().y)));
         } else {
             hit = sf::Rect<float>(
-                m_player->getPosition(),
-                sf::Vector2f(((m_player->getWidth()) * (m_player->getScale().x)) - 200,
-                             (m_player->getHeight()) * (m_player->getScale().y)));
+                m_rocket->getPosition(),
+                sf::Vector2f(((m_rocket->getWidth()) * (m_rocket->getScale().x)) - 200,
+                             (m_rocket->getHeight()) * (m_rocket->getScale().y)));
         }
 
-        if (collision(hit, *player2)) {
-            p2points++;
+        if (collision(hit, *m_robot)) {
+            m_rocketScore++;
             reset = true;
             p2hit.play();
         } else {
             laser.play();
         }
 
-        right = false;
+        m_p1Attack = false;
     }
-    if (o) {
+    if (m_slowDownPressed) {
         m_speed = m_speed - 150.0f;
         if (m_speed < 0)
             m_speed = 1.0f;
-        o = false;
+        m_slowDownPressed = false;
         slow_down.play();
     }
-    if (p) {
+    if (m_speedUpPressed) {
         m_speed = m_speed + 150.0f;
-        p       = false;
+        m_speedUpPressed = false;
         speed_up.play();
     }
 
-    if ((m_up || m_down || m_left || m_right) && !collision(*m_player, *player2)) {
-        m_player->move(p1movement * deltaT.asSeconds());
-        m_player->update(time);
+    if ((m_p1Up || m_p1Down || m_p1Left || m_p1Right) && !collision(*m_rocket, *m_robot)) {
+        m_rocket->move(p1movement * deltaT.asSeconds());
+        m_rocket->update(time);
     }
 
-    if ((w || a || s || d) && !collision(*m_player, *player2)) {
-        player2->move(p2movement * deltaT.asSeconds());
-        player2->update(time);
+    if ((m_p2Up || m_p2Left || m_p2Down || m_p2Right) && !collision(*m_rocket, *m_robot)) {
+        m_robot->move(p2movement * deltaT.asSeconds());
+        m_robot->update(time);
     }
-    for (int x = 0; x < static_cast<int>(stuff.size()); x++) {
-        stuff[x]->update(time);
+    for (int x = 0; x < static_cast<int>(m_arena.size()); x++) {
+        m_arena[x]->update(time);
     }
 
     if (reset) {
-        m_player->setScale(2.0f, 2);
-        player2->setScale(-1.0f, 1.0f);
-        player2->setPosition(m_window.getSize().x - (m_player->getWidth() + 150), 400);
-        m_player->setPosition(m_player->getWidth() + 20, 400);
-        p1left = false;
-        p2left = true;
-        wait   = true;
+        m_rocket->setScale(2.0f, 2);
+        m_robot->setScale(-1.0f, 1.0f);
+        m_robot->setPosition(m_window.getSize().x - (m_rocket->getWidth() + 150), 400);
+        m_rocket->setPosition(m_rocket->getWidth() + 20, 400);
+        m_p1FacingLeft = false;
+        m_p2FacingLeft = true;
+        m_inCooldown   = true;
     }
 
-    text.setString("Rocket Score: " + std::to_string(p2points));
-    text2.setString("Robot Score: " + std::to_string(points));
-    text2.setPosition(m_window.getSize().x - text2.getGlobalBounds().width - 20, 0);
+    m_rocketScoreText.setString("Rocket Score: " + std::to_string(m_rocketScore));
+    m_robotScoreText.setString("Robot Score: " + std::to_string(m_robotScore));
+    m_robotScoreText.setPosition(m_window.getSize().x - m_robotScoreText.getGlobalBounds().width - 20, 0);
 }
 
 // ── render ────────────────────────────────────────────────────────────────────
@@ -598,8 +598,8 @@ void Game::render()
     // LCOV_EXCL_START — CLIENT interpolation; only runs in networked CLIENT mode
     if (m_networkMode == NetworkMode::CLIENT && m_networkManager &&
         !m_networkManager->stateBuf().empty()) {
-        p1Saved  = m_player->getPosition();
-        p2Saved  = player2->getPosition();
+        p1Saved  = m_rocket->getPosition();
+        p2Saved  = m_robot->getPosition();
         didShift = true;
 
         const auto& buf          = m_networkManager->stateBuf();
@@ -625,21 +625,21 @@ void Game::render()
             rp1 = {buf[0].state.p1_x, buf[0].state.p1_y};
             rp2 = {buf[0].state.p2_x, buf[0].state.p2_y};
         }
-        m_player->setPosition(rp1.x, rp1.y);
-        player2->setPosition(rp2.x, rp2.y);
+        m_rocket->setPosition(rp1.x, rp1.y);
+        m_robot->setPosition(rp2.x, rp2.y);
     }
     // LCOV_EXCL_STOP
 
     m_window.clear();
-    for (std::size_t x = 0; x < stuff.size(); ++x) {
-        stuff[x]->draw(m_window);
+    for (std::size_t x = 0; x < m_arena.size(); ++x) {
+        m_arena[x]->draw(m_window);
     }
     m_window.draw(timer);
-    m_window.draw(text);
-    m_window.draw(text2);
-    m_player->draw(m_window);
-    player2->draw(m_window);
-    if (wait) {
+    m_window.draw(m_rocketScoreText);
+    m_window.draw(m_robotScoreText);
+    m_rocket->draw(m_window);
+    m_robot->draw(m_window);
+    if (m_inCooldown) {
         m_window.draw(pause_text);
         m_window.draw(info);
     }
@@ -649,8 +649,8 @@ void Game::render()
     // Restore authoritative positions (symmetric with the save above).
     // LCOV_EXCL_START — only reachable when CLIENT interpolation block ran
     if (didShift) {
-        m_player->setPosition(p1Saved.x, p1Saved.y);
-        player2->setPosition(p2Saved.x, p2Saved.y);
+        m_rocket->setPosition(p1Saved.x, p1Saved.y);
+        m_robot->setPosition(p2Saved.x, p2Saved.y);
     }
     // LCOV_EXCL_STOP
 }
@@ -698,11 +698,11 @@ void Game::handleNetworkCommunication(sf::Time deltaT)
     } else if (m_networkMode == NetworkMode::CLIENT && m_networkManager->isConnected()) {
         // Send local input every frame.
         PlayerInput myInput;
-        myInput.up     = w;
-        myInput.down   = s;
-        myInput.left   = a;
-        myInput.right  = d;
-        myInput.attack = space;
+        myInput.up     = m_p2Up;
+        myInput.down   = m_p2Down;
+        myInput.left   = m_p2Left;
+        myInput.right  = m_p2Right;
+        myInput.attack = m_p2Attack;
         m_networkManager->sendInput(myInput);
 
         // Drain incoming state packets.
@@ -729,31 +729,31 @@ GameState Game::snapshot() const { return captureGameState(); }
 GameState Game::captureGameState() const
 {
     GameState state;
-    state.p1_x      = m_player->getPosition().x;
-    state.p1_y      = m_player->getPosition().y;
-    state.p2_x      = player2->getPosition().x;
-    state.p2_y      = player2->getPosition().y;
-    state.p1_score  = p2points;
-    state.p2_score  = points;
-    state.p1_left   = p1left;
-    state.p2_left   = p2left;
-    state.p1_scale_x = m_player->getScale().x;
-    state.p1_scale_y = m_player->getScale().y;
-    state.p2_scale_x = player2->getScale().x;
-    state.p2_scale_y = player2->getScale().y;
-    state.wait       = wait;
+    state.p1_x      = m_rocket->getPosition().x;
+    state.p1_y      = m_rocket->getPosition().y;
+    state.p2_x      = m_robot->getPosition().x;
+    state.p2_y      = m_robot->getPosition().y;
+    state.p1_score  = m_rocketScore;
+    state.p2_score  = m_robotScore;
+    state.p1_left   = m_p1FacingLeft;
+    state.p2_left   = m_p2FacingLeft;
+    state.p1_scale_x = m_rocket->getScale().x;
+    state.p1_scale_y = m_rocket->getScale().y;
+    state.p2_scale_x = m_robot->getScale().x;
+    state.p2_scale_y = m_robot->getScale().y;
+    state.wait       = m_inCooldown;
     return state;
 }
 
 void Game::applyNetworkState(const GameState& state)
 {
-    m_player->setPosition(state.p1_x, state.p1_y);
-    player2->setPosition(state.p2_x, state.p2_y);
-    p2points = state.p1_score;
-    points   = state.p2_score;
-    p1left   = state.p1_left;
-    p2left   = state.p2_left;
-    m_player->setScale(state.p1_scale_x, state.p1_scale_y);
-    player2->setScale(state.p2_scale_x, state.p2_scale_y);
-    wait = state.wait;
+    m_rocket->setPosition(state.p1_x, state.p1_y);
+    m_robot->setPosition(state.p2_x, state.p2_y);
+    m_rocketScore = state.p1_score;
+    m_robotScore   = state.p2_score;
+    m_p1FacingLeft   = state.p1_left;
+    m_p2FacingLeft   = state.p2_left;
+    m_rocket->setScale(state.p1_scale_x, state.p1_scale_y);
+    m_robot->setScale(state.p2_scale_x, state.p2_scale_y);
+    m_inCooldown = state.wait;
 }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -578,12 +578,12 @@ void Game::update(sf::Time deltaT, float time)
         speed_up.play();
     }
 
-    if ((m_up || m_down || m_left || m_right) & !collision(m_player, player2)) {
+    if ((m_up || m_down || m_left || m_right) && !collision(m_player, player2)) {
         m_player->move(p1movement * deltaT.asSeconds());
         m_player->update(time);
     }
 
-    if ((w || a || s || d) & !collision(m_player, player2)) {
+    if ((w || a || s || d) && !collision(m_player, player2)) {
         player2->move(p2movement * deltaT.asSeconds());
         player2->update(time);
     }

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -4,20 +4,19 @@
 
 // ── free functions ────────────────────────────────────────────────────────────
 
-void dispatchPacket(sf::Packet& pkt, sf::Time arrival,
-                    std::deque<TimedState>&  stateBuf,
-                    std::deque<PlayerInput>& inputQueue,
-                    std::size_t cap)
-{
+void dispatchPacket(sf::Packet& pkt, sf::Time arrival, std::deque<TimedState>& stateBuf,
+                    std::deque<PlayerInput>& inputQueue, std::size_t cap) {
     sf::Uint8 typeRaw = 0;
-    if (!(pkt >> typeRaw)) return;
+    if (!(pkt >> typeRaw))
+        return;
 
     switch (static_cast<MsgType>(typeRaw)) {
     case MsgType::State: {
         TimedState ts;
         ts.arrival = arrival;
         ts.state.fromPacket(pkt);
-        if (stateBuf.size() >= cap) stateBuf.pop_front();
+        if (stateBuf.size() >= cap)
+            stateBuf.pop_front();
         stateBuf.push_back(ts);
         break;
     }
@@ -30,8 +29,8 @@ void dispatchPacket(sf::Packet& pkt, sf::Time arrival,
     default: {
         static bool warned = false;
         if (!warned) {
-            std::cerr << "NetworkManager: unknown message type "
-                      << static_cast<int>(typeRaw) << " — discarding\n";
+            std::cerr << "NetworkManager: unknown message type " << static_cast<int>(typeRaw)
+                      << " — discarding\n";
             warned = true;
         }
         break;
@@ -39,8 +38,7 @@ void dispatchPacket(sf::Packet& pkt, sf::Time arrival,
     }
 }
 
-sf::Vector2f lerpPos(sf::Vector2f from, sf::Vector2f to, float t)
-{
+sf::Vector2f lerpPos(sf::Vector2f from, sf::Vector2f to, float t) {
     t = std::max(0.f, std::min(1.f, t));
     return from + (to - from) * t;
 }
@@ -50,16 +48,15 @@ sf::Vector2f lerpPos(sf::Vector2f from, sf::Vector2f to, float t)
 NetworkManager::NetworkManager() = default;
 NetworkManager::~NetworkManager() { disconnect(); }
 
-void NetworkManager::setDisconnected()
-{
+void NetworkManager::setDisconnected() {
     m_connected = false;
-    m_peerLeft  = true;
+    m_peerLeft = true;
 }
 
 // Try to send the pending packet; returns true when the slot is now clear.
-bool NetworkManager::flushSend()
-{
-    if (!m_hasPending) return true;
+bool NetworkManager::flushSend() {
+    if (!m_hasPending)
+        return true;
     auto status = m_socket.send(m_pendingSend);
     if (status == sf::Socket::Done) {
         m_hasPending = false;
@@ -74,8 +71,7 @@ bool NetworkManager::flushSend()
     return false;
 }
 
-bool NetworkManager::startHost(unsigned short port)
-{
+bool NetworkManager::startHost(unsigned short port) {
     m_isHost = true;
     m_listener.setBlocking(false);
     if (m_listener.listen(port) != sf::Socket::Done) {
@@ -87,9 +83,9 @@ bool NetworkManager::startHost(unsigned short port)
     return true;
 }
 
-bool NetworkManager::waitForClient(sf::Time timeout)
-{
-    if (!m_isHost || m_connected) return false; // already accepted; listener is closed
+bool NetworkManager::waitForClient(sf::Time timeout) {
+    if (!m_isHost || m_connected)
+        return false; // already accepted; listener is closed
     sf::Clock clock;
     while (timeout == sf::Time::Zero || clock.getElapsedTime() < timeout) {
         if (m_listener.accept(m_socket) == sf::Socket::Done) {
@@ -104,8 +100,7 @@ bool NetworkManager::waitForClient(sf::Time timeout)
     return false;
 }
 
-bool NetworkManager::connectToHost(const std::string& ip, unsigned short port)
-{
+bool NetworkManager::connectToHost(const std::string& ip, unsigned short port) {
     // Validate ip before doing any blocking work — bad input fails instantly.
     sf::IpAddress addr(ip);
     if (addr == sf::IpAddress::None) {
@@ -132,10 +127,11 @@ bool NetworkManager::connectToHost(const std::string& ip, unsigned short port)
     return true;
 }
 
-bool NetworkManager::sendInput(const PlayerInput& input)
-{
-    if (!m_connected) return false;
-    if (!flushSend()) return false; // pending slot still occupied — drop
+bool NetworkManager::sendInput(const PlayerInput& input) {
+    if (!m_connected)
+        return false;
+    if (!flushSend())
+        return false; // pending slot still occupied — drop
 
     m_pendingSend.clear();
     m_pendingSend << static_cast<sf::Uint8>(MsgType::Input);
@@ -144,10 +140,11 @@ bool NetworkManager::sendInput(const PlayerInput& input)
     return flushSend();
 }
 
-bool NetworkManager::sendGameState(const GameState& state)
-{
-    if (!m_connected) return false;
-    if (!flushSend()) return false;
+bool NetworkManager::sendGameState(const GameState& state) {
+    if (!m_connected)
+        return false;
+    if (!flushSend())
+        return false;
 
     m_pendingSend.clear();
     m_pendingSend << static_cast<sf::Uint8>(MsgType::State);
@@ -156,15 +153,14 @@ bool NetworkManager::sendGameState(const GameState& state)
     return flushSend();
 }
 
-void NetworkManager::poll()
-{
-    if (!m_connected) return;
+void NetworkManager::poll() {
+    if (!m_connected)
+        return;
     sf::Packet pkt;
     for (;;) {
         auto status = m_socket.receive(pkt);
         if (status == sf::Socket::Done) {
-            dispatchPacket(pkt, m_clock.getElapsedTime(),
-                           m_stateBuf, m_inputQueue, kStateBufCap);
+            dispatchPacket(pkt, m_clock.getElapsedTime(), m_stateBuf, m_inputQueue, kStateBufCap);
         } else if (status == sf::Socket::NotReady || status == sf::Socket::Partial) {
             // NotReady: no data yet.
             // Partial: SFML stores receive progress inside the socket; resume next poll().
@@ -176,20 +172,19 @@ void NetworkManager::poll()
     }
 }
 
-bool NetworkManager::nextInput(PlayerInput& input)
-{
-    if (m_inputQueue.empty()) return false;
+bool NetworkManager::nextInput(PlayerInput& input) {
+    if (m_inputQueue.empty())
+        return false;
     input = m_inputQueue.front();
     m_inputQueue.pop_front();
     return true;
 }
 
-void NetworkManager::disconnect()
-{
+void NetworkManager::disconnect() {
     m_socket.disconnect();
     m_listener.close();
-    m_connected  = false;
-    m_peerLeft   = false;
+    m_connected = false;
+    m_peerLeft = false;
     m_hasPending = false; // reset all transient state so a reused manager starts clean
     m_stateBuf.clear();
     m_inputQueue.clear();

--- a/src/RegularGameObject.cpp
+++ b/src/RegularGameObject.cpp
@@ -16,7 +16,7 @@ bool RegularGameObject::load(const std::string& filename) {
     return false;
 }
 
-void RegularGameObject::update(float deltaT) {}
+void RegularGameObject::update(float /*deltaT*/) {}
 
 void RegularGameObject::draw(sf::RenderWindow& window) {
     if (m_valid)

--- a/src/RegularGameObject.cpp
+++ b/src/RegularGameObject.cpp
@@ -4,79 +4,68 @@
 
 #include "RegularGameObject.h"
 
-RegularGameObject::RegularGameObject() {
-
-}
+RegularGameObject::RegularGameObject() {}
 
 bool RegularGameObject::load(const std::string& filename) {
-	if (m_texture.loadFromFile(filename)) {
-		m_filename = filename;
-		m_sprite.setTexture(m_texture);
-		m_valid = true;
-		return true;
-	}
-	return false;
+    if (m_texture.loadFromFile(filename)) {
+        m_filename = filename;
+        m_sprite.setTexture(m_texture);
+        m_valid = true;
+        return true;
+    }
+    return false;
 }
 
-void RegularGameObject::update(float deltaT) {
-
-}
+void RegularGameObject::update(float deltaT) {}
 
 void RegularGameObject::draw(sf::RenderWindow& window) {
-	if (m_valid)
-		window.draw(m_sprite);
+    if (m_valid)
+        window.draw(m_sprite);
 }
 
 void RegularGameObject::move(sf::Vector2f loc) {
-	if (m_valid)
-		m_sprite.move(loc);
+    if (m_valid)
+        m_sprite.move(loc);
 }
 
 void RegularGameObject::setPosition(float x, float y) {
-	if (m_valid)
-		m_sprite.setPosition(x, y);
+    if (m_valid)
+        m_sprite.setPosition(x, y);
 }
 
 sf::Vector2f RegularGameObject::getPosition() const {
-	if (m_valid)
-		return m_sprite.getPosition();
-	else
-		return sf::Vector2f(0, 0);
+    if (m_valid)
+        return m_sprite.getPosition();
+    else
+        return sf::Vector2f(0, 0);
 }
 
-float RegularGameObject::getHeight() const {
-	return m_sprite.getLocalBounds().height;
-}
+float RegularGameObject::getHeight() const { return m_sprite.getLocalBounds().height; }
 
-float RegularGameObject::getWidth() const {
-	return m_sprite.getLocalBounds().width;
-}
+float RegularGameObject::getWidth() const { return m_sprite.getLocalBounds().width; }
 
 void RegularGameObject::setScale(float scale) {
-	if (m_valid)
-		m_sprite.setScale(scale, scale);
+    if (m_valid)
+        m_sprite.setScale(scale, scale);
 }
 
-void RegularGameObject::setScale(float x,float y) {
+void RegularGameObject::setScale(float x, float y) {
     if (m_valid)
-        m_sprite.setScale(x,y);
+        m_sprite.setScale(x, y);
 }
 
 sf::Vector2f RegularGameObject::getScale() const {
-	if (m_valid)
-		return m_sprite.getScale();
-	else
-		return sf::Vector2f(0, 0);
+    if (m_valid)
+        return m_sprite.getScale();
+    else
+        return sf::Vector2f(0, 0);
 }
 
-void RegularGameObject::changeValid(bool a) {
-    m_valid = a;
-}
+void RegularGameObject::changeValid(bool a) { m_valid = a; }
 
-bool RegularGameObject::isValid() {
-    return m_valid;
-}
+bool RegularGameObject::isValid() { return m_valid; }
 
 void RegularGameObject::setOrigin() {
-    m_sprite.setOrigin((m_sprite.getLocalBounds().width) / 2, (m_sprite.getLocalBounds().height) / 2);
+    m_sprite.setOrigin((m_sprite.getLocalBounds().width) / 2,
+                       (m_sprite.getLocalBounds().height) / 2);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,14 +112,13 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
     bool start_updated = false;
     bool quit_updated = false;
 
-    GameObject *m_start = new AnimatedGameObject(1331, 300, 2, 1, 2, 0);
+    auto m_start = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
     m_start->load(resource_path + "start.png");
     m_start->setOrigin();
     m_start->setPosition((endscreen.getSize().x / 2),(endscreen.getSize().y / 3));
     m_start->setScale(.5f);
 
-
-    GameObject *m_quit = new AnimatedGameObject(1332, 300, 2, 1, 2, 0);
+    auto m_quit = std::make_unique<AnimatedGameObject>(1332, 300, 2, 1, 2, 0);
     m_quit->load(resource_path + "quit.png");
     m_quit->setOrigin();
     m_quit->setPosition((endscreen.getSize().x / 2), 2 * (endscreen.getSize().y / 3));
@@ -330,33 +329,33 @@ int main(int argc, char** argv)
     
     sf::RenderWindow startscreen(sf::VideoMode(1024, 576), "Dungeon Game");
     // Create button objects for main menu
-    GameObject* m_start = new AnimatedGameObject(1331, 300, 2,1,2,0);
+    auto m_start = std::make_unique<AnimatedGameObject>(1331, 300, 2,1,2,0);
     m_start->load(resource_path + "start.png");
     m_start->setOrigin();
     m_start->setPosition(startscreen.getSize().x/2, 200);
     m_start->setScale(.4f);
 
     // Create host and join buttons (will use text labels with start button image)
-    GameObject* m_host = new AnimatedGameObject(1331, 300, 2,1,2,0);
+    auto m_host = std::make_unique<AnimatedGameObject>(1331, 300, 2,1,2,0);
     m_host->load(resource_path + "start.png");
     m_host->setOrigin();
     m_host->setPosition(startscreen.getSize().x/2, 320);
     m_host->setScale(.4f);
 
-    GameObject* m_join = new AnimatedGameObject(1331, 300, 2,1,2,0);
+    auto m_join = std::make_unique<AnimatedGameObject>(1331, 300, 2,1,2,0);
     m_join->load(resource_path + "start.png");
     m_join->setOrigin();
     m_join->setPosition(startscreen.getSize().x/2, 440);
     m_join->setScale(.4f);
 
-    GameObject* m_quit = new AnimatedGameObject(1332, 300, 2,1,2,0);
+    auto m_quit = std::make_unique<AnimatedGameObject>(1332, 300, 2,1,2,0);
     m_quit->load(resource_path+"quit.png");
     m_quit->setOrigin();
     m_quit->setPosition((startscreen.getSize().x/2), 520);
     m_quit->setScale(.3f);
-    
+
     // Back button (using quit button graphics)
-    GameObject* m_back = new AnimatedGameObject(1332, 300, 2,1,2,0);
+    auto m_back = std::make_unique<AnimatedGameObject>(1332, 300, 2,1,2,0);
     m_back->load(resource_path+"quit.png");
     m_back->setOrigin();
     m_back->setPosition(100, 50);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include "NetworkManager.h"
 #include <iostream>
 #include "AnimatedGameObject.h"
+#include "asset_load.h"
 #include "resource_path.h"
 #include "debug.h"
 #include "rng.h"
@@ -44,16 +45,11 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
     sf::Text highscoret;
 
     RegularGameObject wall = RegularGameObject();
-    wall.load(resource_path + "david_background.png");
+    loadOrThrow(wall, resource_path + "david_background.png");
     wall.setScale(.7f);
 
-    if(!pfont.loadFromFile(resource_path + "Joyful_Theatre.otf")){
-        std::cout << "Font did not load" << std::endl;
-    }
-
-    if(!tfont.loadFromFile(resource_path + "timer.ttf")){
-        std::cout << "Font did not load" << std::endl;
-    }
+    loadOrThrow(pfont, resource_path + "Joyful_Theatre.otf");
+    loadOrThrow(tfont, resource_path + "timer.ttf");
 
     sf::RenderWindow endscreen(sf::VideoMode(1024, 576), "end game");
 
@@ -68,9 +64,7 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
     }
 
     sf::Music background;
-    if (!background.openFromFile(resource_path + "m_start_background.wav")) {
-        std::cout << "your music is broken, go fix it" << std::endl;
-    }
+    loadOrThrow(background, resource_path + "m_start_background.wav");
 
     p1scoret = sf::Text(std::to_string(p1score), pfont, 50);
     p1scoret.setFillColor(sf::Color::Blue);
@@ -97,12 +91,8 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
 
     sf::SoundBuffer down_buffer;
     sf::SoundBuffer up_buffer;
-    if (!down_buffer.loadFromFile(resource_path + "ButtonOn.wav")) {
-        std::cout << "sound did not load";
-    }
-    if (!up_buffer.loadFromFile(resource_path + "ButtonOff.wav")) {
-        std::cout << "sound did not load";
-    }
+    loadOrThrow(down_buffer, resource_path + "ButtonOn.wav");
+    loadOrThrow(up_buffer,   resource_path + "ButtonOff.wav");
 
     sf::Sound press;
     sf::Sound up;
@@ -113,13 +103,13 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
     bool quit_updated = false;
 
     auto m_start = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
-    m_start->load(resource_path + "start.png");
+    loadOrThrow(*m_start, resource_path + "start.png");
     m_start->setOrigin();
     m_start->setPosition((endscreen.getSize().x / 2),(endscreen.getSize().y / 3));
     m_start->setScale(.5f);
 
     auto m_quit = std::make_unique<AnimatedGameObject>(1332, 300, 2, 1, 2, 0);
-    m_quit->load(resource_path + "quit.png");
+    loadOrThrow(*m_quit, resource_path + "quit.png");
     m_quit->setOrigin();
     m_quit->setPosition((endscreen.getSize().x / 2), 2 * (endscreen.getSize().y / 3));
     m_quit->setScale(.5f);
@@ -211,6 +201,7 @@ enum MenuState {
 
 int main(int argc, char** argv)
 {
+  try {
     initResourcePath(argv[0]);
 
     int highscore = 0;
@@ -290,12 +281,10 @@ int main(int argc, char** argv)
 
     // Load resources
     RegularGameObject david = RegularGameObject();
-    david.load(resource_path + "david_background.png");
+    loadOrThrow(david, resource_path + "david_background.png");
 
     sf::Music background;
-    if(!background.openFromFile(resource_path + "m_start_background.wav")){
-        std::cout << "your music is broken, go fix it" << std::endl;
-    }
+    loadOrThrow(background, resource_path + "m_start_background.wav");
 
     background.play();
     background.setVolume(60);
@@ -303,12 +292,8 @@ int main(int argc, char** argv)
 
     sf::SoundBuffer down_buffer;
     sf::SoundBuffer up_buffer;
-    if(!down_buffer.loadFromFile(resource_path + "ButtonOn.wav")) {
-        std::cout << "sound did not load";
-    }
-    if(!up_buffer.loadFromFile(resource_path + "ButtonOff.wav")) {
-        std::cout << "sound did not load";
-    }
+    loadOrThrow(down_buffer, resource_path + "ButtonOn.wav");
+    loadOrThrow(up_buffer,   resource_path + "ButtonOff.wav");
 
     sf::Sound press;
     sf::Sound up;
@@ -317,9 +302,7 @@ int main(int argc, char** argv)
 
     // Load font for UI text
     sf::Font font;
-    if(!font.loadFromFile(resource_path + "oswald.ttf")){
-        std::cout << "Font did not load" << std::endl;
-    }
+    loadOrThrow(font, resource_path + "oswald.ttf");
 
     bool start_updated = false;
     bool quit_updated = false;
@@ -330,33 +313,33 @@ int main(int argc, char** argv)
     sf::RenderWindow startscreen(sf::VideoMode(1024, 576), "Dungeon Game");
     // Create button objects for main menu
     auto m_start = std::make_unique<AnimatedGameObject>(1331, 300, 2,1,2,0);
-    m_start->load(resource_path + "start.png");
+    loadOrThrow(*m_start, resource_path + "start.png");
     m_start->setOrigin();
     m_start->setPosition(startscreen.getSize().x/2, 200);
     m_start->setScale(.4f);
 
     // Create host and join buttons (will use text labels with start button image)
     auto m_host = std::make_unique<AnimatedGameObject>(1331, 300, 2,1,2,0);
-    m_host->load(resource_path + "start.png");
+    loadOrThrow(*m_host, resource_path + "start.png");
     m_host->setOrigin();
     m_host->setPosition(startscreen.getSize().x/2, 320);
     m_host->setScale(.4f);
 
     auto m_join = std::make_unique<AnimatedGameObject>(1331, 300, 2,1,2,0);
-    m_join->load(resource_path + "start.png");
+    loadOrThrow(*m_join, resource_path + "start.png");
     m_join->setOrigin();
     m_join->setPosition(startscreen.getSize().x/2, 440);
     m_join->setScale(.4f);
 
     auto m_quit = std::make_unique<AnimatedGameObject>(1332, 300, 2,1,2,0);
-    m_quit->load(resource_path+"quit.png");
+    loadOrThrow(*m_quit, resource_path + "quit.png");
     m_quit->setOrigin();
     m_quit->setPosition((startscreen.getSize().x/2), 520);
     m_quit->setScale(.3f);
 
     // Back button (using quit button graphics)
     auto m_back = std::make_unique<AnimatedGameObject>(1332, 300, 2,1,2,0);
-    m_back->load(resource_path+"quit.png");
+    loadOrThrow(*m_back, resource_path + "quit.png");
     m_back->setOrigin();
     m_back->setPosition(100, 50);
     m_back->setScale(.25f);
@@ -694,4 +677,8 @@ int main(int argc, char** argv)
     
     background.stop();
     return 0;
+  } catch (const std::exception& e) {
+    std::cerr << e.what() << '\n';
+    return 1;
+  }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
     bool peerLeft = std::get<5>(tuple);
     char gTime [10];
     std::snprintf(gTime, sizeof(gTime), "%02.0f:%02d", tempM, tempS);
-    std::string clack = gTime;
+    std::string finalTime = gTime;
 
     if (p1score > highscore )
         highscore = p1score;
@@ -41,7 +41,7 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
     sf::Font pfont;
     sf::Text p1scoret;
     sf::Text p2scoret;
-    sf::Text clackt;
+    sf::Text finalTimet;
     sf::Text highscoret;
 
     RegularGameObject wall = RegularGameObject();
@@ -70,15 +70,15 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
     p1scoret.setFillColor(sf::Color::Blue);
     p2scoret = sf::Text(std::to_string(p2score), pfont, 50);
     p2scoret.setFillColor(sf::Color::Green);
-    clackt = sf::Text(clack, tfont, 50);
-    clackt.setFillColor(sf::Color::Blue);
+    finalTimet = sf::Text(finalTime, tfont, 50);
+    finalTimet.setFillColor(sf::Color::Blue);
 
     highscoret = sf::Text(std::to_string(highscore), pfont,70);
 
 
     p1scoret.setPosition(5,endscreen.getSize().y/2);
     p2scoret.setPosition(endscreen.getSize().x-(p1scoret.getGlobalBounds().width)-5,endscreen.getSize().y/2);
-    clackt.setPosition(endscreen.getSize().x/2 - clackt.getGlobalBounds().width+20,-10);
+    finalTimet.setPosition(endscreen.getSize().x/2 - finalTimet.getGlobalBounds().width+20,-10);
     highscoret.setPosition(endscreen.getSize().x/2 - highscoret.getGlobalBounds().width,25);
 
     if (p1score == highscore )
@@ -120,7 +120,7 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
         wall.draw(endscreen);
         endscreen.draw(p1scoret);
         endscreen.draw(p2scoret);
-        endscreen.draw(clackt);
+        endscreen.draw(finalTimet);
         endscreen.draw(highscoret);
         m_start->draw(endscreen);
         m_quit->draw(endscreen);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,3 @@
-//#pragma once
 #include <SFML/Graphics.hpp>
 #include "Game.h"
 #include "NetworkManager.h"
@@ -28,7 +27,6 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
     float tempM = std::get<2>(tuple);
     int tempS = std::get<3>(tuple);
     bool peerLeft = std::get<5>(tuple);
-    //bool p1win = std::get<4>(tuple);
     char gTime [10];
     std::snprintf(gTime, sizeof(gTime), "%02.0f:%02d", tempM, tempS);
     std::string clack = gTime;
@@ -58,7 +56,6 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
     }
 
     sf::RenderWindow endscreen(sf::VideoMode(1024, 576), "end game");
-    sf::Event event;
 
     sf::Text peerDisconnectedText("", pfont, 36);
     if (peerLeft) {
@@ -97,7 +94,6 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
 
     background.play();
     background.setVolume(60);
-    //background.setLoop(true);
 
     sf::SoundBuffer down_buffer;
     sf::SoundBuffer up_buffer;
@@ -143,9 +139,7 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
         endscreen.display();
 
         sf::Event event;
-        sf::Mouse mouse;
         sf::Rect<float> srect;
-        // m_start->setOrigin();
         srect = sf::Rect<float>(sf::Vector2f(m_start->getPosition().x - (m_start->getWidth() / 4),
                                              m_start->getPosition().y - (m_start->getHeight() / 4)),
                                 sf::Vector2f(m_start->getWidth() * m_start->getScale().x,
@@ -166,7 +160,6 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
                                                 sf::Vector2f(m_quit->getWidth() * m_quit->getScale().x,
                                                              m_quit->getHeight() * m_quit->getScale().y));
 
-        //std::cout << (qrect.contains(endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen)))) << std::endl;
         if (qrect.contains(endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen))) && !quit_updated) {
             m_quit->update(0.0f);
             quit_updated = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,21 +1,22 @@
-#include <SFML/Graphics.hpp>
+#include "AnimatedGameObject.h"
 #include "Game.h"
 #include "NetworkManager.h"
-#include <iostream>
-#include "AnimatedGameObject.h"
 #include "asset_load.h"
-#include "resource_path.h"
 #include "debug.h"
+#include "resource_path.h"
 #include "rng.h"
-#include <filesystem>
-#include <tuple>
+#include <SFML/Graphics.hpp>
 #include <cstdio>
+#include <filesystem>
+#include <iostream>
 #include <memory>
-#include <string>
 #include <stdexcept>
+#include <string>
+#include <tuple>
 
-void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::shared_ptr<NetworkManager> netManager = nullptr) {
-    std::tuple<int,int,float,int,bool,bool> tuple;
+void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL,
+               std::shared_ptr<NetworkManager> netManager = nullptr) {
+    std::tuple<int, int, float, int, bool, bool> tuple;
     if (mode != NetworkMode::LOCAL && netManager) {
         Game game(mode, netManager);
         tuple = game.run();
@@ -28,11 +29,11 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
     float tempM = std::get<2>(tuple);
     int tempS = std::get<3>(tuple);
     bool peerLeft = std::get<5>(tuple);
-    char gTime [10];
+    char gTime[10];
     std::snprintf(gTime, sizeof(gTime), "%02.0f:%02d", tempM, tempS);
     std::string finalTime = gTime;
 
-    if (p1score > highscore )
+    if (p1score > highscore)
         highscore = p1score;
     if (p2score > highscore)
         highscore = p2score;
@@ -73,15 +74,16 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
     finalTimet = sf::Text(finalTime, tfont, 50);
     finalTimet.setFillColor(sf::Color::Blue);
 
-    highscoret = sf::Text(std::to_string(highscore), pfont,70);
+    highscoret = sf::Text(std::to_string(highscore), pfont, 70);
 
+    p1scoret.setPosition(5, endscreen.getSize().y / 2);
+    p2scoret.setPosition(endscreen.getSize().x - (p1scoret.getGlobalBounds().width) - 5,
+                         endscreen.getSize().y / 2);
+    finalTimet.setPosition(endscreen.getSize().x / 2 - finalTimet.getGlobalBounds().width + 20,
+                           -10);
+    highscoret.setPosition(endscreen.getSize().x / 2 - highscoret.getGlobalBounds().width, 25);
 
-    p1scoret.setPosition(5,endscreen.getSize().y/2);
-    p2scoret.setPosition(endscreen.getSize().x-(p1scoret.getGlobalBounds().width)-5,endscreen.getSize().y/2);
-    finalTimet.setPosition(endscreen.getSize().x/2 - finalTimet.getGlobalBounds().width+20,-10);
-    highscoret.setPosition(endscreen.getSize().x/2 - highscoret.getGlobalBounds().width,25);
-
-    if (p1score == highscore )
+    if (p1score == highscore)
         highscoret.setFillColor(sf::Color::Blue);
     if (p2score == highscore)
         highscoret.setFillColor(sf::Color::Green);
@@ -92,7 +94,7 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
     sf::SoundBuffer down_buffer;
     sf::SoundBuffer up_buffer;
     loadOrThrow(down_buffer, resource_path + "ButtonOn.wav");
-    loadOrThrow(up_buffer,   resource_path + "ButtonOff.wav");
+    loadOrThrow(up_buffer, resource_path + "ButtonOff.wav");
 
     sf::Sound press;
     sf::Sound up;
@@ -105,7 +107,7 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
     auto m_start = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
     loadOrThrow(*m_start, resource_path + "start.png");
     m_start->setOrigin();
-    m_start->setPosition((endscreen.getSize().x / 2),(endscreen.getSize().y / 3));
+    m_start->setPosition((endscreen.getSize().x / 2), (endscreen.getSize().y / 3));
     m_start->setScale(.5f);
 
     auto m_quit = std::make_unique<AnimatedGameObject>(1332, 300, 2, 1, 2, 0);
@@ -124,7 +126,8 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
         endscreen.draw(highscoret);
         m_start->draw(endscreen);
         m_quit->draw(endscreen);
-        if (peerLeft) endscreen.draw(peerDisconnectedText);
+        if (peerLeft)
+            endscreen.draw(peerDisconnectedText);
         endscreen.display();
 
         sf::Event event;
@@ -133,7 +136,8 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
                                              m_start->getPosition().y - (m_start->getHeight() / 4)),
                                 sf::Vector2f(m_start->getWidth() * m_start->getScale().x,
                                              m_start->getHeight() * m_start->getScale().y));
-        if (srect.contains(endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen))) && !start_updated) {
+        if (srect.contains(endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen))) &&
+            !start_updated) {
             m_start->update(0.0f);
             start_updated = true;
             press.play();
@@ -144,16 +148,19 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
             up.play();
         }
 
-        sf::Rect<float> qrect = sf::Rect<float>(sf::Vector2f(m_quit->getPosition().x - (m_quit->getWidth() / 4),
-                                                             m_quit->getPosition().y - (m_quit->getHeight() / 4)),
-                                                sf::Vector2f(m_quit->getWidth() * m_quit->getScale().x,
-                                                             m_quit->getHeight() * m_quit->getScale().y));
+        sf::Rect<float> qrect =
+            sf::Rect<float>(sf::Vector2f(m_quit->getPosition().x - (m_quit->getWidth() / 4),
+                                         m_quit->getPosition().y - (m_quit->getHeight() / 4)),
+                            sf::Vector2f(m_quit->getWidth() * m_quit->getScale().x,
+                                         m_quit->getHeight() * m_quit->getScale().y));
 
-        if (qrect.contains(endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen))) && !quit_updated) {
+        if (qrect.contains(endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen))) &&
+            !quit_updated) {
             m_quit->update(0.0f);
             quit_updated = true;
             press.play();
-        } else if (!qrect.contains(endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen))) && quit_updated) {
+        } else if (!qrect.contains(endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen))) &&
+                   quit_updated) {
             quit_updated = false;
             m_quit->update(0.0f);
             up.play();
@@ -171,514 +178,511 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL, std::share
             endscreen.close();
         }
 
-
-            while (endscreen.pollEvent(event)) {
-                if (event.type == sf::Event::Closed){
+        while (endscreen.pollEvent(event)) {
+            if (event.type == sf::Event::Closed) {
+                background.stop();
+                endscreen.close();
+            }
+            if (event.type == sf::Event::KeyPressed) {
+                if (event.key.code == sf::Keyboard::Y) {
+                    background.stop();
+                    endscreen.close();
+                    startgame(highscore, mode, netManager);
+                }
+                if (event.key.code == sf::Keyboard::N) {
                     background.stop();
                     endscreen.close();
                 }
-                if (event.type == sf::Event::KeyPressed) {
-                    if (event.key.code == sf::Keyboard::Y) {
-                        background.stop();
-                        endscreen.close();
-                        startgame(highscore, mode, netManager);
-                    }
-                    if (event.key.code == sf::Keyboard::N) {
-                        background.stop();
-                        endscreen.close();
-                    }
-                }
             }
         }
+    }
 }
 
-enum MenuState {
-    MAIN_MENU,
-    HOST_WAITING,
-    JOIN_INPUT,
-    READY_TO_START
-};
+enum MenuState { MAIN_MENU, HOST_WAITING, JOIN_INPUT, READY_TO_START };
 
-int main(int argc, char** argv)
-{
-  try {
-    initResourcePath(argv[0]);
+int main(int argc, char** argv) {
+    try {
+        initResourcePath(argv[0]);
 
-    int highscore = 0;
+        int highscore = 0;
 
-    // ── CLI parsing ───────────────────────────────────────────────────────────
-    DebugConfig  config;
-    unsigned     seed     = 0;
-    bool         haveSeed = false;
+        // ── CLI parsing ───────────────────────────────────────────────────────────
+        DebugConfig config;
+        unsigned seed = 0;
+        bool haveSeed = false;
 
-    auto needValue = [&](const std::string& flag, int& i) -> const char* {
-        if (i + 1 >= argc) throw std::runtime_error(flag + " requires a value");
-        return argv[++i];
-    };
-    for (int i = 1; i < argc; ++i) {
-        std::string arg(argv[i]);
-        try {
-            if (arg == "--frames") {
-                config.frames = std::stoi(needValue(arg, i));
-            } else if (arg == "--replay") {
-                config.replayPath = needValue(arg, i);
-            } else if (arg == "--replay-p1") {
-                config.replayPathP1 = needValue(arg, i);
-            } else if (arg == "--screenshot-every") {
-                config.screenshotEvery = std::stoi(needValue(arg, i));
-            } else if (arg == "--screenshot-dir") {
-                config.screenshotDir = needValue(arg, i);
-            } else if (arg == "--seed") {
-                seed     = static_cast<unsigned>(std::stoul(needValue(arg, i)));
-                haveSeed = true;
-            } else if (arg == "--help") {
-                std::cout
-                    << "Usage: dungeon_game [options]\n"
-                    << "  --frames N             Run N sim steps then exit\n"
-                    << "  --replay <file>        Drive P2 (robot) from replay file\n"
-                    << "  --replay-p1 <file>     Drive P1 (rocket) from replay file\n"
-                    << "  --screenshot-every N   Save screenshot every N steps\n"
-                    << "  --screenshot-dir <d>   Directory for screenshots (default: .)\n"
-                    << "  --seed <n>             Seed the RNG\n"
-                    << "\n"
-                    << "Replay format: one line per step — 'up down left right attack' (0 or 1)\n"
-                    << "  Everything from '#' to end-of-line is ignored; blank lines skipped.\n";
-                return 0;
-            } else {
-                std::cerr << "Error: unknown option '" << arg << "' (try --help)\n";
+        auto needValue = [&](const std::string& flag, int& i) -> const char* {
+            if (i + 1 >= argc)
+                throw std::runtime_error(flag + " requires a value");
+            return argv[++i];
+        };
+        for (int i = 1; i < argc; ++i) {
+            std::string arg(argv[i]);
+            try {
+                if (arg == "--frames") {
+                    config.frames = std::stoi(needValue(arg, i));
+                } else if (arg == "--replay") {
+                    config.replayPath = needValue(arg, i);
+                } else if (arg == "--replay-p1") {
+                    config.replayPathP1 = needValue(arg, i);
+                } else if (arg == "--screenshot-every") {
+                    config.screenshotEvery = std::stoi(needValue(arg, i));
+                } else if (arg == "--screenshot-dir") {
+                    config.screenshotDir = needValue(arg, i);
+                } else if (arg == "--seed") {
+                    seed = static_cast<unsigned>(std::stoul(needValue(arg, i)));
+                    haveSeed = true;
+                } else if (arg == "--help") {
+                    std::cout << "Usage: dungeon_game [options]\n"
+                              << "  --frames N             Run N sim steps then exit\n"
+                              << "  --replay <file>        Drive P2 (robot) from replay file\n"
+                              << "  --replay-p1 <file>     Drive P1 (rocket) from replay file\n"
+                              << "  --screenshot-every N   Save screenshot every N steps\n"
+                              << "  --screenshot-dir <d>   Directory for screenshots (default: .)\n"
+                              << "  --seed <n>             Seed the RNG\n"
+                              << "\n"
+                              << "Replay format: one line per step — 'up down left right attack' "
+                                 "(0 or 1)\n"
+                              << "  Everything from '#' to end-of-line is ignored; blank lines "
+                                 "skipped.\n";
+                    return 0;
+                } else {
+                    std::cerr << "Error: unknown option '" << arg << "' (try --help)\n";
+                    return 1;
+                }
+            } catch (const std::exception& e) {
+                std::cerr << "Error: " << e.what() << " (option '" << arg << "')\n";
                 return 1;
             }
-        } catch (const std::exception& e) {
-            std::cerr << "Error: " << e.what() << " (option '" << arg << "')\n";
-            return 1;
-        }
-    }
-
-    // ── Debug / harness bypass ────────────────────────────────────────────────
-    if (config.active()) {
-        if (haveSeed)
-            rng::seed(seed);
-        if (config.screenshotEvery > 0)
-            std::filesystem::create_directories(config.screenshotDir);
-
-        Game game;
-        game.setDebugConfig(config);
-        auto result = game.run();
-
-        std::cout << "P1 score: " << std::get<0>(result) << "\n"
-                  << "P2 score: " << std::get<1>(result) << "\n"
-                  << "Steps:    " << game.steps() << "\n";
-        return 0;
-    }
-
-    // ── Normal menu flow (unchanged) ──────────────────────────────────────────
-    MenuState menuState = MAIN_MENU;
-    NetworkMode mode = NetworkMode::LOCAL;
-    std::shared_ptr<NetworkManager> netManager = nullptr;
-    std::string ipInput = "127.0.0.1";
-    std::string statusMessage = "";
-    std::string hostIpAddress = "";
-
-    // Load resources
-    RegularGameObject david = RegularGameObject();
-    loadOrThrow(david, resource_path + "david_background.png");
-
-    sf::Music background;
-    loadOrThrow(background, resource_path + "m_start_background.wav");
-
-    background.play();
-    background.setVolume(60);
-    background.setLoop(true);
-
-    sf::SoundBuffer down_buffer;
-    sf::SoundBuffer up_buffer;
-    loadOrThrow(down_buffer, resource_path + "ButtonOn.wav");
-    loadOrThrow(up_buffer,   resource_path + "ButtonOff.wav");
-
-    sf::Sound press;
-    sf::Sound up;
-    press.setBuffer(down_buffer);
-    up.setBuffer(up_buffer);
-
-    // Load font for UI text
-    sf::Font font;
-    loadOrThrow(font, resource_path + "oswald.ttf");
-
-    bool start_updated = false;
-    bool quit_updated = false;
-    bool host_updated = false;
-    bool join_updated = false;
-    bool back_updated = false;
-    
-    sf::RenderWindow startscreen(sf::VideoMode(1024, 576), "Dungeon Game");
-    // Create button objects for main menu
-    auto m_start = std::make_unique<AnimatedGameObject>(1331, 300, 2,1,2,0);
-    loadOrThrow(*m_start, resource_path + "start.png");
-    m_start->setOrigin();
-    m_start->setPosition(startscreen.getSize().x/2, 200);
-    m_start->setScale(.4f);
-
-    // Create host and join buttons (will use text labels with start button image)
-    auto m_host = std::make_unique<AnimatedGameObject>(1331, 300, 2,1,2,0);
-    loadOrThrow(*m_host, resource_path + "start.png");
-    m_host->setOrigin();
-    m_host->setPosition(startscreen.getSize().x/2, 320);
-    m_host->setScale(.4f);
-
-    auto m_join = std::make_unique<AnimatedGameObject>(1331, 300, 2,1,2,0);
-    loadOrThrow(*m_join, resource_path + "start.png");
-    m_join->setOrigin();
-    m_join->setPosition(startscreen.getSize().x/2, 440);
-    m_join->setScale(.4f);
-
-    auto m_quit = std::make_unique<AnimatedGameObject>(1332, 300, 2,1,2,0);
-    loadOrThrow(*m_quit, resource_path + "quit.png");
-    m_quit->setOrigin();
-    m_quit->setPosition((startscreen.getSize().x/2), 520);
-    m_quit->setScale(.3f);
-
-    // Back button (using quit button graphics)
-    auto m_back = std::make_unique<AnimatedGameObject>(1332, 300, 2,1,2,0);
-    loadOrThrow(*m_back, resource_path + "quit.png");
-    m_back->setOrigin();
-    m_back->setPosition(100, 50);
-    m_back->setScale(.25f);
-
-    // Text labels for buttons
-    sf::Text localLabel("LOCAL", font, 40);
-    localLabel.setFillColor(sf::Color::White);
-    localLabel.setStyle(sf::Text::Bold);
-    
-    sf::Text hostLabel("HOST", font, 40);
-    hostLabel.setFillColor(sf::Color::Green);
-    hostLabel.setStyle(sf::Text::Bold);
-    
-    sf::Text joinLabel("JOIN", font, 40);
-    joinLabel.setFillColor(sf::Color::Blue);
-    joinLabel.setStyle(sf::Text::Bold);
-    
-    sf::Text backLabel("BACK", font, 20);
-    backLabel.setFillColor(sf::Color::White);
-
-    while (startscreen.isOpen()) {
-        sf::Event event;
-        while (startscreen.pollEvent(event)) {
-            if (event.type == sf::Event::Closed) {
-                background.stop();
-                startscreen.close();
-            }
-            
-            // Handle text input for IP address in JOIN_INPUT state
-            if (menuState == JOIN_INPUT && event.type == sf::Event::TextEntered) {
-                if (event.text.unicode == '\b' && !ipInput.empty()) {
-                    ipInput.pop_back();
-                } else if (event.text.unicode == '\r' || event.text.unicode == '\n') {
-                    // Try to connect
-                    netManager = std::make_shared<NetworkManager>();
-                    statusMessage = "Connecting...";
-                    
-                    if (netManager->connectToHost(ipInput)) {
-                        mode = NetworkMode::CLIENT;
-                        menuState = READY_TO_START;
-                        statusMessage = "Connected! Click START to begin";
-                    } else {
-                        statusMessage = "Failed to connect (invalid IP or host unreachable)";
-                        netManager = nullptr;
-                    }
-                } else if (event.text.unicode < 128 && event.text.unicode != '\b' && ipInput.length() < 30) {
-                    char c = static_cast<char>(event.text.unicode);
-                    // Allow only valid IP characters
-                    if ((c >= '0' && c <= '9') || c == '.' || c == ':') {
-                        ipInput += c;
-                    }
-                }
-            }
         }
 
-        // Get mouse position
-        sf::Vector2f mousePos = startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen));
-        
-        // Define button rectangles
-        sf::Rect<float> startRect(m_start->getPosition().x - (m_start->getWidth()/4), 
-                                   m_start->getPosition().y - (m_start->getHeight()/4),
-                                   m_start->getWidth() * m_start->getScale().x, 
-                                   m_start->getHeight() * m_start->getScale().y);
-        
-        sf::Rect<float> hostRect(m_host->getPosition().x - (m_host->getWidth()/4),
-                                  m_host->getPosition().y - (m_host->getHeight()/4),
-                                  m_host->getWidth() * m_host->getScale().x,
-                                  m_host->getHeight() * m_host->getScale().y);
-        
-        sf::Rect<float> joinRect(m_join->getPosition().x - (m_join->getWidth()/4),
-                                  m_join->getPosition().y - (m_join->getHeight()/4),
-                                  m_join->getWidth() * m_join->getScale().x,
-                                  m_join->getHeight() * m_join->getScale().y);
-        
-        sf::Rect<float> quitRect(m_quit->getPosition().x - (m_quit->getWidth()/4),
-                                  m_quit->getPosition().y - (m_quit->getHeight()/4),
-                                  m_quit->getWidth() * m_quit->getScale().x,
-                                  m_quit->getHeight() * m_quit->getScale().y);
-        
-        sf::Rect<float> backRect(m_back->getPosition().x - (m_back->getWidth()/4),
-                                  m_back->getPosition().y - (m_back->getHeight()/4),
-                                  m_back->getWidth() * m_back->getScale().x,
-                                  m_back->getHeight() * m_back->getScale().y);
+        // ── Debug / harness bypass ────────────────────────────────────────────────
+        if (config.active()) {
+            if (haveSeed)
+                rng::seed(seed);
+            if (config.screenshotEvery > 0)
+                std::filesystem::create_directories(config.screenshotDir);
 
-        // Handle menu state logic
-        if (menuState == MAIN_MENU) {
-            // Start button hover
-            if (startRect.contains(mousePos) && !start_updated) {
-                m_start->update(0.0f);
-                start_updated = true;
-                press.play();
-            } else if (!startRect.contains(mousePos) && start_updated) {
-                start_updated = false;
-                m_start->update(0.0f);
-                up.play();
-            }
-            
-            // Host button hover
-            if (hostRect.contains(mousePos) && !host_updated) {
-                m_host->update(0.0f);
-                host_updated = true;
-                press.play();
-            } else if (!hostRect.contains(mousePos) && host_updated) {
-                host_updated = false;
-                m_host->update(0.0f);
-                up.play();
-            }
-            
-            // Join button hover
-            if (joinRect.contains(mousePos) && !join_updated) {
-                m_join->update(0.0f);
-                join_updated = true;
-                press.play();
-            } else if (!joinRect.contains(mousePos) && join_updated) {
-                join_updated = false;
-                m_join->update(0.0f);
-                up.play();
-            }
-            
-            // Quit button hover
-            if (quitRect.contains(mousePos) && !quit_updated) {
-                m_quit->update(0.0f);
-                quit_updated = true;
-                press.play();
-            } else if (!quitRect.contains(mousePos) && quit_updated) {
-                quit_updated = false;
-                m_quit->update(0.0f);
-                up.play();
-            }
-            
-            // Handle clicks
-            if (sf::Mouse::isButtonPressed(sf::Mouse::Left)) {
-                if (startRect.contains(mousePos)) {
-                    mode = NetworkMode::LOCAL;
-                    menuState = READY_TO_START;
-                    sf::sleep(sf::milliseconds(200)); // Prevent double-click
-                } else if (hostRect.contains(mousePos)) {
-                    netManager = std::make_shared<NetworkManager>();
-                    if (netManager->startHost()) {
-                        mode = NetworkMode::HOST;
-                        menuState = HOST_WAITING;
-                        hostIpAddress = sf::IpAddress::getLocalAddress().toString();
-                        statusMessage = "Waiting for player 2...";
-                    } else {
-                        statusMessage = "Failed to start host!";
-                        netManager = nullptr;
-                    }
-                    sf::sleep(sf::milliseconds(200));
-                } else if (joinRect.contains(mousePos)) {
-                    menuState = JOIN_INPUT;
-                    statusMessage = "Enter host IP address";
-                    sf::sleep(sf::milliseconds(200));
-                } else if (quitRect.contains(mousePos)) {
+            Game game;
+            game.setDebugConfig(config);
+            auto result = game.run();
+
+            std::cout << "P1 score: " << std::get<0>(result) << "\n"
+                      << "P2 score: " << std::get<1>(result) << "\n"
+                      << "Steps:    " << game.steps() << "\n";
+            return 0;
+        }
+
+        // ── Normal menu flow (unchanged) ──────────────────────────────────────────
+        MenuState menuState = MAIN_MENU;
+        NetworkMode mode = NetworkMode::LOCAL;
+        std::shared_ptr<NetworkManager> netManager = nullptr;
+        std::string ipInput = "127.0.0.1";
+        std::string statusMessage = "";
+        std::string hostIpAddress = "";
+
+        // Load resources
+        RegularGameObject david = RegularGameObject();
+        loadOrThrow(david, resource_path + "david_background.png");
+
+        sf::Music background;
+        loadOrThrow(background, resource_path + "m_start_background.wav");
+
+        background.play();
+        background.setVolume(60);
+        background.setLoop(true);
+
+        sf::SoundBuffer down_buffer;
+        sf::SoundBuffer up_buffer;
+        loadOrThrow(down_buffer, resource_path + "ButtonOn.wav");
+        loadOrThrow(up_buffer, resource_path + "ButtonOff.wav");
+
+        sf::Sound press;
+        sf::Sound up;
+        press.setBuffer(down_buffer);
+        up.setBuffer(up_buffer);
+
+        // Load font for UI text
+        sf::Font font;
+        loadOrThrow(font, resource_path + "oswald.ttf");
+
+        bool start_updated = false;
+        bool quit_updated = false;
+        bool host_updated = false;
+        bool join_updated = false;
+        bool back_updated = false;
+
+        sf::RenderWindow startscreen(sf::VideoMode(1024, 576), "Dungeon Game");
+        // Create button objects for main menu
+        auto m_start = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
+        loadOrThrow(*m_start, resource_path + "start.png");
+        m_start->setOrigin();
+        m_start->setPosition(startscreen.getSize().x / 2, 200);
+        m_start->setScale(.4f);
+
+        // Create host and join buttons (will use text labels with start button image)
+        auto m_host = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
+        loadOrThrow(*m_host, resource_path + "start.png");
+        m_host->setOrigin();
+        m_host->setPosition(startscreen.getSize().x / 2, 320);
+        m_host->setScale(.4f);
+
+        auto m_join = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
+        loadOrThrow(*m_join, resource_path + "start.png");
+        m_join->setOrigin();
+        m_join->setPosition(startscreen.getSize().x / 2, 440);
+        m_join->setScale(.4f);
+
+        auto m_quit = std::make_unique<AnimatedGameObject>(1332, 300, 2, 1, 2, 0);
+        loadOrThrow(*m_quit, resource_path + "quit.png");
+        m_quit->setOrigin();
+        m_quit->setPosition((startscreen.getSize().x / 2), 520);
+        m_quit->setScale(.3f);
+
+        // Back button (using quit button graphics)
+        auto m_back = std::make_unique<AnimatedGameObject>(1332, 300, 2, 1, 2, 0);
+        loadOrThrow(*m_back, resource_path + "quit.png");
+        m_back->setOrigin();
+        m_back->setPosition(100, 50);
+        m_back->setScale(.25f);
+
+        // Text labels for buttons
+        sf::Text localLabel("LOCAL", font, 40);
+        localLabel.setFillColor(sf::Color::White);
+        localLabel.setStyle(sf::Text::Bold);
+
+        sf::Text hostLabel("HOST", font, 40);
+        hostLabel.setFillColor(sf::Color::Green);
+        hostLabel.setStyle(sf::Text::Bold);
+
+        sf::Text joinLabel("JOIN", font, 40);
+        joinLabel.setFillColor(sf::Color::Blue);
+        joinLabel.setStyle(sf::Text::Bold);
+
+        sf::Text backLabel("BACK", font, 20);
+        backLabel.setFillColor(sf::Color::White);
+
+        while (startscreen.isOpen()) {
+            sf::Event event;
+            while (startscreen.pollEvent(event)) {
+                if (event.type == sf::Event::Closed) {
                     background.stop();
                     startscreen.close();
                 }
-            }
-        }
-        else if (menuState == HOST_WAITING) {
-            // Check for client connection
-            if (netManager && netManager->waitForClient(sf::milliseconds(100))) {
-                menuState = READY_TO_START;
-                statusMessage = "Player 2 connected! Click START to begin";
-            }
-            
-            // Back button hover
-            if (backRect.contains(mousePos) && !back_updated) {
-                m_back->update(0.0f);
-                back_updated = true;
-                press.play();
-            } else if (!backRect.contains(mousePos) && back_updated) {
-                back_updated = false;
-                m_back->update(0.0f);
-                up.play();
-            }
-            
-            // Handle back button click
-            if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && backRect.contains(mousePos)) {
-                menuState = MAIN_MENU;
-                netManager = nullptr;
-                statusMessage = "";
-                sf::sleep(sf::milliseconds(200));
-            }
-        }
-        else if (menuState == JOIN_INPUT) {
-            // Back button hover
-            if (backRect.contains(mousePos) && !back_updated) {
-                m_back->update(0.0f);
-                back_updated = true;
-                press.play();
-            } else if (!backRect.contains(mousePos) && back_updated) {
-                back_updated = false;
-                m_back->update(0.0f);
-                up.play();
-            }
-            
-            // Handle back button click
-            if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && backRect.contains(mousePos)) {
-                menuState = MAIN_MENU;
-                ipInput = "127.0.0.1";
-                statusMessage = "";
-                sf::sleep(sf::milliseconds(200));
-            }
-        }
-        else if (menuState == READY_TO_START) {
-            // Start button hover
-            if (startRect.contains(mousePos) && !start_updated) {
-                m_start->update(0.0f);
-                start_updated = true;
-                press.play();
-            } else if (!startRect.contains(mousePos) && start_updated) {
-                start_updated = false;
-                m_start->update(0.0f);
-                up.play();
-            }
-            
-            // Handle start click
-            if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && startRect.contains(mousePos)) {
-                background.stop();
-                startscreen.close();
-                startgame(highscore, mode, netManager);
-                return 0;
-            }
-        }
 
-        // Render
-        startscreen.clear();
-        david.draw(startscreen);
-        
-        if (menuState == MAIN_MENU) {
-            // Draw all buttons
-            m_start->draw(startscreen);
-            m_host->draw(startscreen);
-            m_join->draw(startscreen);
-            m_quit->draw(startscreen);
-            
-            // Draw labels on buttons
-            localLabel.setOrigin(localLabel.getGlobalBounds().width/2, localLabel.getGlobalBounds().height/2);
-            localLabel.setPosition(m_start->getPosition().x, m_start->getPosition().y);
-            startscreen.draw(localLabel);
-            
-            hostLabel.setOrigin(hostLabel.getGlobalBounds().width/2, hostLabel.getGlobalBounds().height/2);
-            hostLabel.setPosition(m_host->getPosition().x, m_host->getPosition().y);
-            startscreen.draw(hostLabel);
-            
-            joinLabel.setOrigin(joinLabel.getGlobalBounds().width/2, joinLabel.getGlobalBounds().height/2);
-            joinLabel.setPosition(m_join->getPosition().x, m_join->getPosition().y);
-            startscreen.draw(joinLabel);
-        }
-        else if (menuState == HOST_WAITING) {
-            m_back->draw(startscreen);
-            backLabel.setOrigin(backLabel.getGlobalBounds().width/2, backLabel.getGlobalBounds().height/2);
-            backLabel.setPosition(m_back->getPosition().x, m_back->getPosition().y);
-            startscreen.draw(backLabel);
-            
-            sf::Text title("HOSTING GAME", font, 50);
-            title.setFillColor(sf::Color::Green);
-            title.setStyle(sf::Text::Bold);
-            title.setOrigin(title.getGlobalBounds().width/2, 0);
-            title.setPosition(startscreen.getSize().x/2, 150);
-            startscreen.draw(title);
-            
-            sf::Text ipText("Your IP: " + hostIpAddress, font, 35);
-            ipText.setFillColor(sf::Color::White);
-            ipText.setOrigin(ipText.getGlobalBounds().width/2, 0);
-            ipText.setPosition(startscreen.getSize().x/2, 250);
-            startscreen.draw(ipText);
-            
-            sf::Text statusText(statusMessage, font, 30);
-            statusText.setFillColor(sf::Color(200, 200, 200));
-            statusText.setOrigin(statusText.getGlobalBounds().width/2, 0);
-            statusText.setPosition(startscreen.getSize().x/2, 350);
-            startscreen.draw(statusText);
-        }
-        else if (menuState == JOIN_INPUT) {
-            m_back->draw(startscreen);
-            backLabel.setOrigin(backLabel.getGlobalBounds().width/2, backLabel.getGlobalBounds().height/2);
-            backLabel.setPosition(m_back->getPosition().x, m_back->getPosition().y);
-            startscreen.draw(backLabel);
-            
-            sf::Text title("JOIN GAME", font, 50);
-            title.setFillColor(sf::Color::Blue);
-            title.setStyle(sf::Text::Bold);
-            title.setOrigin(title.getGlobalBounds().width/2, 0);
-            title.setPosition(startscreen.getSize().x/2, 150);
-            startscreen.draw(title);
-            
-            sf::Text prompt("Enter Host IP Address:", font, 30);
-            prompt.setFillColor(sf::Color::White);
-            prompt.setOrigin(prompt.getGlobalBounds().width/2, 0);
-            prompt.setPosition(startscreen.getSize().x/2, 250);
-            startscreen.draw(prompt);
-            
-            sf::Text ipText(ipInput, font, 40);
-            ipText.setFillColor(sf::Color::Green);
-            ipText.setOrigin(ipText.getGlobalBounds().width/2, 0);
-            ipText.setPosition(startscreen.getSize().x/2, 320);
-            startscreen.draw(ipText);
-            
-            sf::Text instruct("Press ENTER to connect", font, 25);
-            instruct.setFillColor(sf::Color(200, 200, 200));
-            instruct.setOrigin(instruct.getGlobalBounds().width/2, 0);
-            instruct.setPosition(startscreen.getSize().x/2, 400);
-            startscreen.draw(instruct);
-            
-            if (!statusMessage.empty()) {
-                sf::Text statusText(statusMessage, font, 22);
-                if (statusMessage.find("Failed") != std::string::npos) {
-                    statusText.setFillColor(sf::Color::Red);
-                } else {
-                    statusText.setFillColor(sf::Color::Yellow);
+                // Handle text input for IP address in JOIN_INPUT state
+                if (menuState == JOIN_INPUT && event.type == sf::Event::TextEntered) {
+                    if (event.text.unicode == '\b' && !ipInput.empty()) {
+                        ipInput.pop_back();
+                    } else if (event.text.unicode == '\r' || event.text.unicode == '\n') {
+                        // Try to connect
+                        netManager = std::make_shared<NetworkManager>();
+                        statusMessage = "Connecting...";
+
+                        if (netManager->connectToHost(ipInput)) {
+                            mode = NetworkMode::CLIENT;
+                            menuState = READY_TO_START;
+                            statusMessage = "Connected! Click START to begin";
+                        } else {
+                            statusMessage = "Failed to connect (invalid IP or host unreachable)";
+                            netManager = nullptr;
+                        }
+                    } else if (event.text.unicode < 128 && event.text.unicode != '\b' &&
+                               ipInput.length() < 30) {
+                        char c = static_cast<char>(event.text.unicode);
+                        // Allow only valid IP characters
+                        if ((c >= '0' && c <= '9') || c == '.' || c == ':') {
+                            ipInput += c;
+                        }
+                    }
                 }
-                statusText.setOrigin(statusText.getGlobalBounds().width/2, 0);
-                statusText.setPosition(startscreen.getSize().x/2, 460);
+            }
+
+            // Get mouse position
+            sf::Vector2f mousePos =
+                startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen));
+
+            // Define button rectangles
+            sf::Rect<float> startRect(m_start->getPosition().x - (m_start->getWidth() / 4),
+                                      m_start->getPosition().y - (m_start->getHeight() / 4),
+                                      m_start->getWidth() * m_start->getScale().x,
+                                      m_start->getHeight() * m_start->getScale().y);
+
+            sf::Rect<float> hostRect(m_host->getPosition().x - (m_host->getWidth() / 4),
+                                     m_host->getPosition().y - (m_host->getHeight() / 4),
+                                     m_host->getWidth() * m_host->getScale().x,
+                                     m_host->getHeight() * m_host->getScale().y);
+
+            sf::Rect<float> joinRect(m_join->getPosition().x - (m_join->getWidth() / 4),
+                                     m_join->getPosition().y - (m_join->getHeight() / 4),
+                                     m_join->getWidth() * m_join->getScale().x,
+                                     m_join->getHeight() * m_join->getScale().y);
+
+            sf::Rect<float> quitRect(m_quit->getPosition().x - (m_quit->getWidth() / 4),
+                                     m_quit->getPosition().y - (m_quit->getHeight() / 4),
+                                     m_quit->getWidth() * m_quit->getScale().x,
+                                     m_quit->getHeight() * m_quit->getScale().y);
+
+            sf::Rect<float> backRect(m_back->getPosition().x - (m_back->getWidth() / 4),
+                                     m_back->getPosition().y - (m_back->getHeight() / 4),
+                                     m_back->getWidth() * m_back->getScale().x,
+                                     m_back->getHeight() * m_back->getScale().y);
+
+            // Handle menu state logic
+            if (menuState == MAIN_MENU) {
+                // Start button hover
+                if (startRect.contains(mousePos) && !start_updated) {
+                    m_start->update(0.0f);
+                    start_updated = true;
+                    press.play();
+                } else if (!startRect.contains(mousePos) && start_updated) {
+                    start_updated = false;
+                    m_start->update(0.0f);
+                    up.play();
+                }
+
+                // Host button hover
+                if (hostRect.contains(mousePos) && !host_updated) {
+                    m_host->update(0.0f);
+                    host_updated = true;
+                    press.play();
+                } else if (!hostRect.contains(mousePos) && host_updated) {
+                    host_updated = false;
+                    m_host->update(0.0f);
+                    up.play();
+                }
+
+                // Join button hover
+                if (joinRect.contains(mousePos) && !join_updated) {
+                    m_join->update(0.0f);
+                    join_updated = true;
+                    press.play();
+                } else if (!joinRect.contains(mousePos) && join_updated) {
+                    join_updated = false;
+                    m_join->update(0.0f);
+                    up.play();
+                }
+
+                // Quit button hover
+                if (quitRect.contains(mousePos) && !quit_updated) {
+                    m_quit->update(0.0f);
+                    quit_updated = true;
+                    press.play();
+                } else if (!quitRect.contains(mousePos) && quit_updated) {
+                    quit_updated = false;
+                    m_quit->update(0.0f);
+                    up.play();
+                }
+
+                // Handle clicks
+                if (sf::Mouse::isButtonPressed(sf::Mouse::Left)) {
+                    if (startRect.contains(mousePos)) {
+                        mode = NetworkMode::LOCAL;
+                        menuState = READY_TO_START;
+                        sf::sleep(sf::milliseconds(200)); // Prevent double-click
+                    } else if (hostRect.contains(mousePos)) {
+                        netManager = std::make_shared<NetworkManager>();
+                        if (netManager->startHost()) {
+                            mode = NetworkMode::HOST;
+                            menuState = HOST_WAITING;
+                            hostIpAddress = sf::IpAddress::getLocalAddress().toString();
+                            statusMessage = "Waiting for player 2...";
+                        } else {
+                            statusMessage = "Failed to start host!";
+                            netManager = nullptr;
+                        }
+                        sf::sleep(sf::milliseconds(200));
+                    } else if (joinRect.contains(mousePos)) {
+                        menuState = JOIN_INPUT;
+                        statusMessage = "Enter host IP address";
+                        sf::sleep(sf::milliseconds(200));
+                    } else if (quitRect.contains(mousePos)) {
+                        background.stop();
+                        startscreen.close();
+                    }
+                }
+            } else if (menuState == HOST_WAITING) {
+                // Check for client connection
+                if (netManager && netManager->waitForClient(sf::milliseconds(100))) {
+                    menuState = READY_TO_START;
+                    statusMessage = "Player 2 connected! Click START to begin";
+                }
+
+                // Back button hover
+                if (backRect.contains(mousePos) && !back_updated) {
+                    m_back->update(0.0f);
+                    back_updated = true;
+                    press.play();
+                } else if (!backRect.contains(mousePos) && back_updated) {
+                    back_updated = false;
+                    m_back->update(0.0f);
+                    up.play();
+                }
+
+                // Handle back button click
+                if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && backRect.contains(mousePos)) {
+                    menuState = MAIN_MENU;
+                    netManager = nullptr;
+                    statusMessage = "";
+                    sf::sleep(sf::milliseconds(200));
+                }
+            } else if (menuState == JOIN_INPUT) {
+                // Back button hover
+                if (backRect.contains(mousePos) && !back_updated) {
+                    m_back->update(0.0f);
+                    back_updated = true;
+                    press.play();
+                } else if (!backRect.contains(mousePos) && back_updated) {
+                    back_updated = false;
+                    m_back->update(0.0f);
+                    up.play();
+                }
+
+                // Handle back button click
+                if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && backRect.contains(mousePos)) {
+                    menuState = MAIN_MENU;
+                    ipInput = "127.0.0.1";
+                    statusMessage = "";
+                    sf::sleep(sf::milliseconds(200));
+                }
+            } else if (menuState == READY_TO_START) {
+                // Start button hover
+                if (startRect.contains(mousePos) && !start_updated) {
+                    m_start->update(0.0f);
+                    start_updated = true;
+                    press.play();
+                } else if (!startRect.contains(mousePos) && start_updated) {
+                    start_updated = false;
+                    m_start->update(0.0f);
+                    up.play();
+                }
+
+                // Handle start click
+                if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && startRect.contains(mousePos)) {
+                    background.stop();
+                    startscreen.close();
+                    startgame(highscore, mode, netManager);
+                    return 0;
+                }
+            }
+
+            // Render
+            startscreen.clear();
+            david.draw(startscreen);
+
+            if (menuState == MAIN_MENU) {
+                // Draw all buttons
+                m_start->draw(startscreen);
+                m_host->draw(startscreen);
+                m_join->draw(startscreen);
+                m_quit->draw(startscreen);
+
+                // Draw labels on buttons
+                localLabel.setOrigin(localLabel.getGlobalBounds().width / 2,
+                                     localLabel.getGlobalBounds().height / 2);
+                localLabel.setPosition(m_start->getPosition().x, m_start->getPosition().y);
+                startscreen.draw(localLabel);
+
+                hostLabel.setOrigin(hostLabel.getGlobalBounds().width / 2,
+                                    hostLabel.getGlobalBounds().height / 2);
+                hostLabel.setPosition(m_host->getPosition().x, m_host->getPosition().y);
+                startscreen.draw(hostLabel);
+
+                joinLabel.setOrigin(joinLabel.getGlobalBounds().width / 2,
+                                    joinLabel.getGlobalBounds().height / 2);
+                joinLabel.setPosition(m_join->getPosition().x, m_join->getPosition().y);
+                startscreen.draw(joinLabel);
+            } else if (menuState == HOST_WAITING) {
+                m_back->draw(startscreen);
+                backLabel.setOrigin(backLabel.getGlobalBounds().width / 2,
+                                    backLabel.getGlobalBounds().height / 2);
+                backLabel.setPosition(m_back->getPosition().x, m_back->getPosition().y);
+                startscreen.draw(backLabel);
+
+                sf::Text title("HOSTING GAME", font, 50);
+                title.setFillColor(sf::Color::Green);
+                title.setStyle(sf::Text::Bold);
+                title.setOrigin(title.getGlobalBounds().width / 2, 0);
+                title.setPosition(startscreen.getSize().x / 2, 150);
+                startscreen.draw(title);
+
+                sf::Text ipText("Your IP: " + hostIpAddress, font, 35);
+                ipText.setFillColor(sf::Color::White);
+                ipText.setOrigin(ipText.getGlobalBounds().width / 2, 0);
+                ipText.setPosition(startscreen.getSize().x / 2, 250);
+                startscreen.draw(ipText);
+
+                sf::Text statusText(statusMessage, font, 30);
+                statusText.setFillColor(sf::Color(200, 200, 200));
+                statusText.setOrigin(statusText.getGlobalBounds().width / 2, 0);
+                statusText.setPosition(startscreen.getSize().x / 2, 350);
+                startscreen.draw(statusText);
+            } else if (menuState == JOIN_INPUT) {
+                m_back->draw(startscreen);
+                backLabel.setOrigin(backLabel.getGlobalBounds().width / 2,
+                                    backLabel.getGlobalBounds().height / 2);
+                backLabel.setPosition(m_back->getPosition().x, m_back->getPosition().y);
+                startscreen.draw(backLabel);
+
+                sf::Text title("JOIN GAME", font, 50);
+                title.setFillColor(sf::Color::Blue);
+                title.setStyle(sf::Text::Bold);
+                title.setOrigin(title.getGlobalBounds().width / 2, 0);
+                title.setPosition(startscreen.getSize().x / 2, 150);
+                startscreen.draw(title);
+
+                sf::Text prompt("Enter Host IP Address:", font, 30);
+                prompt.setFillColor(sf::Color::White);
+                prompt.setOrigin(prompt.getGlobalBounds().width / 2, 0);
+                prompt.setPosition(startscreen.getSize().x / 2, 250);
+                startscreen.draw(prompt);
+
+                sf::Text ipText(ipInput, font, 40);
+                ipText.setFillColor(sf::Color::Green);
+                ipText.setOrigin(ipText.getGlobalBounds().width / 2, 0);
+                ipText.setPosition(startscreen.getSize().x / 2, 320);
+                startscreen.draw(ipText);
+
+                sf::Text instruct("Press ENTER to connect", font, 25);
+                instruct.setFillColor(sf::Color(200, 200, 200));
+                instruct.setOrigin(instruct.getGlobalBounds().width / 2, 0);
+                instruct.setPosition(startscreen.getSize().x / 2, 400);
+                startscreen.draw(instruct);
+
+                if (!statusMessage.empty()) {
+                    sf::Text statusText(statusMessage, font, 22);
+                    if (statusMessage.find("Failed") != std::string::npos) {
+                        statusText.setFillColor(sf::Color::Red);
+                    } else {
+                        statusText.setFillColor(sf::Color::Yellow);
+                    }
+                    statusText.setOrigin(statusText.getGlobalBounds().width / 2, 0);
+                    statusText.setPosition(startscreen.getSize().x / 2, 460);
+                    startscreen.draw(statusText);
+                }
+            } else if (menuState == READY_TO_START) {
+                m_start->draw(startscreen);
+                localLabel.setString("START");
+                localLabel.setOrigin(localLabel.getGlobalBounds().width / 2,
+                                     localLabel.getGlobalBounds().height / 2);
+                localLabel.setPosition(m_start->getPosition().x, m_start->getPosition().y);
+                startscreen.draw(localLabel);
+
+                sf::Text statusText(statusMessage, font, 30);
+                statusText.setFillColor(sf::Color::Green);
+                statusText.setStyle(sf::Text::Bold);
+                statusText.setOrigin(statusText.getGlobalBounds().width / 2, 0);
+                statusText.setPosition(startscreen.getSize().x / 2, 350);
                 startscreen.draw(statusText);
             }
+
+            startscreen.display();
         }
-        else if (menuState == READY_TO_START) {
-            m_start->draw(startscreen);
-            localLabel.setString("START");
-            localLabel.setOrigin(localLabel.getGlobalBounds().width/2, localLabel.getGlobalBounds().height/2);
-            localLabel.setPosition(m_start->getPosition().x, m_start->getPosition().y);
-            startscreen.draw(localLabel);
-            
-            sf::Text statusText(statusMessage, font, 30);
-            statusText.setFillColor(sf::Color::Green);
-            statusText.setStyle(sf::Text::Bold);
-            statusText.setOrigin(statusText.getGlobalBounds().width/2, 0);
-            statusText.setPosition(startscreen.getSize().x/2, 350);
-            startscreen.draw(statusText);
-        }
-        
-        startscreen.display();
+
+        background.stop();
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << '\n';
+        return 1;
     }
-    
-    background.stop();
-    return 0;
-  } catch (const std::exception& e) {
-    std::cerr << e.what() << '\n';
-    return 1;
-  }
 }

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -3,35 +3,32 @@
 #include <iostream>
 #include <sstream>
 
-void applyInputTo(bool& w, bool& a, bool& s, bool& d, bool& space, const PlayerInput& in)
-{
-    w     = in.up;
-    a     = in.left;
-    s     = in.down;
-    d     = in.right;
+void applyInputTo(bool& w, bool& a, bool& s, bool& d, bool& space, const PlayerInput& in) {
+    w = in.up;
+    a = in.left;
+    s = in.down;
+    d = in.right;
     space = in.attack;
 }
 
-void applyInputToP1(bool& w, bool& a, bool& s, bool& d, bool& attack, const PlayerInput& in)
-{
-    w      = in.up;
-    a      = in.left;
-    s      = in.down;
-    d      = in.right;
+void applyInputToP1(bool& w, bool& a, bool& s, bool& d, bool& attack, const PlayerInput& in) {
+    w = in.up;
+    a = in.left;
+    s = in.down;
+    d = in.right;
     attack = in.attack;
 }
 
-std::vector<PlayerInput> loadReplay(const std::string& path)
-{
+std::vector<PlayerInput> loadReplay(const std::string& path) {
     std::vector<PlayerInput> result;
-    std::ifstream            f(path);
+    std::ifstream f(path);
     if (!f.is_open()) {
         std::cerr << "replay: cannot open '" << path << "'\n";
         return result;
     }
 
     std::string line;
-    int         lineNum = 0;
+    int lineNum = 0;
     while (std::getline(f, line)) {
         ++lineNum;
 
@@ -52,8 +49,8 @@ std::vector<PlayerInput> loadReplay(const std::string& path)
 
         // Parse exactly 5 fields, each 0 or 1
         std::istringstream ss(line);
-        int                vals[5];
-        bool               ok = true;
+        int vals[5];
+        bool ok = true;
         for (int i = 0; i < 5 && ok; ++i) {
             if (!(ss >> vals[i]))
                 ok = false;
@@ -73,10 +70,10 @@ std::vector<PlayerInput> loadReplay(const std::string& path)
         }
 
         PlayerInput inp;
-        inp.up     = (vals[0] != 0);
-        inp.down   = (vals[1] != 0);
-        inp.left   = (vals[2] != 0);
-        inp.right  = (vals[3] != 0);
+        inp.up = (vals[0] != 0);
+        inp.down = (vals[1] != 0);
+        inp.left = (vals[2] != 0);
+        inp.right = (vals[3] != 0);
         inp.attack = (vals[4] != 0);
         result.push_back(inp);
     }

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -12,13 +12,13 @@ void applyInputTo(bool& w, bool& a, bool& s, bool& d, bool& space, const PlayerI
     space = in.attack;
 }
 
-void applyInputToP1(bool& w, bool& a, bool& s, bool& d, int& attack, const PlayerInput& in)
+void applyInputToP1(bool& w, bool& a, bool& s, bool& d, bool& attack, const PlayerInput& in)
 {
     w      = in.up;
     a      = in.left;
     s      = in.down;
     d      = in.right;
-    attack = in.attack ? 1 : 0;
+    attack = in.attack;
 }
 
 std::vector<PlayerInput> loadReplay(const std::string& path)

--- a/src/resource_path.cpp
+++ b/src/resource_path.cpp
@@ -4,7 +4,8 @@
 std::string resource_path = "assets/";
 
 void initResourcePath(const char* argv0) {
-    if (!argv0) return;
+    if (!argv0)
+        return;
     namespace fs = std::filesystem;
     fs::path exeDir = fs::weakly_canonical(fs::path(argv0)).parent_path();
     if (fs::exists(exeDir / "assets")) {

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -385,8 +385,7 @@ TEST_CASE("integration: P2 moves down — p2_y increases 20 px per step", "[inte
 // Step 2 (a=1): triggers if(!p2left) branch → p2left=true, scale.x=-1 (pinned here).
 // Steps 3-5: continue left; p2left stays true (no re-flip).
 
-TEST_CASE("integration: P2 left-direction flip branch sets p2left and scale",
-          "[integration]") {
+TEST_CASE("integration: P2 left-direction flip branch sets p2left and scale", "[integration]") {
     DebugConfig cfg;
     cfg.frames = 5;
     cfg.replayPath = dataPath("p2_left_flip.replay"); // 1 right then 4 left steps

--- a/tests/test_unit.cpp
+++ b/tests/test_unit.cpp
@@ -1,7 +1,7 @@
 // Unit tests for extracted free functions:
 //   objectBounds — rectangle construction from a GameObject
 //   advanceFrameRect — sprite-sheet frame stepping
-//   applyInputToP1 — P1 input mapping (int attack parameter)
+//   applyInputToP1 — P1 input mapping (bool attack parameter)
 // Also: RegularGameObject method coverage.
 
 #include <catch2/catch_approx.hpp>
@@ -234,7 +234,7 @@ TEST_CASE("advanceFrameRect: robot sheet - walk first frame", "[anim][unit]") {
 
 // ── applyInputToP1 ─────────────────────────────────────────────────────────────
 
-TEST_CASE("applyInputToP1 maps all five fields; attack is int", "[harness][unit]") {
+TEST_CASE("applyInputToP1 maps all five fields; attack is bool", "[harness][unit]") {
     PlayerInput in;
     in.up = true;
     in.down = false;
@@ -243,25 +243,25 @@ TEST_CASE("applyInputToP1 maps all five fields; attack is int", "[harness][unit]
     in.attack = true;
 
     bool w = false, a = false, s = true, d = true;
-    int attack = 0;
+    bool attack = false;
     applyInputToP1(w, a, s, d, attack, in);
 
-    REQUIRE(w == true);   // in.up    → m_up
-    REQUIRE(a == true);   // in.left  → m_left
-    REQUIRE(s == false);  // in.down  → m_down
-    REQUIRE(d == false);  // in.right → m_right
-    REQUIRE(attack == 1); // in.attack → right (int)
+    REQUIRE(w == true);      // in.up    → m_up
+    REQUIRE(a == true);      // in.left  → m_left
+    REQUIRE(s == false);     // in.down  → m_down
+    REQUIRE(d == false);     // in.right → m_right
+    REQUIRE(attack == true); // in.attack → right (bool)
 }
 
-TEST_CASE("applyInputToP1 attack=false maps to 0", "[harness][unit]") {
+TEST_CASE("applyInputToP1 attack=false maps to false", "[harness][unit]") {
     PlayerInput in;
     in.attack = false;
 
     bool w = false, a = false, s = false, d = false;
-    int attack = 99;
+    bool attack = true;
     applyInputToP1(w, a, s, d, attack, in);
 
-    REQUIRE(attack == 0);
+    REQUIRE(attack == false);
 }
 
 // ── RegularGameObject: method coverage ───────────────────────────────────────


### PR DESCRIPTION
Resolves #9 and #6.

The code-quality pass, in **8 reviewable commits** (tests green after every one), protected by #7's 65 tests.

## #9 — code smell / memory safety
- **RAII / no more leaks or UB**: `GameObject` gets a `virtual` destructor + deleted copy/move (Rule of Five); the players, the arena props (`m_arena`), and the menu buttons are `std::unique_ptr` (the recursive menu even leaked two buttons per game before). `collision()` now takes `const GameObject&`.
- **Bug fixes**: bitwise `&`→`&&` in the movement guards; `int right`→`bool`.
- **Fail-fast asset loading**: a `loadOrThrow` helper replaces ~30 silent-continue loads; `main()` wraps construction in a try/catch → clear "failed to load asset" message + exit 1 (previously a missing asset silently rendered invisible sprites).
- **Dead code / dedup**: duplicate audio include, commented-out blocks, write-only `p1move`/`p2move`, unused vars removed.
- **Naming**: the confusing identifiers are gone — notably the **swapped** `points`/`p2points` are now `m_robotScore`/`m_rocketScore` (mapping preserved), plus `m_rocket`/`m_robot`, `m_p1Up…`/`m_p2Up…`, `m_arena`, `m_inCooldown`, `apieceofcrap`→`minutes`, `clack`→`finalTime`, etc.

## #6 — lint / format / CI
- **`.clang-tidy`** (strict-but-useful; advisory) + `.clang-format`/`.editorconfig` (finalized) + `compile_commands.json` export.
- **clang-format** applied across the whole codebase (one isolated commit).
- **`-Werror`** on the project targets (not SFML/Catch2) — the build is now **0 warnings**. CI adds a pinned `clang-format-18 --dry-run` check + an advisory `clang-tidy` step, keeping the build/test/coverage jobs.

## Preserved deliberately
Magic numbers (a separate effort) and the load-bearing attack-on-key-**release** input handling are untouched. Determinism (the harness) still holds.

## Validation
Fresh `-Werror` build = 0 warnings/errors; `ctest` = 65/65; `clang-format --dry-run` clean (verified under the pinned v18); fail-fast confirmed (missing asset → exit 1). Both reviewers converged (behavior-preservation: no findings).
