### PR TITLE
Gameplay polish: resizable/letterbox window, fullscreen, vsync, key remap, pause/quit-to-menu — #11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
         run: cmake --build build -j
 
       - name: Run tests (xvfb for integration cases)
+        env:
+          ALSOFT_DRIVERS: 'null'   # headless runner has no audio device; OpenAL-soft null driver
+                                   # so SoundBuffer/Sound calls are safe no-ops (else burn.play() segfaults)
         run: |
           mkdir -p build/cov
           LLVM_PROFILE_FILE=$PWD/build/cov/%p-%m.profraw \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(dungeon_lib STATIC
     src/resource_path.cpp
     src/replay.cpp
     src/rng.cpp
+    src/key_bindings.cpp
 )
 
 target_include_directories(dungeon_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,11 @@ if(MSVC)
     target_compile_options(dungeon_lib    PRIVATE /W4)
     target_compile_options(dungeon_game   PRIVATE /W4)
 else()
-    target_compile_options(dungeon_lib    PRIVATE -Wall -Wextra -Wpedantic -Werror)
-    target_compile_options(dungeon_game   PRIVATE -Wall -Wextra -Wpedantic -Werror)
+    # -Wno-deprecated-declarations: don't let toolchain/SDK deprecations (e.g. newer
+    # libc++ deprecating char_traits<unsigned> on bleeding-edge Xcode) fail our -Werror;
+    # they're outside our control and vary by compiler version.
+    target_compile_options(dungeon_lib    PRIVATE -Wall -Wextra -Wpedantic -Werror -Wno-deprecated-declarations)
+    target_compile_options(dungeon_game   PRIVATE -Wall -Wextra -Wpedantic -Werror -Wno-deprecated-declarations)
 endif()
 
 # ── Copy assets next to the binary at build time ────────────────────────────

--- a/README.md
+++ b/README.md
@@ -33,14 +33,22 @@ Launch the game and use the main menu:
 
 ## Controls
 
-| Action         | Player 1 (Robot)       | Player 2 (Rocket) |
+| Action         | Player 1 (Rocket)      | Player 2 (Robot)  |
 |----------------|------------------------|-------------------|
-| Move           | Numpad 8/5/4/6         | W/S/A/D           |
+| Move           | Numpad 8/5/4/6         | W/A/S/D           |
 | Attack         | Right arrow            | Space             |
-| Slow down      | O                      | O                 |
-| Speed up       | P                      | P                 |
-| Skip cooldown  | K                      | K                 |
-| Quit           | Escape                 | Escape            |
+
+| Global         | Key                    |
+|----------------|------------------------|
+| Slow down      | O                      |
+| Speed up       | P                      |
+| Skip cooldown  | K                      |
+| Pause / resume | Esc                    |
+| Quit to menu   | Q (while paused)       |
+| Fullscreen     | F11                    |
+
+The window is resizable and scales with a letterbox (aspect preserved). Key bindings can be customised
+via a `controls.cfg` file next to the binary — run `dungeon_game --help` for the format.
 
 ---
 

--- a/include/Game.h
+++ b/include/Game.h
@@ -117,6 +117,9 @@ private:
 
     // Fixed-timestep state
     static constexpr float kFixedDt = 1.f / 60.f;
+    // Logical canvas size — all sim positions use these, never m_window.getSize().
+    static constexpr float kLogicalW = 1920.f;
+    static constexpr float kLogicalH = 1080.f;
     long long m_steps = 0;
     float m_accumulator = 0.f;
     float m_animTime = 0.f;

--- a/include/Game.h
+++ b/include/Game.h
@@ -8,6 +8,7 @@
 #include "NetworkManager.h"
 #include "RegularGameObject.h"
 #include "debug.h"
+#include "key_bindings.h"
 #include "replay.h"
 #include <SFML/Audio.hpp>
 #include <SFML/Graphics.hpp>
@@ -24,8 +25,14 @@ public:
     // Configure debug/harness options; call before run().
     void setDebugConfig(const DebugConfig& cfg);
 
+    // Override key bindings (defaults loaded from controls.cfg or hard-coded defaults).
+    void setBindings(const KeyBindings& b) { m_bindings = b; }
+
     // Accessor for step count (useful for post-run reporting).
     long long steps() const { return m_steps; }
+
+    // True if the game ended because the user chose "quit to menu" (Escape+Q or quitAtStep).
+    bool quitToMenu() const { return m_quitToMenu; }
 
     // Public snapshot of game state (for tests and network round-trip verification).
     GameState snapshot() const;
@@ -144,4 +151,15 @@ private:
     GameState m_latestState;
     float m_stateAccum = 0.f;
     static constexpr float kStateSendInterval = 1.f / 25.f; // ~25 Hz
+
+    // Pause / quit-to-menu state
+    bool m_paused = false;
+    bool m_quitToMenu = false;
+
+    // Fullscreen toggle (F11); track current mode to know how to recreate.
+    bool m_fullscreen = false;
+    void toggleFullscreen();
+
+    // Key bindings (loaded from controls.cfg; defaults = original hard-coded keys).
+    KeyBindings m_bindings = defaultBindings();
 };

--- a/include/debug.h
+++ b/include/debug.h
@@ -7,8 +7,12 @@ struct DebugConfig {
     std::string replayPathP1;
     int screenshotEvery = 0;
     std::string screenshotDir = ".";
+    // When >= 0, Game closes + sets quitToMenu after this many sim steps.
+    // Also makes active() return true so vsync/F11 are gated off correctly.
+    int quitAtStep = -1;
 
     bool active() const {
-        return frames > 0 || !replayPath.empty() || !replayPathP1.empty() || screenshotEvery > 0;
+        return frames > 0 || !replayPath.empty() || !replayPathP1.empty() || screenshotEvery > 0 ||
+               quitAtStep >= 0;
     }
 };

--- a/include/key_bindings.h
+++ b/include/key_bindings.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <SFML/Window.hpp>
+#include <iosfwd>
+#include <string>
+
+// Per-player movement and attack bindings.
+struct PlayerBindings {
+    sf::Keyboard::Key up;
+    sf::Keyboard::Key down;
+    sf::Keyboard::Key left;
+    sf::Keyboard::Key right;
+    sf::Keyboard::Key attack;
+};
+
+// Full set of key bindings for both players plus debug/speed keys.
+struct KeyBindings {
+    PlayerBindings p1;
+    PlayerBindings p2;
+    sf::Keyboard::Key slowDown;
+    sf::Keyboard::Key speedUp;
+    sf::Keyboard::Key skipCooldown;
+};
+
+// Returns the compile-time defaults (original hard-coded keys).
+KeyBindings defaultBindings();
+
+// Parse a "key = value" config stream, returning a KeyBindings populated from
+// recognised entries.  Unknown SFML key names produce a std::cerr warning and
+// keep the existing binding's default.  Unrecognised field names are silently
+// ignored.  An absent/empty stream returns defaults untouched.
+KeyBindings loadBindings(std::istream& in);
+
+// Convert between SFML key enum and the string names used in controls.cfg.
+// keyFromName returns sf::Keyboard::Unknown for unrecognised names.
+// nameFromKey returns "Unknown" for keys not in the table.
+sf::Keyboard::Key keyFromName(const std::string& name);
+std::string nameFromKey(sf::Keyboard::Key key);

--- a/include/letterbox.h
+++ b/include/letterbox.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <SFML/Graphics.hpp>
+
+// Compute an aspect-preserving centered sf::View that maps logicalSize onto
+// windowPx screen pixels.  The view's rectangle covers [0,0]×logicalSize;
+// the viewport is the pillar- or letter-boxed sub-rect of the window.
+// Pass this to RenderWindow::setView() after window creation and on
+// sf::Event::Resized.
+inline sf::View makeLetterboxView(sf::Vector2f logicalSize, sf::Vector2u windowPx) {
+    float logicalAspect = logicalSize.x / logicalSize.y;
+    float windowAspect = static_cast<float>(windowPx.x) / static_cast<float>(windowPx.y);
+
+    sf::FloatRect viewport;
+    if (windowAspect >= logicalAspect) {
+        // Window is wider than logical canvas → pillarbox (black bars on sides).
+        float vpW = logicalAspect / windowAspect;
+        viewport = sf::FloatRect((1.f - vpW) / 2.f, 0.f, vpW, 1.f);
+    } else {
+        // Window is taller than logical canvas → letterbox (black bars top/bottom).
+        float vpH = windowAspect / logicalAspect;
+        viewport = sf::FloatRect(0.f, (1.f - vpH) / 2.f, 1.f, vpH);
+    }
+
+    sf::View view(sf::FloatRect(0.f, 0.f, logicalSize.x, logicalSize.y));
+    view.setViewport(viewport);
+    return view;
+}

--- a/include/resource_path.h
+++ b/include/resource_path.h
@@ -2,4 +2,7 @@
 #include <string>
 
 extern std::string resource_path;
+// Directory containing the executable (set by initResourcePath).
+// Use this to locate files next to the binary (e.g. controls.cfg).
+extern std::string exe_dir_path;
 void initResourcePath(const char* argv0);

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -5,6 +5,7 @@
 #include "Game.h"
 #include "asset_load.h"
 #include "geometry.h"
+#include "letterbox.h"
 #include "resource_path.h"
 #include <algorithm>
 #include <cmath>
@@ -22,14 +23,37 @@ static void captureScreenshot(const sf::RenderWindow& w, const std::string& path
 }
 // LCOV_EXCL_STOP
 
+// ── toggleFullscreen ──────────────────────────────────────────────────────────
+// LCOV_EXCL_START — requires a display; not reachable from harness tests
+void Game::toggleFullscreen() {
+    m_fullscreen = !m_fullscreen;
+    const std::string title = m_networkMode == NetworkMode::LOCAL  ? "Dungeon Game"
+                              : m_networkMode == NetworkMode::HOST ? "Dungeon Game - Host"
+                                                                   : "Dungeon Game - Client";
+    if (m_fullscreen) {
+        m_window.create(sf::VideoMode::getDesktopMode(), title, sf::Style::Fullscreen);
+    } else {
+        m_window.create(sf::VideoMode(1920, 1080), title, sf::Style::Default);
+    }
+    // Re-apply display settings after create() resets them.
+    // NOTE (macOS): SFML 2 create() reconstructs the GL context; textures
+    // live on the shared context and should survive, but verify visually.
+    if (!m_debug.active())
+        m_window.setVerticalSyncEnabled(true);
+    m_window.setView(makeLetterboxView({kLogicalW, kLogicalH}, m_window.getSize()));
+}
+// LCOV_EXCL_STOP
+
 // ── constructors ──────────────────────────────────────────────────────────────
 
 Game::Game() : Game(NetworkMode::LOCAL, nullptr) {}
 
 Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
-    : m_window(sf::VideoMode(1920, 1080), mode == NetworkMode::LOCAL  ? "Dungeon Game"
-                                          : mode == NetworkMode::HOST ? "Dungeon Game - Host"
-                                                                      : "Dungeon Game - Client"),
+    : m_window(sf::VideoMode(1920, 1080),
+               mode == NetworkMode::LOCAL  ? "Dungeon Game"
+               : mode == NetworkMode::HOST ? "Dungeon Game - Host"
+                                           : "Dungeon Game - Client",
+               sf::Style::Default),
       m_networkMode(mode), m_networkManager(netManager) {
     loadOrThrow(background, resource_path + "background.wav");
 
@@ -125,6 +149,11 @@ void Game::setDebugConfig(const DebugConfig& cfg) {
 // ── run ───────────────────────────────────────────────────────────────────────
 
 std::tuple<int, int, float, int, bool, bool> Game::run() {
+    // Apply display settings now that debug config is known.
+    if (!m_debug.active())
+        m_window.setVerticalSyncEnabled(true);
+    m_window.setView(makeLetterboxView({kLogicalW, kLogicalH}, m_window.getSize()));
+
     sf::Clock clock;
     background.play();
     background.setLoop(true);
@@ -160,13 +189,15 @@ std::tuple<int, int, float, int, bool, bool> Game::run() {
         // ── Sim steps ────────────────────────────────────────────────────────
         if (framesMode) {
             simStep();
-        } else {
+        } else if (!m_paused || m_networkMode != NetworkMode::LOCAL) {
             m_accumulator += iterDt;
             while (m_accumulator >= kFixedDt) {
                 simStep();
                 m_accumulator -= kFixedDt;
             }
         }
+        // When LOCAL-paused, iterDt was consumed by clock.restart() above;
+        // skipping the accumulator prevents a time-jump on unpause.
 
         // ── Render + capture (back buffer ready; swap comes last) ─────────────
         render();
@@ -252,6 +283,13 @@ void Game::simStep() {
         m_rocketScore = 0;
 
     ++m_steps;
+
+    // quitAtStep: harness-controlled exit that sets quitToMenu so callers can
+    // distinguish it from the frames-limit exit.
+    if (m_debug.quitAtStep >= 0 && m_steps >= static_cast<long long>(m_debug.quitAtStep)) {
+        m_quitToMenu = true;
+        m_window.close();
+    }
 }
 
 // ── applyPlayerInput / captureIfDue ──────────────────────────────────────────
@@ -282,12 +320,20 @@ void Game::processEvents() {
     sf::Event event;
     while (m_window.pollEvent(event)) {
         switch (event.type) {
-        // LCOV_EXCL_START — keyboard events are not generated in harness/headless runs
+        // LCOV_EXCL_START — UI events not generated in harness/headless runs
         case sf::Event::KeyPressed:
+            if (event.key.code == sf::Keyboard::F11 && !m_debug.active()) {
+                toggleFullscreen();
+                return; // restart event loop with the new window
+            }
             handlePlayerInput(event.key.code, true);
             break;
         case sf::Event::KeyReleased:
             handlePlayerInput(event.key.code, false);
+            break;
+        case sf::Event::Resized:
+            m_window.setView(
+                makeLetterboxView({kLogicalW, kLogicalH}, {event.size.width, event.size.height}));
             break;
         case sf::Event::Closed:
             m_window.close();
@@ -303,43 +349,60 @@ void Game::processEvents() {
 
 // LCOV_EXCL_START — keyboard glue; entirely gated off when the harness is active
 void Game::handlePlayerInput(sf::Keyboard::Key key, bool isDown) {
-    // Gate all game-key bindings when the harness is active so that live
+    // Gate all interactive bindings when the harness is active so that live
     // keyboard cannot perturb a --frames / --replay run.
     if (!m_debug.active()) {
-        // Player 1 controls (rocket — numpad)
+        // Pause / resume
+        if (key == sf::Keyboard::Escape && isDown) {
+            m_paused = !m_paused;
+            if (m_paused)
+                background.pause();
+            else
+                background.play();
+        }
+
+        // Quit to menu while paused
+        if (m_paused && key == sf::Keyboard::Q && isDown) {
+            if (m_networkManager)
+                m_networkManager->disconnect();
+            m_quitToMenu = true;
+            m_window.close();
+        }
+
+        // Player 1 controls (rocket — configurable, default numpad)
         if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::HOST) {
-            if (key == sf::Keyboard::Numpad4)
+            if (key == m_bindings.p1.left)
                 m_p1Left = isDown;
-            if (key == sf::Keyboard::Numpad6)
+            if (key == m_bindings.p1.right)
                 m_p1Right = isDown;
-            if (key == sf::Keyboard::Numpad8)
+            if (key == m_bindings.p1.up)
                 m_p1Up = isDown;
-            if (key == sf::Keyboard::Numpad5)
+            if (key == m_bindings.p1.down)
                 m_p1Down = isDown;
-            if (key == sf::Keyboard::Right)
+            if (key == m_bindings.p1.attack)
                 m_p1Attack = isDown;
         }
 
-        // Player 2 controls (robot — WASD)
+        // Player 2 controls (robot — configurable, default WASD+Space)
         if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::CLIENT) {
-            if (key == sf::Keyboard::W)
+            if (key == m_bindings.p2.up)
                 m_p2Up = isDown;
-            if (key == sf::Keyboard::A)
+            if (key == m_bindings.p2.left)
                 m_p2Left = isDown;
-            if (key == sf::Keyboard::S)
+            if (key == m_bindings.p2.down)
                 m_p2Down = isDown;
-            if (key == sf::Keyboard::D)
+            if (key == m_bindings.p2.right)
                 m_p2Right = isDown;
-            if (key == sf::Keyboard::Space)
+            if (key == m_bindings.p2.attack)
                 m_p2Attack = !isDown;
         }
 
         // Speed tweaks and wait-skip
-        if (key == sf::Keyboard::O)
+        if (key == m_bindings.slowDown)
             m_slowDownPressed = !isDown;
-        if (key == sf::Keyboard::P)
+        if (key == m_bindings.speedUp)
             m_speedUpPressed = !isDown;
-        if (key == sf::Keyboard::K) {
+        if (key == m_bindings.skipCooldown && isDown) {
             if (m_inCooldown) {
                 m_inCooldown = false;
                 gong.play();
@@ -347,9 +410,7 @@ void Game::handlePlayerInput(sf::Keyboard::Key key, bool isDown) {
         }
     }
 
-    // Always-active: window close and manual screenshot.
-    if (key == sf::Keyboard::Escape)
-        m_window.close();
+    // Always-active: manual screenshot (F12).
     if (key == sf::Keyboard::F12 && isDown)
         captureScreenshot(m_window,
                           m_debug.screenshotDir + "/manual_" + std::to_string(m_steps) + ".png");
@@ -626,6 +687,18 @@ void Game::render() {
     if (m_inCooldown) {
         m_window.draw(pause_text);
         m_window.draw(info);
+    }
+    if (m_paused) {
+        sf::RectangleShape overlay(sf::Vector2f(kLogicalW, kLogicalH));
+        overlay.setFillColor(sf::Color(0, 0, 0, 140));
+        m_window.draw(overlay);
+        sf::Text txt("PAUSED\nEsc: resume   Q: quit to menu", font, 60);
+        txt.setFillColor(sf::Color::White);
+        txt.setStyle(sf::Text::Bold);
+        auto bounds = txt.getLocalBounds();
+        txt.setOrigin(bounds.width / 2.f, bounds.height / 2.f);
+        txt.setPosition(kLogicalW / 2.f, kLogicalH / 2.f);
+        m_window.draw(txt);
     }
     // NOTE: m_window.display() is called by run() so screenshots can be
     // captured between draw and swap.

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -191,7 +191,9 @@ std::tuple<int, int, float, int, bool, bool> Game::run() {
             simStep();
         } else if (!m_paused || m_networkMode != NetworkMode::LOCAL) {
             m_accumulator += iterDt;
-            while (m_accumulator >= kFixedDt) {
+            // Guard on isOpen() so a simStep() that closes the window mid-drain
+            // (e.g. debug quitAtStep) can't overshoot the target step count.
+            while (m_accumulator >= kFixedDt && m_window.isOpen()) {
                 simStep();
                 m_accumulator -= kFixedDt;
             }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -39,7 +39,7 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
 
     loadOrThrow(*m_robot, resource_path + "robot.png");
     m_robot->setScale(-1.0f, 1.0f);
-    m_robot->setPosition(m_window.getSize().x - (m_rocket->getWidth() + 150), 400);
+    m_robot->setPosition(kLogicalW - (m_rocket->getWidth() + 150), 400);
 
     m_arena.push_back(std::make_unique<RegularGameObject>());
     loadOrThrow(*m_arena[0], resource_path + "brick.png");
@@ -56,14 +56,14 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
         auto fire2 = std::make_unique<AnimatedGameObject>(216, 216, 5, 3, 10, 0);
         loadOrThrow(*fire2, resource_path + "fire.png");
         fire2->setScale(2.0f);
-        fire2->setPosition((1920 / 2) - 5, 400);
+        fire2->setPosition(kLogicalW / 2 - 5, 400);
         m_arena.push_back(std::move(fire2));
     }
     {
         auto fire3 = std::make_unique<AnimatedGameObject>(216, 216, 5, 3, 10, 0);
         loadOrThrow(*fire3, resource_path + "fire.png");
         fire3->setScale(2.0f);
-        fire3->setPosition(1820, 400);
+        fire3->setPosition(kLogicalW - 100, 400);
         m_arena.push_back(std::move(fire3));
     }
 
@@ -72,7 +72,7 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
     loadOrThrow(block, resource_path + "Blockt.ttf");
 
     pause_text = sf::Text("Cooldown", block, 400);
-    pause_text.setPosition(m_window.getSize().x / 2 - 850, 100);
+    pause_text.setPosition(kLogicalW / 2 - 850, 100);
     pause_text.setFillColor(sf::Color::Black);
 
     info = sf::Text("a short intermission", font, 50);
@@ -82,10 +82,9 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
     m_rocketScoreText = sf::Text("Rocket Score: 0", font, 40);
     m_robotScoreText = sf::Text("Robot Score: 0", font, 40);
     timer = sf::Text("timer", tfont, 60);
-    timer.setPosition((m_window.getSize().x / 2) - 60, 0);
+    timer.setPosition(kLogicalW / 2 - 60, 0);
     m_rocketScoreText.setPosition(10, 0);
-    m_robotScoreText.setPosition(m_window.getSize().x - m_robotScoreText.getGlobalBounds().width,
-                                 0);
+    m_robotScoreText.setPosition(kLogicalW - m_robotScoreText.getGlobalBounds().width, 0);
     m_robotScoreText.setFillColor(sf::Color::Green);
     timer.setFillColor(sf::Color::Black);
     m_rocketScoreText.setFillColor(sf::Color::Blue);
@@ -367,8 +366,7 @@ void Game::update(sf::Time deltaT, float time) {
 
     if (m_p1Up) {
         if (m_rocket->getPosition().y < -(m_rocket->getHeight())) {
-            m_rocket->setPosition(m_rocket->getPosition().x,
-                                  (m_window.getSize().y) - m_rocket->getHeight());
+            m_rocket->setPosition(m_rocket->getPosition().x, kLogicalH - m_rocket->getHeight());
         }
 
         if (collision(*m_rocket, *m_robot)) {
@@ -379,7 +377,7 @@ void Game::update(sf::Time deltaT, float time) {
     }
 
     if (m_p1Down) {
-        if (m_rocket->getPosition().y > (m_window.getSize().y) - (m_rocket->getHeight())) {
+        if (m_rocket->getPosition().y > kLogicalH - m_rocket->getHeight()) {
             m_rocket->setPosition(m_rocket->getPosition().x, -(m_rocket->getHeight()));
         }
 
@@ -391,7 +389,7 @@ void Game::update(sf::Time deltaT, float time) {
     }
     if (m_p1Left) {
         if (m_rocket->getPosition().x < -(m_rocket->getWidth())) {
-            m_rocket->setPosition(m_window.getSize().x, m_rocket->getPosition().y);
+            m_rocket->setPosition(kLogicalW, m_rocket->getPosition().y);
         }
         if (!m_p1FacingLeft) {
             m_rocket->setScale(-2.0f, 2);
@@ -410,7 +408,7 @@ void Game::update(sf::Time deltaT, float time) {
     if (m_p1Right) {
         m_rocket->setScale(2.0f, 2);
 
-        if (m_rocket->getPosition().x > m_window.getSize().x) {
+        if (m_rocket->getPosition().x > kLogicalW) {
             m_rocket->setPosition(-(m_rocket->getWidth()), m_rocket->getPosition().y);
         }
 
@@ -429,8 +427,7 @@ void Game::update(sf::Time deltaT, float time) {
     }
     if (m_p2Up) {
         if (m_robot->getPosition().y < -(m_robot->getHeight())) {
-            m_robot->setPosition(m_robot->getPosition().x,
-                                 (m_window.getSize().y) - m_robot->getHeight());
+            m_robot->setPosition(m_robot->getPosition().x, kLogicalH - m_robot->getHeight());
         }
 
         if (collision(*m_rocket, *m_robot)) {
@@ -440,7 +437,7 @@ void Game::update(sf::Time deltaT, float time) {
         }
     }
     if (m_p2Down) {
-        if (m_robot->getPosition().y > (m_window.getSize().y) - (m_robot->getHeight())) {
+        if (m_robot->getPosition().y > kLogicalH - m_robot->getHeight()) {
             m_robot->setPosition(m_robot->getPosition().x, -(m_robot->getHeight()));
         }
 
@@ -452,7 +449,7 @@ void Game::update(sf::Time deltaT, float time) {
     }
     if (m_p2Left) {
         if (m_robot->getPosition().x < -(m_robot->getWidth())) {
-            m_robot->setPosition(m_window.getSize().x, m_robot->getPosition().y);
+            m_robot->setPosition(kLogicalW, m_robot->getPosition().y);
         }
         m_robot->setScale(-1.0f, 1.0f);
         if (!m_p2FacingLeft) {
@@ -470,7 +467,7 @@ void Game::update(sf::Time deltaT, float time) {
     }
     if (m_p2Right) {
         m_robot->setScale(1.0f, 1.0f);
-        if (m_robot->getPosition().x > m_window.getSize().x) {
+        if (m_robot->getPosition().x > kLogicalW) {
             m_robot->setPosition(-(m_robot->getWidth()), m_robot->getPosition().y);
         }
         if (m_p2FacingLeft) {
@@ -563,7 +560,7 @@ void Game::update(sf::Time deltaT, float time) {
     if (reset) {
         m_rocket->setScale(2.0f, 2);
         m_robot->setScale(-1.0f, 1.0f);
-        m_robot->setPosition(m_window.getSize().x - (m_rocket->getWidth() + 150), 400);
+        m_robot->setPosition(kLogicalW - (m_rocket->getWidth() + 150), 400);
         m_rocket->setPosition(m_rocket->getWidth() + 20, 400);
         m_p1FacingLeft = false;
         m_p2FacingLeft = true;
@@ -572,8 +569,7 @@ void Game::update(sf::Time deltaT, float time) {
 
     m_rocketScoreText.setString("Rocket Score: " + std::to_string(m_rocketScore));
     m_robotScoreText.setString("Robot Score: " + std::to_string(m_robotScore));
-    m_robotScoreText.setPosition(
-        m_window.getSize().x - m_robotScoreText.getGlobalBounds().width - 20, 0);
+    m_robotScoreText.setPosition(kLogicalW - m_robotScoreText.getGlobalBounds().width - 20, 0);
 }
 
 // ── render ────────────────────────────────────────────────────────────────────

--- a/src/key_bindings.cpp
+++ b/src/key_bindings.cpp
@@ -1,0 +1,135 @@
+#include "key_bindings.h"
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+// ── Key name table ─────────────────────────────────────────────────────────────
+// Bidirectional: keyFromName / nameFromKey both iterate this array.
+
+static const std::pair<const char*, sf::Keyboard::Key> kKeyTable[] = {
+    // Letters
+    {"A", sf::Keyboard::A}, {"B", sf::Keyboard::B}, {"C", sf::Keyboard::C},
+    {"D", sf::Keyboard::D}, {"E", sf::Keyboard::E}, {"F", sf::Keyboard::F},
+    {"G", sf::Keyboard::G}, {"H", sf::Keyboard::H}, {"I", sf::Keyboard::I},
+    {"J", sf::Keyboard::J}, {"K", sf::Keyboard::K}, {"L", sf::Keyboard::L},
+    {"M", sf::Keyboard::M}, {"N", sf::Keyboard::N}, {"O", sf::Keyboard::O},
+    {"P", sf::Keyboard::P}, {"Q", sf::Keyboard::Q}, {"R", sf::Keyboard::R},
+    {"S", sf::Keyboard::S}, {"T", sf::Keyboard::T}, {"U", sf::Keyboard::U},
+    {"V", sf::Keyboard::V}, {"W", sf::Keyboard::W}, {"X", sf::Keyboard::X},
+    {"Y", sf::Keyboard::Y}, {"Z", sf::Keyboard::Z},
+    // Top-row digits
+    {"0", sf::Keyboard::Num0}, {"1", sf::Keyboard::Num1}, {"2", sf::Keyboard::Num2},
+    {"3", sf::Keyboard::Num3}, {"4", sf::Keyboard::Num4}, {"5", sf::Keyboard::Num5},
+    {"6", sf::Keyboard::Num6}, {"7", sf::Keyboard::Num7}, {"8", sf::Keyboard::Num8},
+    {"9", sf::Keyboard::Num9},
+    // Numpad
+    {"Num0", sf::Keyboard::Numpad0}, {"Num1", sf::Keyboard::Numpad1},
+    {"Num2", sf::Keyboard::Numpad2}, {"Num3", sf::Keyboard::Numpad3},
+    {"Num4", sf::Keyboard::Numpad4}, {"Num5", sf::Keyboard::Numpad5},
+    {"Num6", sf::Keyboard::Numpad6}, {"Num7", sf::Keyboard::Numpad7},
+    {"Num8", sf::Keyboard::Numpad8}, {"Num9", sf::Keyboard::Numpad9},
+    // Arrow keys
+    {"Up", sf::Keyboard::Up},     {"Down", sf::Keyboard::Down},
+    {"Left", sf::Keyboard::Left}, {"Right", sf::Keyboard::Right},
+    // Special keys
+    {"Space", sf::Keyboard::Space},     {"Enter", sf::Keyboard::Return},
+    {"Escape", sf::Keyboard::Escape},   {"Tab", sf::Keyboard::Tab},
+    {"Backspace", sf::Keyboard::BackSpace},
+    // Function keys
+    {"F1",  sf::Keyboard::F1},  {"F2",  sf::Keyboard::F2},  {"F3",  sf::Keyboard::F3},
+    {"F4",  sf::Keyboard::F4},  {"F5",  sf::Keyboard::F5},  {"F6",  sf::Keyboard::F6},
+    {"F7",  sf::Keyboard::F7},  {"F8",  sf::Keyboard::F8},  {"F9",  sf::Keyboard::F9},
+    {"F10", sf::Keyboard::F10}, {"F11", sf::Keyboard::F11}, {"F12", sf::Keyboard::F12},
+};
+
+sf::Keyboard::Key keyFromName(const std::string& name) {
+    for (const auto& [n, k] : kKeyTable)
+        if (name == n)
+            return k;
+    return sf::Keyboard::Unknown;
+}
+
+std::string nameFromKey(sf::Keyboard::Key key) {
+    for (const auto& [n, k] : kKeyTable)
+        if (k == key)
+            return n;
+    return "Unknown";
+}
+
+// ── Defaults ───────────────────────────────────────────────────────────────────
+
+KeyBindings defaultBindings() {
+    KeyBindings b;
+    // P1 (rocket) — numpad
+    b.p1.up = sf::Keyboard::Numpad8;
+    b.p1.down = sf::Keyboard::Numpad5;
+    b.p1.left = sf::Keyboard::Numpad4;
+    b.p1.right = sf::Keyboard::Numpad6;
+    b.p1.attack = sf::Keyboard::Right;
+    // P2 (robot) — WASD + Space
+    b.p2.up = sf::Keyboard::W;
+    b.p2.down = sf::Keyboard::S;
+    b.p2.left = sf::Keyboard::A;
+    b.p2.right = sf::Keyboard::D;
+    b.p2.attack = sf::Keyboard::Space;
+    // Debug/speed keys
+    b.slowDown = sf::Keyboard::O;
+    b.speedUp = sf::Keyboard::P;
+    b.skipCooldown = sf::Keyboard::K;
+    return b;
+}
+
+// ── loadBindings ──────────────────────────────────────────────────────────────
+
+static std::string trim(const std::string& s) {
+    auto start = s.find_first_not_of(" \t\r\n");
+    if (start == std::string::npos)
+        return {};
+    auto end = s.find_last_not_of(" \t\r\n");
+    return s.substr(start, end - start + 1);
+}
+
+KeyBindings loadBindings(std::istream& in) {
+    KeyBindings b = defaultBindings();
+    std::string line;
+    while (std::getline(in, line)) {
+        // Strip comment
+        auto cpos = line.find('#');
+        if (cpos != std::string::npos)
+            line = line.substr(0, cpos);
+        line = trim(line);
+        if (line.empty())
+            continue;
+        auto eqpos = line.find('=');
+        if (eqpos == std::string::npos)
+            continue;
+        std::string field = trim(line.substr(0, eqpos));
+        std::string val = trim(line.substr(eqpos + 1));
+        if (val.empty())
+            continue;
+
+        sf::Keyboard::Key k = keyFromName(val);
+        if (k == sf::Keyboard::Unknown) {
+            std::cerr << "[controls.cfg] Unknown key name '" << val
+                      << "' for field '" << field << "', keeping default\n";
+            continue; // keep default
+        }
+
+        if      (field == "p1_up")          b.p1.up = k;
+        else if (field == "p1_down")         b.p1.down = k;
+        else if (field == "p1_left")         b.p1.left = k;
+        else if (field == "p1_right")        b.p1.right = k;
+        else if (field == "p1_attack")       b.p1.attack = k;
+        else if (field == "p2_up")           b.p2.up = k;
+        else if (field == "p2_down")         b.p2.down = k;
+        else if (field == "p2_left")         b.p2.left = k;
+        else if (field == "p2_right")        b.p2.right = k;
+        else if (field == "p2_attack")       b.p2.attack = k;
+        else if (field == "slow_down")       b.slowDown = k;
+        else if (field == "speed_up")        b.speedUp = k;
+        else if (field == "skip_cooldown")   b.skipCooldown = k;
+        // Unknown fields silently ignored (forward-compat)
+    }
+    return b;
+}

--- a/src/key_bindings.cpp
+++ b/src/key_bindings.cpp
@@ -9,38 +9,78 @@
 
 static const std::pair<const char*, sf::Keyboard::Key> kKeyTable[] = {
     // Letters
-    {"A", sf::Keyboard::A}, {"B", sf::Keyboard::B}, {"C", sf::Keyboard::C},
-    {"D", sf::Keyboard::D}, {"E", sf::Keyboard::E}, {"F", sf::Keyboard::F},
-    {"G", sf::Keyboard::G}, {"H", sf::Keyboard::H}, {"I", sf::Keyboard::I},
-    {"J", sf::Keyboard::J}, {"K", sf::Keyboard::K}, {"L", sf::Keyboard::L},
-    {"M", sf::Keyboard::M}, {"N", sf::Keyboard::N}, {"O", sf::Keyboard::O},
-    {"P", sf::Keyboard::P}, {"Q", sf::Keyboard::Q}, {"R", sf::Keyboard::R},
-    {"S", sf::Keyboard::S}, {"T", sf::Keyboard::T}, {"U", sf::Keyboard::U},
-    {"V", sf::Keyboard::V}, {"W", sf::Keyboard::W}, {"X", sf::Keyboard::X},
-    {"Y", sf::Keyboard::Y}, {"Z", sf::Keyboard::Z},
+    {"A", sf::Keyboard::A},
+    {"B", sf::Keyboard::B},
+    {"C", sf::Keyboard::C},
+    {"D", sf::Keyboard::D},
+    {"E", sf::Keyboard::E},
+    {"F", sf::Keyboard::F},
+    {"G", sf::Keyboard::G},
+    {"H", sf::Keyboard::H},
+    {"I", sf::Keyboard::I},
+    {"J", sf::Keyboard::J},
+    {"K", sf::Keyboard::K},
+    {"L", sf::Keyboard::L},
+    {"M", sf::Keyboard::M},
+    {"N", sf::Keyboard::N},
+    {"O", sf::Keyboard::O},
+    {"P", sf::Keyboard::P},
+    {"Q", sf::Keyboard::Q},
+    {"R", sf::Keyboard::R},
+    {"S", sf::Keyboard::S},
+    {"T", sf::Keyboard::T},
+    {"U", sf::Keyboard::U},
+    {"V", sf::Keyboard::V},
+    {"W", sf::Keyboard::W},
+    {"X", sf::Keyboard::X},
+    {"Y", sf::Keyboard::Y},
+    {"Z", sf::Keyboard::Z},
     // Top-row digits
-    {"0", sf::Keyboard::Num0}, {"1", sf::Keyboard::Num1}, {"2", sf::Keyboard::Num2},
-    {"3", sf::Keyboard::Num3}, {"4", sf::Keyboard::Num4}, {"5", sf::Keyboard::Num5},
-    {"6", sf::Keyboard::Num6}, {"7", sf::Keyboard::Num7}, {"8", sf::Keyboard::Num8},
+    {"0", sf::Keyboard::Num0},
+    {"1", sf::Keyboard::Num1},
+    {"2", sf::Keyboard::Num2},
+    {"3", sf::Keyboard::Num3},
+    {"4", sf::Keyboard::Num4},
+    {"5", sf::Keyboard::Num5},
+    {"6", sf::Keyboard::Num6},
+    {"7", sf::Keyboard::Num7},
+    {"8", sf::Keyboard::Num8},
     {"9", sf::Keyboard::Num9},
     // Numpad
-    {"Num0", sf::Keyboard::Numpad0}, {"Num1", sf::Keyboard::Numpad1},
-    {"Num2", sf::Keyboard::Numpad2}, {"Num3", sf::Keyboard::Numpad3},
-    {"Num4", sf::Keyboard::Numpad4}, {"Num5", sf::Keyboard::Numpad5},
-    {"Num6", sf::Keyboard::Numpad6}, {"Num7", sf::Keyboard::Numpad7},
-    {"Num8", sf::Keyboard::Numpad8}, {"Num9", sf::Keyboard::Numpad9},
+    {"Num0", sf::Keyboard::Numpad0},
+    {"Num1", sf::Keyboard::Numpad1},
+    {"Num2", sf::Keyboard::Numpad2},
+    {"Num3", sf::Keyboard::Numpad3},
+    {"Num4", sf::Keyboard::Numpad4},
+    {"Num5", sf::Keyboard::Numpad5},
+    {"Num6", sf::Keyboard::Numpad6},
+    {"Num7", sf::Keyboard::Numpad7},
+    {"Num8", sf::Keyboard::Numpad8},
+    {"Num9", sf::Keyboard::Numpad9},
     // Arrow keys
-    {"Up", sf::Keyboard::Up},     {"Down", sf::Keyboard::Down},
-    {"Left", sf::Keyboard::Left}, {"Right", sf::Keyboard::Right},
+    {"Up", sf::Keyboard::Up},
+    {"Down", sf::Keyboard::Down},
+    {"Left", sf::Keyboard::Left},
+    {"Right", sf::Keyboard::Right},
     // Special keys
-    {"Space", sf::Keyboard::Space},     {"Enter", sf::Keyboard::Return},
-    {"Escape", sf::Keyboard::Escape},   {"Tab", sf::Keyboard::Tab},
+    {"Space", sf::Keyboard::Space},
+    {"Enter", sf::Keyboard::Return},
+    {"Escape", sf::Keyboard::Escape},
+    {"Tab", sf::Keyboard::Tab},
     {"Backspace", sf::Keyboard::BackSpace},
     // Function keys
-    {"F1",  sf::Keyboard::F1},  {"F2",  sf::Keyboard::F2},  {"F3",  sf::Keyboard::F3},
-    {"F4",  sf::Keyboard::F4},  {"F5",  sf::Keyboard::F5},  {"F6",  sf::Keyboard::F6},
-    {"F7",  sf::Keyboard::F7},  {"F8",  sf::Keyboard::F8},  {"F9",  sf::Keyboard::F9},
-    {"F10", sf::Keyboard::F10}, {"F11", sf::Keyboard::F11}, {"F12", sf::Keyboard::F12},
+    {"F1", sf::Keyboard::F1},
+    {"F2", sf::Keyboard::F2},
+    {"F3", sf::Keyboard::F3},
+    {"F4", sf::Keyboard::F4},
+    {"F5", sf::Keyboard::F5},
+    {"F6", sf::Keyboard::F6},
+    {"F7", sf::Keyboard::F7},
+    {"F8", sf::Keyboard::F8},
+    {"F9", sf::Keyboard::F9},
+    {"F10", sf::Keyboard::F10},
+    {"F11", sf::Keyboard::F11},
+    {"F12", sf::Keyboard::F12},
 };
 
 sf::Keyboard::Key keyFromName(const std::string& name) {
@@ -111,24 +151,37 @@ KeyBindings loadBindings(std::istream& in) {
 
         sf::Keyboard::Key k = keyFromName(val);
         if (k == sf::Keyboard::Unknown) {
-            std::cerr << "[controls.cfg] Unknown key name '" << val
-                      << "' for field '" << field << "', keeping default\n";
+            std::cerr << "[controls.cfg] Unknown key name '" << val << "' for field '" << field
+                      << "', keeping default\n";
             continue; // keep default
         }
 
-        if      (field == "p1_up")          b.p1.up = k;
-        else if (field == "p1_down")         b.p1.down = k;
-        else if (field == "p1_left")         b.p1.left = k;
-        else if (field == "p1_right")        b.p1.right = k;
-        else if (field == "p1_attack")       b.p1.attack = k;
-        else if (field == "p2_up")           b.p2.up = k;
-        else if (field == "p2_down")         b.p2.down = k;
-        else if (field == "p2_left")         b.p2.left = k;
-        else if (field == "p2_right")        b.p2.right = k;
-        else if (field == "p2_attack")       b.p2.attack = k;
-        else if (field == "slow_down")       b.slowDown = k;
-        else if (field == "speed_up")        b.speedUp = k;
-        else if (field == "skip_cooldown")   b.skipCooldown = k;
+        if (field == "p1_up")
+            b.p1.up = k;
+        else if (field == "p1_down")
+            b.p1.down = k;
+        else if (field == "p1_left")
+            b.p1.left = k;
+        else if (field == "p1_right")
+            b.p1.right = k;
+        else if (field == "p1_attack")
+            b.p1.attack = k;
+        else if (field == "p2_up")
+            b.p2.up = k;
+        else if (field == "p2_down")
+            b.p2.down = k;
+        else if (field == "p2_left")
+            b.p2.left = k;
+        else if (field == "p2_right")
+            b.p2.right = k;
+        else if (field == "p2_attack")
+            b.p2.attack = k;
+        else if (field == "slow_down")
+            b.slowDown = k;
+        else if (field == "speed_up")
+            b.speedUp = k;
+        else if (field == "skip_cooldown")
+            b.skipCooldown = k;
         // Unknown fields silently ignored (forward-compat)
     }
     return b;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,40 +3,42 @@
 #include "NetworkManager.h"
 #include "asset_load.h"
 #include "debug.h"
+#include "key_bindings.h"
+#include "letterbox.h"
 #include "resource_path.h"
 #include "rng.h"
 #include <SFML/Graphics.hpp>
 #include <cstdio>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <tuple>
 
-void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL,
-               std::shared_ptr<NetworkManager> netManager = nullptr) {
-    std::tuple<int, int, float, int, bool, bool> tuple;
-    if (mode != NetworkMode::LOCAL && netManager) {
-        Game game(mode, netManager);
-        tuple = game.run();
-    } else {
-        Game game;
-        tuple = game.run();
-    }
-    int p1score = std::get<0>(tuple);
-    int p2score = std::get<1>(tuple);
-    float tempM = std::get<2>(tuple);
-    int tempS = std::get<3>(tuple);
-    bool peerLeft = std::get<5>(tuple);
-    char gTime[10];
-    std::snprintf(gTime, sizeof(gTime), "%02.0f:%02d", tempM, tempS);
-    std::string finalTime = gTime;
+// Logical canvas size for the menu / endscreen windows.
+static constexpr float kMenuW = 1024.f;
+static constexpr float kMenuH = 576.f;
 
-    if (p1score > highscore)
-        highscore = p1score;
-    if (p2score > highscore)
-        highscore = p2score;
+enum MenuState { MAIN_MENU, HOST_WAITING, JOIN_INPUT, READY_TO_START };
+
+struct MenuResult {
+    NetworkMode mode = NetworkMode::LOCAL;
+    std::shared_ptr<NetworkManager> netManager;
+    bool quit = false;
+};
+
+// ── showEndscreen ─────────────────────────────────────────────────────────────
+// Show the post-game results screen.  Returns true if the player wants to play
+// again immediately (LOCAL only; online always returns false so the caller goes
+// back through the menu to re-establish the connection).
+
+static bool showEndscreen(int highscore, int p1score, int p2score, float minutes, int seconds,
+                          bool peerLeft, NetworkMode mode) {
+    char gTime[10];
+    std::snprintf(gTime, sizeof(gTime), "%02.0f:%02d", minutes, seconds);
+    const std::string finalTime = gTime;
 
     sf::Font tfont;
     sf::Font pfont;
@@ -52,16 +54,16 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL,
     loadOrThrow(pfont, resource_path + "Joyful_Theatre.otf");
     loadOrThrow(tfont, resource_path + "timer.ttf");
 
-    sf::RenderWindow endscreen(sf::VideoMode(1024, 576), "end game");
+    sf::RenderWindow endscreen(sf::VideoMode(1024, 576), "end game", sf::Style::Default);
+    endscreen.setView(makeLetterboxView({kMenuW, kMenuH}, endscreen.getSize()));
 
     sf::Text peerDisconnectedText("", pfont, 36);
     if (peerLeft) {
         peerDisconnectedText.setString("Peer disconnected");
         peerDisconnectedText.setFillColor(sf::Color::Red);
         peerDisconnectedText.setStyle(sf::Text::Bold);
-        // Use getLocalBounds for centering — unaffected by world transform.
         peerDisconnectedText.setOrigin(peerDisconnectedText.getLocalBounds().width / 2.f, 0);
-        peerDisconnectedText.setPosition(endscreen.getSize().x / 2.f, 460.f);
+        peerDisconnectedText.setPosition(kMenuW / 2.f, 460.f);
     }
 
     sf::Music background;
@@ -73,15 +75,12 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL,
     p2scoret.setFillColor(sf::Color::Green);
     finalTimet = sf::Text(finalTime, tfont, 50);
     finalTimet.setFillColor(sf::Color::Blue);
-
     highscoret = sf::Text(std::to_string(highscore), pfont, 70);
 
-    p1scoret.setPosition(5, endscreen.getSize().y / 2);
-    p2scoret.setPosition(endscreen.getSize().x - (p1scoret.getGlobalBounds().width) - 5,
-                         endscreen.getSize().y / 2);
-    finalTimet.setPosition(endscreen.getSize().x / 2 - finalTimet.getGlobalBounds().width + 20,
-                           -10);
-    highscoret.setPosition(endscreen.getSize().x / 2 - highscoret.getGlobalBounds().width, 25);
+    p1scoret.setPosition(5, kMenuH / 2);
+    p2scoret.setPosition(kMenuW - p1scoret.getGlobalBounds().width - 5, kMenuH / 2);
+    finalTimet.setPosition(kMenuW / 2 - finalTimet.getGlobalBounds().width + 20, -10);
+    highscoret.setPosition(kMenuW / 2 - highscoret.getGlobalBounds().width, 25);
 
     if (p1score == highscore)
         highscoret.setFillColor(sf::Color::Blue);
@@ -107,16 +106,82 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL,
     auto m_start = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
     loadOrThrow(*m_start, resource_path + "start.png");
     m_start->setOrigin();
-    m_start->setPosition((endscreen.getSize().x / 2), (endscreen.getSize().y / 3));
+    m_start->setPosition(kMenuW / 2, kMenuH / 3);
     m_start->setScale(.5f);
 
     auto m_quit = std::make_unique<AnimatedGameObject>(1332, 300, 2, 1, 2, 0);
     loadOrThrow(*m_quit, resource_path + "quit.png");
     m_quit->setOrigin();
-    m_quit->setPosition((endscreen.getSize().x / 2), 2 * (endscreen.getSize().y / 3));
+    m_quit->setPosition(kMenuW / 2, 2 * (kMenuH / 3));
     m_quit->setScale(.5f);
 
+    bool playAgain = false;
+
     while (endscreen.isOpen()) {
+        sf::Rect<float> srect(sf::Vector2f(m_start->getPosition().x - (m_start->getWidth() / 4),
+                                           m_start->getPosition().y - (m_start->getHeight() / 4)),
+                              sf::Vector2f(m_start->getWidth() * m_start->getScale().x,
+                                           m_start->getHeight() * m_start->getScale().y));
+        sf::Rect<float> qrect(sf::Vector2f(m_quit->getPosition().x - (m_quit->getWidth() / 4),
+                                           m_quit->getPosition().y - (m_quit->getHeight() / 4)),
+                              sf::Vector2f(m_quit->getWidth() * m_quit->getScale().x,
+                                           m_quit->getHeight() * m_quit->getScale().y));
+
+        sf::Vector2f mousePos = endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen));
+
+        if (srect.contains(mousePos) && !start_updated) {
+            m_start->update(0.0f);
+            start_updated = true;
+            press.play();
+        } else if (!srect.contains(mousePos) && start_updated) {
+            start_updated = false;
+            m_start->update(0.0f);
+            up.play();
+        }
+
+        if (qrect.contains(mousePos) && !quit_updated) {
+            m_quit->update(0.0f);
+            quit_updated = true;
+            press.play();
+        } else if (!qrect.contains(mousePos) && quit_updated) {
+            quit_updated = false;
+            m_quit->update(0.0f);
+            up.play();
+        }
+
+        if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && srect.contains(mousePos)) {
+            background.stop();
+            endscreen.close();
+            // Play again only for LOCAL; online must go back through menu.
+            playAgain = (mode == NetworkMode::LOCAL);
+        }
+        if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && qrect.contains(mousePos)) {
+            background.stop();
+            endscreen.close();
+        }
+
+        sf::Event event;
+        while (endscreen.pollEvent(event)) {
+            if (event.type == sf::Event::Closed) {
+                background.stop();
+                endscreen.close();
+            }
+            if (event.type == sf::Event::Resized) {
+                endscreen.setView(
+                    makeLetterboxView({kMenuW, kMenuH}, {event.size.width, event.size.height}));
+            }
+            if (event.type == sf::Event::KeyPressed) {
+                if (event.key.code == sf::Keyboard::Y) {
+                    background.stop();
+                    endscreen.close();
+                    playAgain = (mode == NetworkMode::LOCAL);
+                }
+                if (event.key.code == sf::Keyboard::N) {
+                    background.stop();
+                    endscreen.close();
+                }
+            }
+        }
 
         endscreen.clear();
         wall.draw(endscreen);
@@ -129,76 +194,394 @@ void startgame(int& highscore, NetworkMode mode = NetworkMode::LOCAL,
         if (peerLeft)
             endscreen.draw(peerDisconnectedText);
         endscreen.display();
-
-        sf::Event event;
-        sf::Rect<float> srect;
-        srect = sf::Rect<float>(sf::Vector2f(m_start->getPosition().x - (m_start->getWidth() / 4),
-                                             m_start->getPosition().y - (m_start->getHeight() / 4)),
-                                sf::Vector2f(m_start->getWidth() * m_start->getScale().x,
-                                             m_start->getHeight() * m_start->getScale().y));
-        if (srect.contains(endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen))) &&
-            !start_updated) {
-            m_start->update(0.0f);
-            start_updated = true;
-            press.play();
-        } else if (!srect.contains(endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen))) &&
-                   start_updated) {
-            start_updated = false;
-            m_start->update(0.0f);
-            up.play();
-        }
-
-        sf::Rect<float> qrect =
-            sf::Rect<float>(sf::Vector2f(m_quit->getPosition().x - (m_quit->getWidth() / 4),
-                                         m_quit->getPosition().y - (m_quit->getHeight() / 4)),
-                            sf::Vector2f(m_quit->getWidth() * m_quit->getScale().x,
-                                         m_quit->getHeight() * m_quit->getScale().y));
-
-        if (qrect.contains(endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen))) &&
-            !quit_updated) {
-            m_quit->update(0.0f);
-            quit_updated = true;
-            press.play();
-        } else if (!qrect.contains(endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen))) &&
-                   quit_updated) {
-            quit_updated = false;
-            m_quit->update(0.0f);
-            up.play();
-        }
-
-        if (sf::Mouse::isButtonPressed(sf::Mouse::Left) &&
-            srect.contains(endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen)))) {
-            background.stop();
-            endscreen.close();
-            startgame(highscore, mode, netManager);
-        }
-        if (sf::Mouse::isButtonPressed(sf::Mouse::Left) &&
-            qrect.contains(endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen)))) {
-            background.stop();
-            endscreen.close();
-        }
-
-        while (endscreen.pollEvent(event)) {
-            if (event.type == sf::Event::Closed) {
-                background.stop();
-                endscreen.close();
-            }
-            if (event.type == sf::Event::KeyPressed) {
-                if (event.key.code == sf::Keyboard::Y) {
-                    background.stop();
-                    endscreen.close();
-                    startgame(highscore, mode, netManager);
-                }
-                if (event.key.code == sf::Keyboard::N) {
-                    background.stop();
-                    endscreen.close();
-                }
-            }
-        }
     }
+
+    return playAgain;
 }
 
-enum MenuState { MAIN_MENU, HOST_WAITING, JOIN_INPUT, READY_TO_START };
+// ── showMenu ──────────────────────────────────────────────────────────────────
+// Runs the start screen menu loop.  Returns the selected game mode, network
+// manager, and a quit flag (true if the user closed the window without starting).
+
+static MenuResult showMenu() {
+    MenuState menuState = MAIN_MENU;
+    NetworkMode mode = NetworkMode::LOCAL;
+    std::shared_ptr<NetworkManager> netManager = nullptr;
+    std::string ipInput = "127.0.0.1";
+    std::string statusMessage;
+    std::string hostIpAddress;
+
+    RegularGameObject david = RegularGameObject();
+    loadOrThrow(david, resource_path + "david_background.png");
+
+    sf::Music background;
+    loadOrThrow(background, resource_path + "m_start_background.wav");
+    background.play();
+    background.setVolume(60);
+    background.setLoop(true);
+
+    sf::SoundBuffer down_buffer;
+    sf::SoundBuffer up_buffer;
+    loadOrThrow(down_buffer, resource_path + "ButtonOn.wav");
+    loadOrThrow(up_buffer, resource_path + "ButtonOff.wav");
+
+    sf::Sound press;
+    sf::Sound up;
+    press.setBuffer(down_buffer);
+    up.setBuffer(up_buffer);
+
+    sf::Font font;
+    loadOrThrow(font, resource_path + "oswald.ttf");
+
+    bool start_updated = false;
+    bool quit_updated = false;
+    bool host_updated = false;
+    bool join_updated = false;
+    bool back_updated = false;
+
+    sf::RenderWindow startscreen(sf::VideoMode(1024, 576), "Dungeon Game", sf::Style::Default);
+    startscreen.setView(makeLetterboxView({kMenuW, kMenuH}, startscreen.getSize()));
+
+    auto m_start = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
+    loadOrThrow(*m_start, resource_path + "start.png");
+    m_start->setOrigin();
+    m_start->setPosition(kMenuW / 2, 200);
+    m_start->setScale(.4f);
+
+    auto m_host = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
+    loadOrThrow(*m_host, resource_path + "start.png");
+    m_host->setOrigin();
+    m_host->setPosition(kMenuW / 2, 320);
+    m_host->setScale(.4f);
+
+    auto m_join = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
+    loadOrThrow(*m_join, resource_path + "start.png");
+    m_join->setOrigin();
+    m_join->setPosition(kMenuW / 2, 440);
+    m_join->setScale(.4f);
+
+    auto m_quit = std::make_unique<AnimatedGameObject>(1332, 300, 2, 1, 2, 0);
+    loadOrThrow(*m_quit, resource_path + "quit.png");
+    m_quit->setOrigin();
+    m_quit->setPosition(kMenuW / 2, 520);
+    m_quit->setScale(.3f);
+
+    auto m_back = std::make_unique<AnimatedGameObject>(1332, 300, 2, 1, 2, 0);
+    loadOrThrow(*m_back, resource_path + "quit.png");
+    m_back->setOrigin();
+    m_back->setPosition(100, 50);
+    m_back->setScale(.25f);
+
+    sf::Text localLabel("LOCAL", font, 40);
+    localLabel.setFillColor(sf::Color::White);
+    localLabel.setStyle(sf::Text::Bold);
+
+    sf::Text hostLabel("HOST", font, 40);
+    hostLabel.setFillColor(sf::Color::Green);
+    hostLabel.setStyle(sf::Text::Bold);
+
+    sf::Text joinLabel("JOIN", font, 40);
+    joinLabel.setFillColor(sf::Color::Blue);
+    joinLabel.setStyle(sf::Text::Bold);
+
+    sf::Text backLabel("BACK", font, 20);
+    backLabel.setFillColor(sf::Color::White);
+
+    MenuResult result;
+
+    while (startscreen.isOpen()) {
+        sf::Event event;
+        while (startscreen.pollEvent(event)) {
+            if (event.type == sf::Event::Closed) {
+                background.stop();
+                startscreen.close();
+                result.quit = true;
+                return result;
+            }
+            if (event.type == sf::Event::Resized) {
+                startscreen.setView(
+                    makeLetterboxView({kMenuW, kMenuH}, {event.size.width, event.size.height}));
+            }
+            if (menuState == JOIN_INPUT && event.type == sf::Event::TextEntered) {
+                if (event.text.unicode == '\b' && !ipInput.empty()) {
+                    ipInput.pop_back();
+                } else if (event.text.unicode == '\r' || event.text.unicode == '\n') {
+                    netManager = std::make_shared<NetworkManager>();
+                    statusMessage = "Connecting...";
+                    if (netManager->connectToHost(ipInput)) {
+                        mode = NetworkMode::CLIENT;
+                        menuState = READY_TO_START;
+                        statusMessage = "Connected! Click START to begin";
+                    } else {
+                        statusMessage = "Failed to connect (invalid IP or host unreachable)";
+                        netManager = nullptr;
+                    }
+                } else if (event.text.unicode < 128 && event.text.unicode != '\b' &&
+                           ipInput.length() < 30) {
+                    char c = static_cast<char>(event.text.unicode);
+                    if ((c >= '0' && c <= '9') || c == '.' || c == ':')
+                        ipInput += c;
+                }
+            }
+        }
+
+        sf::Vector2f mousePos = startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen));
+
+        sf::Rect<float> startRect(m_start->getPosition().x - (m_start->getWidth() / 4),
+                                  m_start->getPosition().y - (m_start->getHeight() / 4),
+                                  m_start->getWidth() * m_start->getScale().x,
+                                  m_start->getHeight() * m_start->getScale().y);
+        sf::Rect<float> hostRect(m_host->getPosition().x - (m_host->getWidth() / 4),
+                                 m_host->getPosition().y - (m_host->getHeight() / 4),
+                                 m_host->getWidth() * m_host->getScale().x,
+                                 m_host->getHeight() * m_host->getScale().y);
+        sf::Rect<float> joinRect(m_join->getPosition().x - (m_join->getWidth() / 4),
+                                 m_join->getPosition().y - (m_join->getHeight() / 4),
+                                 m_join->getWidth() * m_join->getScale().x,
+                                 m_join->getHeight() * m_join->getScale().y);
+        sf::Rect<float> quitRect(m_quit->getPosition().x - (m_quit->getWidth() / 4),
+                                 m_quit->getPosition().y - (m_quit->getHeight() / 4),
+                                 m_quit->getWidth() * m_quit->getScale().x,
+                                 m_quit->getHeight() * m_quit->getScale().y);
+        sf::Rect<float> backRect(m_back->getPosition().x - (m_back->getWidth() / 4),
+                                 m_back->getPosition().y - (m_back->getHeight() / 4),
+                                 m_back->getWidth() * m_back->getScale().x,
+                                 m_back->getHeight() * m_back->getScale().y);
+
+        if (menuState == MAIN_MENU) {
+            if (startRect.contains(mousePos) && !start_updated) {
+                m_start->update(0.0f);
+                start_updated = true;
+                press.play();
+            } else if (!startRect.contains(mousePos) && start_updated) {
+                start_updated = false;
+                m_start->update(0.0f);
+                up.play();
+            }
+            if (hostRect.contains(mousePos) && !host_updated) {
+                m_host->update(0.0f);
+                host_updated = true;
+                press.play();
+            } else if (!hostRect.contains(mousePos) && host_updated) {
+                host_updated = false;
+                m_host->update(0.0f);
+                up.play();
+            }
+            if (joinRect.contains(mousePos) && !join_updated) {
+                m_join->update(0.0f);
+                join_updated = true;
+                press.play();
+            } else if (!joinRect.contains(mousePos) && join_updated) {
+                join_updated = false;
+                m_join->update(0.0f);
+                up.play();
+            }
+            if (quitRect.contains(mousePos) && !quit_updated) {
+                m_quit->update(0.0f);
+                quit_updated = true;
+                press.play();
+            } else if (!quitRect.contains(mousePos) && quit_updated) {
+                quit_updated = false;
+                m_quit->update(0.0f);
+                up.play();
+            }
+            if (sf::Mouse::isButtonPressed(sf::Mouse::Left)) {
+                if (startRect.contains(mousePos)) {
+                    mode = NetworkMode::LOCAL;
+                    menuState = READY_TO_START;
+                    sf::sleep(sf::milliseconds(200));
+                } else if (hostRect.contains(mousePos)) {
+                    netManager = std::make_shared<NetworkManager>();
+                    if (netManager->startHost()) {
+                        mode = NetworkMode::HOST;
+                        menuState = HOST_WAITING;
+                        hostIpAddress = sf::IpAddress::getLocalAddress().toString();
+                        statusMessage = "Waiting for player 2...";
+                    } else {
+                        statusMessage = "Failed to start host!";
+                        netManager = nullptr;
+                    }
+                    sf::sleep(sf::milliseconds(200));
+                } else if (joinRect.contains(mousePos)) {
+                    menuState = JOIN_INPUT;
+                    statusMessage = "Enter host IP address";
+                    sf::sleep(sf::milliseconds(200));
+                } else if (quitRect.contains(mousePos)) {
+                    background.stop();
+                    startscreen.close();
+                    result.quit = true;
+                    return result;
+                }
+            }
+        } else if (menuState == HOST_WAITING) {
+            if (netManager && netManager->waitForClient(sf::milliseconds(100))) {
+                menuState = READY_TO_START;
+                statusMessage = "Player 2 connected! Click START to begin";
+            }
+            if (backRect.contains(mousePos) && !back_updated) {
+                m_back->update(0.0f);
+                back_updated = true;
+                press.play();
+            } else if (!backRect.contains(mousePos) && back_updated) {
+                back_updated = false;
+                m_back->update(0.0f);
+                up.play();
+            }
+            if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && backRect.contains(mousePos)) {
+                menuState = MAIN_MENU;
+                netManager = nullptr;
+                statusMessage = "";
+                sf::sleep(sf::milliseconds(200));
+            }
+        } else if (menuState == JOIN_INPUT) {
+            if (backRect.contains(mousePos) && !back_updated) {
+                m_back->update(0.0f);
+                back_updated = true;
+                press.play();
+            } else if (!backRect.contains(mousePos) && back_updated) {
+                back_updated = false;
+                m_back->update(0.0f);
+                up.play();
+            }
+            if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && backRect.contains(mousePos)) {
+                menuState = MAIN_MENU;
+                ipInput = "127.0.0.1";
+                statusMessage = "";
+                sf::sleep(sf::milliseconds(200));
+            }
+        } else if (menuState == READY_TO_START) {
+            if (startRect.contains(mousePos) && !start_updated) {
+                m_start->update(0.0f);
+                start_updated = true;
+                press.play();
+            } else if (!startRect.contains(mousePos) && start_updated) {
+                start_updated = false;
+                m_start->update(0.0f);
+                up.play();
+            }
+            if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && startRect.contains(mousePos)) {
+                background.stop();
+                startscreen.close();
+                result.mode = mode;
+                result.netManager = netManager;
+                return result;
+            }
+        }
+
+        startscreen.clear();
+        david.draw(startscreen);
+
+        if (menuState == MAIN_MENU) {
+            m_start->draw(startscreen);
+            m_host->draw(startscreen);
+            m_join->draw(startscreen);
+            m_quit->draw(startscreen);
+
+            localLabel.setOrigin(localLabel.getGlobalBounds().width / 2,
+                                 localLabel.getGlobalBounds().height / 2);
+            localLabel.setPosition(m_start->getPosition().x, m_start->getPosition().y);
+            startscreen.draw(localLabel);
+
+            hostLabel.setOrigin(hostLabel.getGlobalBounds().width / 2,
+                                hostLabel.getGlobalBounds().height / 2);
+            hostLabel.setPosition(m_host->getPosition().x, m_host->getPosition().y);
+            startscreen.draw(hostLabel);
+
+            joinLabel.setOrigin(joinLabel.getGlobalBounds().width / 2,
+                                joinLabel.getGlobalBounds().height / 2);
+            joinLabel.setPosition(m_join->getPosition().x, m_join->getPosition().y);
+            startscreen.draw(joinLabel);
+        } else if (menuState == HOST_WAITING) {
+            m_back->draw(startscreen);
+            backLabel.setOrigin(backLabel.getGlobalBounds().width / 2,
+                                backLabel.getGlobalBounds().height / 2);
+            backLabel.setPosition(m_back->getPosition().x, m_back->getPosition().y);
+            startscreen.draw(backLabel);
+
+            sf::Text title("HOSTING GAME", font, 50);
+            title.setFillColor(sf::Color::Green);
+            title.setStyle(sf::Text::Bold);
+            title.setOrigin(title.getGlobalBounds().width / 2, 0);
+            title.setPosition(kMenuW / 2, 150);
+            startscreen.draw(title);
+
+            sf::Text ipText("Your IP: " + hostIpAddress, font, 35);
+            ipText.setFillColor(sf::Color::White);
+            ipText.setOrigin(ipText.getGlobalBounds().width / 2, 0);
+            ipText.setPosition(kMenuW / 2, 250);
+            startscreen.draw(ipText);
+
+            sf::Text statusText(statusMessage, font, 30);
+            statusText.setFillColor(sf::Color(200, 200, 200));
+            statusText.setOrigin(statusText.getGlobalBounds().width / 2, 0);
+            statusText.setPosition(kMenuW / 2, 350);
+            startscreen.draw(statusText);
+        } else if (menuState == JOIN_INPUT) {
+            m_back->draw(startscreen);
+            backLabel.setOrigin(backLabel.getGlobalBounds().width / 2,
+                                backLabel.getGlobalBounds().height / 2);
+            backLabel.setPosition(m_back->getPosition().x, m_back->getPosition().y);
+            startscreen.draw(backLabel);
+
+            sf::Text title("JOIN GAME", font, 50);
+            title.setFillColor(sf::Color::Blue);
+            title.setStyle(sf::Text::Bold);
+            title.setOrigin(title.getGlobalBounds().width / 2, 0);
+            title.setPosition(kMenuW / 2, 150);
+            startscreen.draw(title);
+
+            sf::Text prompt("Enter Host IP Address:", font, 30);
+            prompt.setFillColor(sf::Color::White);
+            prompt.setOrigin(prompt.getGlobalBounds().width / 2, 0);
+            prompt.setPosition(kMenuW / 2, 250);
+            startscreen.draw(prompt);
+
+            sf::Text ipText(ipInput, font, 40);
+            ipText.setFillColor(sf::Color::Green);
+            ipText.setOrigin(ipText.getGlobalBounds().width / 2, 0);
+            ipText.setPosition(kMenuW / 2, 320);
+            startscreen.draw(ipText);
+
+            sf::Text instruct("Press ENTER to connect", font, 25);
+            instruct.setFillColor(sf::Color(200, 200, 200));
+            instruct.setOrigin(instruct.getGlobalBounds().width / 2, 0);
+            instruct.setPosition(kMenuW / 2, 400);
+            startscreen.draw(instruct);
+
+            if (!statusMessage.empty()) {
+                sf::Text statusText(statusMessage, font, 22);
+                if (statusMessage.find("Failed") != std::string::npos)
+                    statusText.setFillColor(sf::Color::Red);
+                else
+                    statusText.setFillColor(sf::Color::Yellow);
+                statusText.setOrigin(statusText.getGlobalBounds().width / 2, 0);
+                statusText.setPosition(kMenuW / 2, 460);
+                startscreen.draw(statusText);
+            }
+        } else if (menuState == READY_TO_START) {
+            m_start->draw(startscreen);
+            localLabel.setString("START");
+            localLabel.setOrigin(localLabel.getGlobalBounds().width / 2,
+                                 localLabel.getGlobalBounds().height / 2);
+            localLabel.setPosition(m_start->getPosition().x, m_start->getPosition().y);
+            startscreen.draw(localLabel);
+
+            sf::Text statusText(statusMessage, font, 30);
+            statusText.setFillColor(sf::Color::Green);
+            statusText.setStyle(sf::Text::Bold);
+            statusText.setOrigin(statusText.getGlobalBounds().width / 2, 0);
+            statusText.setPosition(kMenuW / 2, 350);
+            startscreen.draw(statusText);
+        }
+
+        startscreen.display();
+    }
+
+    result.quit = true;
+    return result;
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
 
 int main(int argc, char** argv) {
     try {
@@ -241,6 +624,22 @@ int main(int argc, char** argv) {
                               << "  --screenshot-dir <d>   Directory for screenshots (default: .)\n"
                               << "  --seed <n>             Seed the RNG\n"
                               << "\n"
+                              << "Key bindings can be customised by placing a controls.cfg file\n"
+                              << "next to the dungeon_game binary.  Example:\n"
+                              << "  p1_up = Num8\n"
+                              << "  p1_down = Num5\n"
+                              << "  p1_left = Num4\n"
+                              << "  p1_right = Num6\n"
+                              << "  p1_attack = Right\n"
+                              << "  p2_up = W\n"
+                              << "  p2_down = S\n"
+                              << "  p2_left = A\n"
+                              << "  p2_right = D\n"
+                              << "  p2_attack = Space\n"
+                              << "  slow_down = O\n"
+                              << "  speed_up = P\n"
+                              << "  skip_cooldown = K\n"
+                              << "\n"
                               << "Replay format: one line per step — 'up down left right attack' "
                                  "(0 or 1)\n"
                               << "  Everything from '#' to end-of-line is ignored; blank lines "
@@ -273,413 +672,49 @@ int main(int argc, char** argv) {
             return 0;
         }
 
-        // ── Normal menu flow (unchanged) ──────────────────────────────────────────
-        MenuState menuState = MAIN_MENU;
-        NetworkMode mode = NetworkMode::LOCAL;
-        std::shared_ptr<NetworkManager> netManager = nullptr;
-        std::string ipInput = "127.0.0.1";
-        std::string statusMessage = "";
-        std::string hostIpAddress = "";
-
-        // Load resources
-        RegularGameObject david = RegularGameObject();
-        loadOrThrow(david, resource_path + "david_background.png");
-
-        sf::Music background;
-        loadOrThrow(background, resource_path + "m_start_background.wav");
-
-        background.play();
-        background.setVolume(60);
-        background.setLoop(true);
-
-        sf::SoundBuffer down_buffer;
-        sf::SoundBuffer up_buffer;
-        loadOrThrow(down_buffer, resource_path + "ButtonOn.wav");
-        loadOrThrow(up_buffer, resource_path + "ButtonOff.wav");
-
-        sf::Sound press;
-        sf::Sound up;
-        press.setBuffer(down_buffer);
-        up.setBuffer(up_buffer);
-
-        // Load font for UI text
-        sf::Font font;
-        loadOrThrow(font, resource_path + "oswald.ttf");
-
-        bool start_updated = false;
-        bool quit_updated = false;
-        bool host_updated = false;
-        bool join_updated = false;
-        bool back_updated = false;
-
-        sf::RenderWindow startscreen(sf::VideoMode(1024, 576), "Dungeon Game");
-        // Create button objects for main menu
-        auto m_start = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
-        loadOrThrow(*m_start, resource_path + "start.png");
-        m_start->setOrigin();
-        m_start->setPosition(startscreen.getSize().x / 2, 200);
-        m_start->setScale(.4f);
-
-        // Create host and join buttons (will use text labels with start button image)
-        auto m_host = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
-        loadOrThrow(*m_host, resource_path + "start.png");
-        m_host->setOrigin();
-        m_host->setPosition(startscreen.getSize().x / 2, 320);
-        m_host->setScale(.4f);
-
-        auto m_join = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
-        loadOrThrow(*m_join, resource_path + "start.png");
-        m_join->setOrigin();
-        m_join->setPosition(startscreen.getSize().x / 2, 440);
-        m_join->setScale(.4f);
-
-        auto m_quit = std::make_unique<AnimatedGameObject>(1332, 300, 2, 1, 2, 0);
-        loadOrThrow(*m_quit, resource_path + "quit.png");
-        m_quit->setOrigin();
-        m_quit->setPosition((startscreen.getSize().x / 2), 520);
-        m_quit->setScale(.3f);
-
-        // Back button (using quit button graphics)
-        auto m_back = std::make_unique<AnimatedGameObject>(1332, 300, 2, 1, 2, 0);
-        loadOrThrow(*m_back, resource_path + "quit.png");
-        m_back->setOrigin();
-        m_back->setPosition(100, 50);
-        m_back->setScale(.25f);
-
-        // Text labels for buttons
-        sf::Text localLabel("LOCAL", font, 40);
-        localLabel.setFillColor(sf::Color::White);
-        localLabel.setStyle(sf::Text::Bold);
-
-        sf::Text hostLabel("HOST", font, 40);
-        hostLabel.setFillColor(sf::Color::Green);
-        hostLabel.setStyle(sf::Text::Bold);
-
-        sf::Text joinLabel("JOIN", font, 40);
-        joinLabel.setFillColor(sf::Color::Blue);
-        joinLabel.setStyle(sf::Text::Bold);
-
-        sf::Text backLabel("BACK", font, 20);
-        backLabel.setFillColor(sf::Color::White);
-
-        while (startscreen.isOpen()) {
-            sf::Event event;
-            while (startscreen.pollEvent(event)) {
-                if (event.type == sf::Event::Closed) {
-                    background.stop();
-                    startscreen.close();
-                }
-
-                // Handle text input for IP address in JOIN_INPUT state
-                if (menuState == JOIN_INPUT && event.type == sf::Event::TextEntered) {
-                    if (event.text.unicode == '\b' && !ipInput.empty()) {
-                        ipInput.pop_back();
-                    } else if (event.text.unicode == '\r' || event.text.unicode == '\n') {
-                        // Try to connect
-                        netManager = std::make_shared<NetworkManager>();
-                        statusMessage = "Connecting...";
-
-                        if (netManager->connectToHost(ipInput)) {
-                            mode = NetworkMode::CLIENT;
-                            menuState = READY_TO_START;
-                            statusMessage = "Connected! Click START to begin";
-                        } else {
-                            statusMessage = "Failed to connect (invalid IP or host unreachable)";
-                            netManager = nullptr;
-                        }
-                    } else if (event.text.unicode < 128 && event.text.unicode != '\b' &&
-                               ipInput.length() < 30) {
-                        char c = static_cast<char>(event.text.unicode);
-                        // Allow only valid IP characters
-                        if ((c >= '0' && c <= '9') || c == '.' || c == ':') {
-                            ipInput += c;
-                        }
-                    }
-                }
+        // ── Load key bindings (exe-relative controls.cfg, absent → defaults) ──────
+        KeyBindings bindings = defaultBindings();
+        {
+            namespace fs = std::filesystem;
+            fs::path cfgPath = fs::path(exe_dir_path) / "controls.cfg";
+            if (fs::exists(cfgPath)) {
+                std::ifstream f(cfgPath);
+                bindings = loadBindings(f);
             }
-
-            // Get mouse position
-            sf::Vector2f mousePos =
-                startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen));
-
-            // Define button rectangles
-            sf::Rect<float> startRect(m_start->getPosition().x - (m_start->getWidth() / 4),
-                                      m_start->getPosition().y - (m_start->getHeight() / 4),
-                                      m_start->getWidth() * m_start->getScale().x,
-                                      m_start->getHeight() * m_start->getScale().y);
-
-            sf::Rect<float> hostRect(m_host->getPosition().x - (m_host->getWidth() / 4),
-                                     m_host->getPosition().y - (m_host->getHeight() / 4),
-                                     m_host->getWidth() * m_host->getScale().x,
-                                     m_host->getHeight() * m_host->getScale().y);
-
-            sf::Rect<float> joinRect(m_join->getPosition().x - (m_join->getWidth() / 4),
-                                     m_join->getPosition().y - (m_join->getHeight() / 4),
-                                     m_join->getWidth() * m_join->getScale().x,
-                                     m_join->getHeight() * m_join->getScale().y);
-
-            sf::Rect<float> quitRect(m_quit->getPosition().x - (m_quit->getWidth() / 4),
-                                     m_quit->getPosition().y - (m_quit->getHeight() / 4),
-                                     m_quit->getWidth() * m_quit->getScale().x,
-                                     m_quit->getHeight() * m_quit->getScale().y);
-
-            sf::Rect<float> backRect(m_back->getPosition().x - (m_back->getWidth() / 4),
-                                     m_back->getPosition().y - (m_back->getHeight() / 4),
-                                     m_back->getWidth() * m_back->getScale().x,
-                                     m_back->getHeight() * m_back->getScale().y);
-
-            // Handle menu state logic
-            if (menuState == MAIN_MENU) {
-                // Start button hover
-                if (startRect.contains(mousePos) && !start_updated) {
-                    m_start->update(0.0f);
-                    start_updated = true;
-                    press.play();
-                } else if (!startRect.contains(mousePos) && start_updated) {
-                    start_updated = false;
-                    m_start->update(0.0f);
-                    up.play();
-                }
-
-                // Host button hover
-                if (hostRect.contains(mousePos) && !host_updated) {
-                    m_host->update(0.0f);
-                    host_updated = true;
-                    press.play();
-                } else if (!hostRect.contains(mousePos) && host_updated) {
-                    host_updated = false;
-                    m_host->update(0.0f);
-                    up.play();
-                }
-
-                // Join button hover
-                if (joinRect.contains(mousePos) && !join_updated) {
-                    m_join->update(0.0f);
-                    join_updated = true;
-                    press.play();
-                } else if (!joinRect.contains(mousePos) && join_updated) {
-                    join_updated = false;
-                    m_join->update(0.0f);
-                    up.play();
-                }
-
-                // Quit button hover
-                if (quitRect.contains(mousePos) && !quit_updated) {
-                    m_quit->update(0.0f);
-                    quit_updated = true;
-                    press.play();
-                } else if (!quitRect.contains(mousePos) && quit_updated) {
-                    quit_updated = false;
-                    m_quit->update(0.0f);
-                    up.play();
-                }
-
-                // Handle clicks
-                if (sf::Mouse::isButtonPressed(sf::Mouse::Left)) {
-                    if (startRect.contains(mousePos)) {
-                        mode = NetworkMode::LOCAL;
-                        menuState = READY_TO_START;
-                        sf::sleep(sf::milliseconds(200)); // Prevent double-click
-                    } else if (hostRect.contains(mousePos)) {
-                        netManager = std::make_shared<NetworkManager>();
-                        if (netManager->startHost()) {
-                            mode = NetworkMode::HOST;
-                            menuState = HOST_WAITING;
-                            hostIpAddress = sf::IpAddress::getLocalAddress().toString();
-                            statusMessage = "Waiting for player 2...";
-                        } else {
-                            statusMessage = "Failed to start host!";
-                            netManager = nullptr;
-                        }
-                        sf::sleep(sf::milliseconds(200));
-                    } else if (joinRect.contains(mousePos)) {
-                        menuState = JOIN_INPUT;
-                        statusMessage = "Enter host IP address";
-                        sf::sleep(sf::milliseconds(200));
-                    } else if (quitRect.contains(mousePos)) {
-                        background.stop();
-                        startscreen.close();
-                    }
-                }
-            } else if (menuState == HOST_WAITING) {
-                // Check for client connection
-                if (netManager && netManager->waitForClient(sf::milliseconds(100))) {
-                    menuState = READY_TO_START;
-                    statusMessage = "Player 2 connected! Click START to begin";
-                }
-
-                // Back button hover
-                if (backRect.contains(mousePos) && !back_updated) {
-                    m_back->update(0.0f);
-                    back_updated = true;
-                    press.play();
-                } else if (!backRect.contains(mousePos) && back_updated) {
-                    back_updated = false;
-                    m_back->update(0.0f);
-                    up.play();
-                }
-
-                // Handle back button click
-                if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && backRect.contains(mousePos)) {
-                    menuState = MAIN_MENU;
-                    netManager = nullptr;
-                    statusMessage = "";
-                    sf::sleep(sf::milliseconds(200));
-                }
-            } else if (menuState == JOIN_INPUT) {
-                // Back button hover
-                if (backRect.contains(mousePos) && !back_updated) {
-                    m_back->update(0.0f);
-                    back_updated = true;
-                    press.play();
-                } else if (!backRect.contains(mousePos) && back_updated) {
-                    back_updated = false;
-                    m_back->update(0.0f);
-                    up.play();
-                }
-
-                // Handle back button click
-                if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && backRect.contains(mousePos)) {
-                    menuState = MAIN_MENU;
-                    ipInput = "127.0.0.1";
-                    statusMessage = "";
-                    sf::sleep(sf::milliseconds(200));
-                }
-            } else if (menuState == READY_TO_START) {
-                // Start button hover
-                if (startRect.contains(mousePos) && !start_updated) {
-                    m_start->update(0.0f);
-                    start_updated = true;
-                    press.play();
-                } else if (!startRect.contains(mousePos) && start_updated) {
-                    start_updated = false;
-                    m_start->update(0.0f);
-                    up.play();
-                }
-
-                // Handle start click
-                if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && startRect.contains(mousePos)) {
-                    background.stop();
-                    startscreen.close();
-                    startgame(highscore, mode, netManager);
-                    return 0;
-                }
-            }
-
-            // Render
-            startscreen.clear();
-            david.draw(startscreen);
-
-            if (menuState == MAIN_MENU) {
-                // Draw all buttons
-                m_start->draw(startscreen);
-                m_host->draw(startscreen);
-                m_join->draw(startscreen);
-                m_quit->draw(startscreen);
-
-                // Draw labels on buttons
-                localLabel.setOrigin(localLabel.getGlobalBounds().width / 2,
-                                     localLabel.getGlobalBounds().height / 2);
-                localLabel.setPosition(m_start->getPosition().x, m_start->getPosition().y);
-                startscreen.draw(localLabel);
-
-                hostLabel.setOrigin(hostLabel.getGlobalBounds().width / 2,
-                                    hostLabel.getGlobalBounds().height / 2);
-                hostLabel.setPosition(m_host->getPosition().x, m_host->getPosition().y);
-                startscreen.draw(hostLabel);
-
-                joinLabel.setOrigin(joinLabel.getGlobalBounds().width / 2,
-                                    joinLabel.getGlobalBounds().height / 2);
-                joinLabel.setPosition(m_join->getPosition().x, m_join->getPosition().y);
-                startscreen.draw(joinLabel);
-            } else if (menuState == HOST_WAITING) {
-                m_back->draw(startscreen);
-                backLabel.setOrigin(backLabel.getGlobalBounds().width / 2,
-                                    backLabel.getGlobalBounds().height / 2);
-                backLabel.setPosition(m_back->getPosition().x, m_back->getPosition().y);
-                startscreen.draw(backLabel);
-
-                sf::Text title("HOSTING GAME", font, 50);
-                title.setFillColor(sf::Color::Green);
-                title.setStyle(sf::Text::Bold);
-                title.setOrigin(title.getGlobalBounds().width / 2, 0);
-                title.setPosition(startscreen.getSize().x / 2, 150);
-                startscreen.draw(title);
-
-                sf::Text ipText("Your IP: " + hostIpAddress, font, 35);
-                ipText.setFillColor(sf::Color::White);
-                ipText.setOrigin(ipText.getGlobalBounds().width / 2, 0);
-                ipText.setPosition(startscreen.getSize().x / 2, 250);
-                startscreen.draw(ipText);
-
-                sf::Text statusText(statusMessage, font, 30);
-                statusText.setFillColor(sf::Color(200, 200, 200));
-                statusText.setOrigin(statusText.getGlobalBounds().width / 2, 0);
-                statusText.setPosition(startscreen.getSize().x / 2, 350);
-                startscreen.draw(statusText);
-            } else if (menuState == JOIN_INPUT) {
-                m_back->draw(startscreen);
-                backLabel.setOrigin(backLabel.getGlobalBounds().width / 2,
-                                    backLabel.getGlobalBounds().height / 2);
-                backLabel.setPosition(m_back->getPosition().x, m_back->getPosition().y);
-                startscreen.draw(backLabel);
-
-                sf::Text title("JOIN GAME", font, 50);
-                title.setFillColor(sf::Color::Blue);
-                title.setStyle(sf::Text::Bold);
-                title.setOrigin(title.getGlobalBounds().width / 2, 0);
-                title.setPosition(startscreen.getSize().x / 2, 150);
-                startscreen.draw(title);
-
-                sf::Text prompt("Enter Host IP Address:", font, 30);
-                prompt.setFillColor(sf::Color::White);
-                prompt.setOrigin(prompt.getGlobalBounds().width / 2, 0);
-                prompt.setPosition(startscreen.getSize().x / 2, 250);
-                startscreen.draw(prompt);
-
-                sf::Text ipText(ipInput, font, 40);
-                ipText.setFillColor(sf::Color::Green);
-                ipText.setOrigin(ipText.getGlobalBounds().width / 2, 0);
-                ipText.setPosition(startscreen.getSize().x / 2, 320);
-                startscreen.draw(ipText);
-
-                sf::Text instruct("Press ENTER to connect", font, 25);
-                instruct.setFillColor(sf::Color(200, 200, 200));
-                instruct.setOrigin(instruct.getGlobalBounds().width / 2, 0);
-                instruct.setPosition(startscreen.getSize().x / 2, 400);
-                startscreen.draw(instruct);
-
-                if (!statusMessage.empty()) {
-                    sf::Text statusText(statusMessage, font, 22);
-                    if (statusMessage.find("Failed") != std::string::npos) {
-                        statusText.setFillColor(sf::Color::Red);
-                    } else {
-                        statusText.setFillColor(sf::Color::Yellow);
-                    }
-                    statusText.setOrigin(statusText.getGlobalBounds().width / 2, 0);
-                    statusText.setPosition(startscreen.getSize().x / 2, 460);
-                    startscreen.draw(statusText);
-                }
-            } else if (menuState == READY_TO_START) {
-                m_start->draw(startscreen);
-                localLabel.setString("START");
-                localLabel.setOrigin(localLabel.getGlobalBounds().width / 2,
-                                     localLabel.getGlobalBounds().height / 2);
-                localLabel.setPosition(m_start->getPosition().x, m_start->getPosition().y);
-                startscreen.draw(localLabel);
-
-                sf::Text statusText(statusMessage, font, 30);
-                statusText.setFillColor(sf::Color::Green);
-                statusText.setStyle(sf::Text::Bold);
-                statusText.setOrigin(statusText.getGlobalBounds().width / 2, 0);
-                statusText.setPosition(startscreen.getSize().x / 2, 350);
-                startscreen.draw(statusText);
-            }
-
-            startscreen.display();
         }
 
-        background.stop();
+        // ── Normal menu / game loop ───────────────────────────────────────────────
+        while (true) {
+            MenuResult menu = showMenu();
+            if (menu.quit)
+                break;
+
+            bool playAgain = true;
+            while (playAgain) {
+                playAgain = false;
+
+                Game game(menu.mode, menu.netManager);
+                game.setBindings(bindings);
+                auto [p1score, p2score, minutes, seconds, p1win, peerLeft] = game.run();
+
+                if (p1score > highscore)
+                    highscore = p1score;
+                if (p2score > highscore)
+                    highscore = p2score;
+
+                if (game.quitToMenu())
+                    break; // user pressed Q → back to menu
+
+                bool wantAgain = showEndscreen(highscore, p1score, p2score, minutes, seconds,
+                                               peerLeft, menu.mode);
+                if (wantAgain && menu.mode == NetworkMode::LOCAL)
+                    playAgain = true;
+            }
+            // Reset session state so the next menu iteration is clean.
+            menu.netManager = nullptr;
+            menu.mode = NetworkMode::LOCAL;
+        }
+
         return 0;
     } catch (const std::exception& e) {
         std::cerr << e.what() << '\n';

--- a/src/resource_path.cpp
+++ b/src/resource_path.cpp
@@ -2,12 +2,14 @@
 #include <filesystem>
 
 std::string resource_path = "assets/";
+std::string exe_dir_path;
 
 void initResourcePath(const char* argv0) {
     if (!argv0)
         return;
     namespace fs = std::filesystem;
     fs::path exeDir = fs::weakly_canonical(fs::path(argv0)).parent_path();
+    exe_dir_path = exeDir.string();
     if (fs::exists(exeDir / "assets")) {
         // Append the separator after .string() so the trailing slash survives on
         // MSVC std::filesystem too (call sites do `resource_path + "file"`).

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -396,7 +396,22 @@ TEST_CASE("integration: P2 left-direction flip branch sets p2left and scale", "[
     REQUIRE(s.p2_scale_x == Catch::Approx(-1.f).margin(0.01f));
 }
 
-// ── 18. HOST Game + loopback NetworkManager ───────────────────────────────────
+// ── 18. quitAtStep ────────────────────────────────────────────────────────────
+// When DebugConfig::quitAtStep is set, the Game closes after that many sim
+// steps and sets m_quitToMenu.  This pins the step-8 outer-loop contract.
+
+TEST_CASE("integration: quitAtStep closes game and sets quitToMenu", "[integration]") {
+    Game g;
+    DebugConfig cfg;
+    cfg.quitAtStep = 5;
+    g.setDebugConfig(cfg);
+    g.run();
+
+    REQUIRE(g.quitToMenu() == true);
+    REQUIRE(g.steps() == 5);
+}
+
+// ── 19. HOST Game + loopback NetworkManager ───────────────────────────────────
 // Client connects, sends one input, disconnects.  Host detects peerLost via
 // poll(); Game's handleNetworkCommunication() then sets m_peerLeft → run()
 // tuple element 5 == true.

--- a/tests/test_unit.cpp
+++ b/tests/test_unit.cpp
@@ -2,6 +2,8 @@
 //   objectBounds — rectangle construction from a GameObject
 //   advanceFrameRect — sprite-sheet frame stepping
 //   applyInputToP1 — P1 input mapping (bool attack parameter)
+//   makeLetterboxView — aspect-preserving viewport math
+//   loadBindings / keyFromName / nameFromKey — config parser (step 6)
 // Also: RegularGameObject method coverage.
 
 #include <catch2/catch_approx.hpp>
@@ -9,8 +11,11 @@
 
 #include "RegularGameObject.h"
 #include "geometry.h"
+#include "key_bindings.h"
+#include "letterbox.h"
 #include "replay.h"
 #include "sprite_anim.h"
+#include <sstream>
 
 // ── StubGameObject ─────────────────────────────────────────────────────────────
 // Minimal concrete implementation of GameObject for testing objectBounds.
@@ -329,4 +334,141 @@ TEST_CASE("RegularGameObject: position/scale/move work after changeValid", "[uni
 TEST_CASE("RegularGameObject: setOrigin does not crash", "[unit]") {
     RegularGameObject obj;
     obj.setOrigin(); // no m_valid guard; safe on untextured sprite
+}
+
+// ── makeLetterboxView ──────────────────────────────────────────────────────────
+
+TEST_CASE("makeLetterboxView: wider window → pillarbox viewport", "[letterbox][unit]") {
+    // 2560×1080 window, 1920×1080 logical (16:9)
+    // logicalAspect=1.777, windowAspect=2.370 → pillarbox
+    // vpW = 1.777/2.370 = 0.75, vpX = 0.125
+    auto view = makeLetterboxView({1920.f, 1080.f}, {2560u, 1080u});
+    auto vp = view.getViewport();
+    REQUIRE(vp.left == Catch::Approx(0.125f).margin(0.001f));
+    REQUIRE(vp.top == Catch::Approx(0.f).margin(0.001f));
+    REQUIRE(vp.width == Catch::Approx(0.75f).margin(0.001f));
+    REQUIRE(vp.height == Catch::Approx(1.f).margin(0.001f));
+}
+
+TEST_CASE("makeLetterboxView: taller window → letterbox viewport", "[letterbox][unit]") {
+    // 1920×1440 window (4:3), 1920×1080 logical (16:9)
+    // logicalAspect=1.777, windowAspect=1.333 → letterbox
+    // vpH = 1.333/1.777 = 0.75, vpY = 0.125
+    auto view = makeLetterboxView({1920.f, 1080.f}, {1920u, 1440u});
+    auto vp = view.getViewport();
+    REQUIRE(vp.left == Catch::Approx(0.f).margin(0.001f));
+    REQUIRE(vp.top == Catch::Approx(0.125f).margin(0.001f));
+    REQUIRE(vp.width == Catch::Approx(1.f).margin(0.001f));
+    REQUIRE(vp.height == Catch::Approx(0.75f).margin(0.001f));
+}
+
+TEST_CASE("makeLetterboxView: exact aspect → full viewport", "[letterbox][unit]") {
+    auto view = makeLetterboxView({1920.f, 1080.f}, {1920u, 1080u});
+    auto vp = view.getViewport();
+    REQUIRE(vp.left == Catch::Approx(0.f).margin(0.001f));
+    REQUIRE(vp.top == Catch::Approx(0.f).margin(0.001f));
+    REQUIRE(vp.width == Catch::Approx(1.f).margin(0.001f));
+    REQUIRE(vp.height == Catch::Approx(1.f).margin(0.001f));
+}
+
+TEST_CASE("makeLetterboxView: view maps logical rect [0,0,w,h]", "[letterbox][unit]") {
+    auto view = makeLetterboxView({1024.f, 576.f}, {1920u, 1080u});
+    // The view's logical rectangle should cover the full 1024×576 logical canvas
+    auto r = view.getSize();
+    REQUIRE(r.x == Catch::Approx(1024.f).margin(0.1f));
+    REQUIRE(r.y == Catch::Approx(576.f).margin(0.1f));
+    auto c = view.getCenter();
+    REQUIRE(c.x == Catch::Approx(512.f).margin(0.1f));
+    REQUIRE(c.y == Catch::Approx(288.f).margin(0.1f));
+}
+
+// ── key_bindings ───────────────────────────────────────────────────────────────
+
+TEST_CASE("keyFromName / nameFromKey round-trip", "[key_bindings][unit]") {
+    REQUIRE(keyFromName("Num8") == sf::Keyboard::Numpad8);
+    REQUIRE(nameFromKey(sf::Keyboard::Numpad8) == "Num8");
+    REQUIRE(keyFromName("Space") == sf::Keyboard::Space);
+    REQUIRE(nameFromKey(sf::Keyboard::Space) == "Space");
+    REQUIRE(keyFromName("Right") == sf::Keyboard::Right);
+    REQUIRE(nameFromKey(sf::Keyboard::Right) == "Right");
+    REQUIRE(keyFromName("W") == sf::Keyboard::W);
+    REQUIRE(nameFromKey(sf::Keyboard::W) == "W");
+}
+
+TEST_CASE("keyFromName: unknown name returns Unknown", "[key_bindings][unit]") {
+    REQUIRE(keyFromName("INVALID_KEY") == sf::Keyboard::Unknown);
+    REQUIRE(keyFromName("") == sf::Keyboard::Unknown);
+}
+
+TEST_CASE("nameFromKey: unknown key returns 'Unknown'", "[key_bindings][unit]") {
+    REQUIRE(nameFromKey(sf::Keyboard::Unknown) == "Unknown");
+}
+
+TEST_CASE("defaultBindings: hard-coded keys match original layout", "[key_bindings][unit]") {
+    auto b = defaultBindings();
+    REQUIRE(b.p1.up == sf::Keyboard::Numpad8);
+    REQUIRE(b.p1.down == sf::Keyboard::Numpad5);
+    REQUIRE(b.p1.left == sf::Keyboard::Numpad4);
+    REQUIRE(b.p1.right == sf::Keyboard::Numpad6);
+    REQUIRE(b.p1.attack == sf::Keyboard::Right);
+    REQUIRE(b.p2.up == sf::Keyboard::W);
+    REQUIRE(b.p2.down == sf::Keyboard::S);
+    REQUIRE(b.p2.left == sf::Keyboard::A);
+    REQUIRE(b.p2.right == sf::Keyboard::D);
+    REQUIRE(b.p2.attack == sf::Keyboard::Space);
+    REQUIRE(b.slowDown == sf::Keyboard::O);
+    REQUIRE(b.speedUp == sf::Keyboard::P);
+    REQUIRE(b.skipCooldown == sf::Keyboard::K);
+}
+
+TEST_CASE("loadBindings: empty stream returns defaults", "[key_bindings][unit]") {
+    std::istringstream empty("");
+    auto b = loadBindings(empty);
+    auto d = defaultBindings();
+    REQUIRE(b.p1.up == d.p1.up);
+    REQUIRE(b.p2.attack == d.p2.attack);
+    REQUIRE(b.slowDown == d.slowDown);
+}
+
+TEST_CASE("loadBindings: parses valid p1/p2 fields", "[key_bindings][unit]") {
+    std::istringstream cfg("p1_up = W\np2_attack = Enter\n");
+    auto b = loadBindings(cfg);
+    REQUIRE(b.p1.up == sf::Keyboard::W);
+    REQUIRE(b.p2.attack == sf::Keyboard::Return);
+    // Unspecified fields keep defaults
+    REQUIRE(b.p1.down == defaultBindings().p1.down);
+}
+
+TEST_CASE("loadBindings: strips comments and blank lines", "[key_bindings][unit]") {
+    std::istringstream cfg("# comment\n\np1_up = A # inline comment\n");
+    auto b = loadBindings(cfg);
+    REQUIRE(b.p1.up == sf::Keyboard::A);
+}
+
+TEST_CASE("loadBindings: unknown key name warns and keeps default", "[key_bindings][unit]") {
+    std::istringstream cfg("p1_up = NOTAKEY\n");
+    auto b = loadBindings(cfg);
+    // Unknown key → default kept
+    REQUIRE(b.p1.up == defaultBindings().p1.up);
+}
+
+TEST_CASE("loadBindings: all 13 fields parsed", "[key_bindings][unit]") {
+    std::istringstream cfg(
+        "p1_up = F1\np1_down = F2\np1_left = F3\np1_right = F4\np1_attack = F5\n"
+        "p2_up = F6\np2_down = F7\np2_left = F8\np2_right = F9\np2_attack = F10\n"
+        "slow_down = F11\nspeed_up = F12\nskip_cooldown = Tab\n");
+    auto b = loadBindings(cfg);
+    REQUIRE(b.p1.up == sf::Keyboard::F1);
+    REQUIRE(b.p1.down == sf::Keyboard::F2);
+    REQUIRE(b.p1.left == sf::Keyboard::F3);
+    REQUIRE(b.p1.right == sf::Keyboard::F4);
+    REQUIRE(b.p1.attack == sf::Keyboard::F5);
+    REQUIRE(b.p2.up == sf::Keyboard::F6);
+    REQUIRE(b.p2.down == sf::Keyboard::F7);
+    REQUIRE(b.p2.left == sf::Keyboard::F8);
+    REQUIRE(b.p2.right == sf::Keyboard::F9);
+    REQUIRE(b.p2.attack == sf::Keyboard::F10);
+    REQUIRE(b.slowDown == sf::Keyboard::F11);
+    REQUIRE(b.speedUp == sf::Keyboard::F12);
+    REQUIRE(b.skipCooldown == sf::Keyboard::Tab);
 }


### PR DESCRIPTION
Resolves #11.

Gameplay polish & behavior-level correctness — display, framerate, controls, and pause — **without changing gameplay** (protected by #7's tests + #13's determinism; both preserved).

## Window / display
- **Window size left the simulation**: sim code no longer reads `m_window.getSize()` — a fixed logical space (1920×1080 game / 1024×576 menus) drives physics, and display is render-only. This is what makes resizing safe.
- **Resizable window + letterbox `sf::View`** (aspect preserved, black bars — a pure, unit-tested `makeLetterboxView`); applied on create, on `Resized`, and after fullscreen. Menus + endscreen get the same treatment (mouse hit-testing stays correct via the view).
- **F11 fullscreen toggle** (desktop mode).

## Framerate
- **vsync** (`setVerticalSyncEnabled`) — but **gated off in harness mode** so `--frames` runs stay fast/deterministic (verified: `--frames 180` = 0.49s).

## Controls
- **Key remapping** via a data-only `KeyBindings` (defaults = today's keys) + a `controls.cfg` (`key=value`) next to the binary (absent → defaults; unknown key → warn + default). Pure, unit-tested loader. Documented in README + `--help`. (Gamepad deferred — the `PlayerInput` abstraction accommodates it later.)

## Pause / quit-to-menu
- **Escape → pause** (was hard-close), with an overlay. **Q → quit to menu.** LOCAL pauses the sim; **HOST/CLIENT keep simulating + networking** through the overlay (a silent host freeze would hang the peer); Q gracefully `disconnect()`s. Quit-to-menu is a new `quitToMenu()` accessor (the `run()` tuple shape is unchanged so tests are unaffected).
- **`main()` restructured into a menu→game→menu loop**, killing the old `startgame` self-recursion (which also fixes a stale-`NetworkManager` reuse bug); session state resets between games.

## Validation
Fresh `-Werror` build = 0 warnings; `ctest` = **79/79** (65 + 14 new: letterbox aspect, bindings parse, quit-to-menu contract); `--frames 180` = 0.49s (vsync gated); determinism preserved (1920×1080 screenshots identical; a captured frame confirms correct rendering through the view). Both reviewers converged.

Deliberately left: the `m_animTime>.1f` animation hack (deterministic, pinned) and a single-window rewrite (backlog).
