### PR TITLE
Add AI opponent (single-player) for P2 — #12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(dungeon_lib STATIC
     src/replay.cpp
     src/rng.cpp
     src/key_bindings.cpp
+    src/ai.cpp
 )
 
 target_include_directories(dungeon_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/include/Game.h
+++ b/include/Game.h
@@ -7,6 +7,7 @@
 #include "GameObject.h"
 #include "NetworkManager.h"
 #include "RegularGameObject.h"
+#include "ai.h"
 #include "debug.h"
 #include "key_bindings.h"
 #include "replay.h"
@@ -24,6 +25,10 @@ public:
 
     // Configure debug/harness options; call before run().
     void setDebugConfig(const DebugConfig& cfg);
+
+    // Attach an AI driver for P2 (robot).  Call before run().
+    // Passing None tears down any existing AI.
+    void setAiOpponent(AiDifficulty d);
 
     // Override key bindings (defaults loaded from controls.cfg or hard-coded defaults).
     void setBindings(const KeyBindings& b) { m_bindings = b; }
@@ -61,6 +66,8 @@ private:
     void applyPlayerInput(const PlayerInput& in);
     // Capture a screenshot if the debug config says it is due this step.
     void captureIfDue();
+    // Build the AiView snapshot for the current frame.
+    AiView makeAiView() const;
 
     sf::RenderWindow m_window;
 
@@ -151,6 +158,9 @@ private:
     GameState m_latestState;
     float m_stateAccum = 0.f;
     static constexpr float kStateSendInterval = 1.f / 25.f; // ~25 Hz
+
+    // AI opponent for P2 (null when human or network drives P2)
+    std::unique_ptr<AiController> m_ai;
 
     // Pause / quit-to-menu state
     bool m_paused = false;

--- a/include/ai.h
+++ b/include/ai.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "NetworkManager.h" // PlayerInput
+#include "ai_difficulty.h"
+#include <SFML/Graphics.hpp>
+#include <array>
+#include <deque>
+#include <random>
+
+// ── AiParams ─────────────────────────────────────────────────────────────────
+// All tunable knobs for one difficulty level.
+
+struct AiParams {
+    int reactionSteps;    // frames of opponent-position delay
+    int decisionEvery;    // re-decide every N steps; hold in between
+    float attackRange;    // max horizontal distance (px) to trigger attack
+    float attackAlignY;   // max vertical distance (px) to trigger attack
+    float missTimeProb;   // probability of passing on a valid attack opportunity
+    int swingEverySteps;  // minimum steps between successive attack=true outputs
+    float hazardMargin;   // px to inflate selfBounds before hazard intersection check
+    float preferredGapX;  // preferred horizontal distance from opponent (px)
+    float aggression;     // probability [0,1] of closing in when gap > preferredGapX
+    float mistakeProb;    // probability [0,1] of going idle on any given decision
+};
+
+AiParams paramsFor(AiDifficulty d);
+
+// ── AiView ───────────────────────────────────────────────────────────────────
+// Snapshot of game state fed to the decider each step.
+// selfBounds MUST be a normalised (positive-width) rect — see Game::makeAiView.
+
+struct AiView {
+    sf::Vector2f selfPos;
+    sf::FloatRect selfBounds;   // normalised (positive width/height)
+    bool selfFacingLeft;
+    sf::Vector2f oppPos;
+    sf::FloatRect oppBounds;
+    std::array<sf::FloatRect, 3> hazards; // fire hazards (arena[1..3])
+    bool inCooldown;
+    int selfScore;
+    int oppScore;
+    long long step;
+};
+
+// ── Pure decider ─────────────────────────────────────────────────────────────
+// Stateless: maps (view, params, rng) → PlayerInput.
+// Decision priority: inCooldown → mistake → hazard escape → attack → positioning.
+// Draws from rng only as needed; never reads game state through any other path.
+
+PlayerInput decideAiInput(const AiView& view, const AiParams& params, std::mt19937& rng);
+
+// ── AiController ─────────────────────────────────────────────────────────────
+// Thin stateful wrapper that:
+//   • maintains the reaction-delay ring (opponent snapshots);
+//   • holds the last decision for decisionEvery steps;
+//   • applies the swing-pacing output filter.
+// Stores std::mt19937& (reference to rng::engine()) — NOT a copy — so
+// rng::seed() deterministically resets the draw sequence.
+
+class AiController {
+public:
+    AiController(const AiParams& params, std::mt19937& rng);
+
+    // Drive one sim step; returns the PlayerInput to feed applyPlayerInput().
+    PlayerInput step(const AiView& view);
+
+private:
+    AiParams m_params;
+    std::mt19937& m_rng;
+
+    struct OppSnapshot {
+        sf::Vector2f pos;
+        sf::FloatRect bounds;
+    };
+    std::deque<OppSnapshot> m_ring; // opponent history for reaction delay
+
+    int m_holdCounter = 0;       // steps until next re-decide (0 → decide now)
+    PlayerInput m_heldDecision;  // last computed decision
+
+    int m_swingCooldown = 0; // steps remaining before attack=true is allowed again
+};

--- a/include/ai.h
+++ b/include/ai.h
@@ -27,19 +27,21 @@ AiParams paramsFor(AiDifficulty d);
 
 // ── AiView ───────────────────────────────────────────────────────────────────
 // Snapshot of game state fed to the decider each step.
-// selfBounds MUST be a normalised (positive-width) rect — see Game::makeAiView.
+// selfBounds AND oppBounds MUST be normalised (positive-width) rects — the
+// decider's nearest-edge math assumes a canonical left/width. See
+// Game::makeAiView (both go through normalizedBounds()).
 
 struct AiView {
     sf::Vector2f selfPos;
     sf::FloatRect selfBounds; // normalised (positive width/height)
-    bool selfFacingLeft;
+    bool selfFacingLeft;      // reserved: decider derives facing from dx; currently unread
     sf::Vector2f oppPos;
-    sf::FloatRect oppBounds;
+    sf::FloatRect oppBounds;              // normalised (positive width/height)
     std::array<sf::FloatRect, 3> hazards; // fire hazards (arena[1..3])
     bool inCooldown;
     int selfScore;
     int oppScore;
-    long long step;
+    long long step; // reserved: currently unread by the decider/controller
 };
 
 // ── Pure decider ─────────────────────────────────────────────────────────────

--- a/include/ai.h
+++ b/include/ai.h
@@ -11,16 +11,16 @@
 // All tunable knobs for one difficulty level.
 
 struct AiParams {
-    int reactionSteps;    // frames of opponent-position delay
-    int decisionEvery;    // re-decide every N steps; hold in between
-    float attackRange;    // max horizontal distance (px) to trigger attack
-    float attackAlignY;   // max vertical distance (px) to trigger attack
-    float missTimeProb;   // probability of passing on a valid attack opportunity
-    int swingEverySteps;  // minimum steps between successive attack=true outputs
-    float hazardMargin;   // px to inflate selfBounds before hazard intersection check
-    float preferredGapX;  // preferred horizontal distance from opponent (px)
-    float aggression;     // probability [0,1] of closing in when gap > preferredGapX
-    float mistakeProb;    // probability [0,1] of going idle on any given decision
+    int reactionSteps;   // frames of opponent-position delay
+    int decisionEvery;   // re-decide every N steps; hold in between
+    float attackRange;   // max horizontal distance (px) to trigger attack
+    float attackAlignY;  // max vertical distance (px) to trigger attack
+    float missTimeProb;  // probability of passing on a valid attack opportunity
+    int swingEverySteps; // minimum steps between successive attack=true outputs
+    float hazardMargin;  // px to inflate selfBounds before hazard intersection check
+    float preferredGapX; // preferred horizontal distance from opponent (px)
+    float aggression;    // probability [0,1] of closing in when gap > preferredGapX
+    float mistakeProb;   // probability [0,1] of going idle on any given decision
 };
 
 AiParams paramsFor(AiDifficulty d);
@@ -31,7 +31,7 @@ AiParams paramsFor(AiDifficulty d);
 
 struct AiView {
     sf::Vector2f selfPos;
-    sf::FloatRect selfBounds;   // normalised (positive width/height)
+    sf::FloatRect selfBounds; // normalised (positive width/height)
     bool selfFacingLeft;
     sf::Vector2f oppPos;
     sf::FloatRect oppBounds;
@@ -74,8 +74,8 @@ private:
     };
     std::deque<OppSnapshot> m_ring; // opponent history for reaction delay
 
-    int m_holdCounter = 0;       // steps until next re-decide (0 → decide now)
-    PlayerInput m_heldDecision;  // last computed decision
+    int m_holdCounter = 0;      // steps until next re-decide (0 → decide now)
+    PlayerInput m_heldDecision; // last computed decision
 
     int m_swingCooldown = 0; // steps remaining before attack=true is allowed again
 };

--- a/include/ai_difficulty.h
+++ b/include/ai_difficulty.h
@@ -1,0 +1,3 @@
+#pragma once
+
+enum class AiDifficulty { None, Easy, Medium, Hard };

--- a/include/debug.h
+++ b/include/debug.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "ai_difficulty.h"
 #include <string>
 
 struct DebugConfig {
@@ -10,6 +11,10 @@ struct DebugConfig {
     // When >= 0, Game closes + sets quitToMenu after this many sim steps.
     // Also makes active() return true so vsync/F11 are gated off correctly.
     int quitAtStep = -1;
+
+    // AI opponent for P2 (--ai easy|medium|hard).  Does NOT affect active()
+    // so --ai without --frames is a silent no-op for the harness bypass check.
+    AiDifficulty ai = AiDifficulty::None;
 
     bool active() const {
         return frames > 0 || !replayPath.empty() || !replayPathP1.empty() || screenshotEvery > 0 ||

--- a/include/geometry.h
+++ b/include/geometry.h
@@ -10,3 +10,21 @@ inline sf::FloatRect objectBounds(const GameObject& obj) {
     return sf::FloatRect(obj.getPosition(), sf::Vector2f(obj.getWidth() * obj.getScale().x,
                                                          obj.getHeight() * obj.getScale().y));
 }
+
+// Same rect as objectBounds() but normalised to positive width/height (a
+// left-facing object has scale.x = -1, so objectBounds() yields a negative
+// width).  Use this wherever edge arithmetic needs a canonical left/top and
+// positive extent — e.g. the AI's nearest-edge distance math.  Do NOT use it
+// for collision: intersects() relies on the raw negative-width form.
+inline sf::FloatRect normalizedBounds(const GameObject& obj) {
+    sf::FloatRect r = objectBounds(obj);
+    if (r.width < 0.f) {
+        r.left += r.width;
+        r.width = -r.width;
+    }
+    if (r.height < 0.f) {
+        r.top += r.height;
+        r.height = -r.height;
+    }
+    return r;
+}

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -162,22 +162,17 @@ AiView Game::makeAiView() const {
     AiView view;
     view.selfPos = m_robot->getPosition();
 
-    // selfBounds must be normalised: robot faces left by default (scale.x=-1),
-    // so objectBounds returns a negative-width rect — fix it.
-    sf::FloatRect sb = objectBounds(*m_robot);
-    if (sb.width < 0.f) {
-        sb.left += sb.width;
-        sb.width = -sb.width;
-    }
-    if (sb.height < 0.f) {
-        sb.top += sb.height;
-        sb.height = -sb.height;
-    }
-    view.selfBounds = sb;
+    // Both bounds must be normalised to positive width/height: either fighter
+    // may face left (scale.x = -1), which makes objectBounds negative-width.
+    // The decider's nearest-edge math needs a canonical left/width, so use
+    // normalizedBounds for self AND opponent (opp normalisation matters when
+    // P1 faces left while the robot is to its left — otherwise nearOppEdge
+    // picks the far edge and the AI thinks it is a full body-width too far).
+    view.selfBounds = normalizedBounds(*m_robot);
 
     view.selfFacingLeft = m_p2FacingLeft;
     view.oppPos = m_rocket->getPosition();
-    view.oppBounds = objectBounds(*m_rocket);
+    view.oppBounds = normalizedBounds(*m_rocket);
 
     // arena[0] is the brick floor; arena[1..3] are the three fire hazards.
     for (int i = 0; i < 3; ++i)

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -7,6 +7,7 @@
 #include "geometry.h"
 #include "letterbox.h"
 #include "resource_path.h"
+#include "rng.h"
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
@@ -144,6 +145,50 @@ void Game::setDebugConfig(const DebugConfig& cfg) {
         m_replayP1 = loadReplay(cfg.replayPathP1);
         m_replayP1Idx = 0;
     }
+    if (cfg.ai != AiDifficulty::None)
+        setAiOpponent(cfg.ai);
+}
+
+// ── AI opponent ──────────────────────────────────────────────────────────────
+
+void Game::setAiOpponent(AiDifficulty d) {
+    if (d != AiDifficulty::None)
+        m_ai = std::make_unique<AiController>(paramsFor(d), rng::engine());
+    else
+        m_ai.reset();
+}
+
+AiView Game::makeAiView() const {
+    AiView view;
+    view.selfPos = m_robot->getPosition();
+
+    // selfBounds must be normalised: robot faces left by default (scale.x=-1),
+    // so objectBounds returns a negative-width rect — fix it.
+    sf::FloatRect sb = objectBounds(*m_robot);
+    if (sb.width < 0.f) {
+        sb.left += sb.width;
+        sb.width = -sb.width;
+    }
+    if (sb.height < 0.f) {
+        sb.top += sb.height;
+        sb.height = -sb.height;
+    }
+    view.selfBounds = sb;
+
+    view.selfFacingLeft = m_p2FacingLeft;
+    view.oppPos = m_rocket->getPosition();
+    view.oppBounds = objectBounds(*m_rocket);
+
+    // arena[0] is the brick floor; arena[1..3] are the three fire hazards.
+    for (int i = 0; i < 3; ++i)
+        view.hazards[static_cast<std::size_t>(i)] =
+            objectBounds(*m_arena[static_cast<std::size_t>(i + 1)]);
+
+    view.inCooldown = m_inCooldown;
+    view.selfScore = m_robotScore;
+    view.oppScore = m_rocketScore;
+    view.step = m_steps;
+    return view;
 }
 
 // ── run ───────────────────────────────────────────────────────────────────────
@@ -229,6 +274,8 @@ void Game::simStep() {
         } else {
             applyPlayerInput(PlayerInput{}); // EOF → all-false
         }
+    } else if (m_ai) {
+        applyPlayerInput(m_ai->step(makeAiView()));
     }
 
     // Apply replay input for P1.
@@ -386,7 +433,9 @@ void Game::handlePlayerInput(sf::Keyboard::Key key, bool isDown) {
         }
 
         // Player 2 controls (robot — configurable, default WASD+Space)
-        if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::CLIENT) {
+        // Gated off when AI is driving P2.
+        if ((m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::CLIENT) &&
+            !m_ai) {
             if (key == m_bindings.p2.up)
                 m_p2Up = isDown;
             if (key == m_bindings.p2.left)

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -68,8 +68,8 @@ PlayerInput decideAiInput(const AiView& view, const AiParams& p, std::mt19937& r
     // This accounts for the opponent's body width so the AI fires when its weapon can
     // actually connect, not just when the sprite anchors are within attackRange.
     {
-        float nearOppEdge = oppToRight ? view.oppBounds.left
-                                       : view.oppBounds.left + view.oppBounds.width;
+        float nearOppEdge =
+            oppToRight ? view.oppBounds.left : view.oppBounds.left + view.oppBounds.width;
         float horizDist = (view.selfPos.x - nearOppEdge);
         if (horizDist < 0.f)
             horizDist = -horizDist;

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -1,0 +1,154 @@
+#include "ai.h"
+#include <cmath>
+#include <stdexcept>
+
+// ── paramsFor ─────────────────────────────────────────────────────────────────
+
+AiParams paramsFor(AiDifficulty d) {
+    switch (d) {
+    case AiDifficulty::Easy:
+        return {18, 12, 200.f, 40.f, 0.50f, 60, 0.f, 500.f, 0.35f, 0.15f};
+    case AiDifficulty::Medium:
+        return {9, 6, 280.f, 60.f, 0.20f, 40, 40.f, 300.f, 0.65f, 0.05f};
+    case AiDifficulty::Hard:
+        // hazardMargin=0: Hard is a pure aggressor — ignores fire, pursues P1 through the
+        // centre-arena hazard zone (fire2) that would otherwise block the approach path.
+        return {3, 3, 320.f, 80.f, 0.02f, 25, 0.f, 180.f, 0.90f, 0.00f};
+    case AiDifficulty::None:
+        break;
+    }
+    throw std::invalid_argument("paramsFor: AiDifficulty::None has no params");
+}
+
+// ── decideAiInput ────────────────────────────────────────────────────────────
+
+PlayerInput decideAiInput(const AiView& view, const AiParams& p, std::mt19937& rng) {
+    PlayerInput out; // all false
+
+    // Priority 1: in cooldown → idle
+    if (view.inCooldown)
+        return out;
+
+    // Priority 2: mistake roll
+    if (p.mistakeProb > 0.f) {
+        std::uniform_real_distribution<float> uni(0.f, 1.f);
+        if (uni(rng) < p.mistakeProb)
+            return out;
+    }
+
+    // Priority 3: hazard escape (uses self — not delayed — position + bounds)
+    if (p.hazardMargin > 0.f) {
+        sf::FloatRect inflated = view.selfBounds;
+        inflated.left -= p.hazardMargin;
+        inflated.top -= p.hazardMargin;
+        inflated.width += 2.f * p.hazardMargin;
+        inflated.height += 2.f * p.hazardMargin;
+
+        for (const auto& hazard : view.hazards) {
+            if (inflated.intersects(hazard)) {
+                // Move away from hazard centre horizontally
+                float hcx = hazard.left + hazard.width * 0.5f;
+                float scx = view.selfBounds.left + view.selfBounds.width * 0.5f;
+                out.right = (hcx <= scx);
+                out.left = (hcx > scx);
+                return out;
+            }
+        }
+    }
+
+    // Delayed opponent info (already substituted by AiController)
+    float dx = view.oppPos.x - view.selfPos.x;
+    float absDx = (dx < 0.f ? -dx : dx);
+    bool oppToRight = (dx > 0.f);
+    float dy = view.oppPos.y - view.selfPos.y;
+    float absDy = (dy < 0.f ? -dy : dy);
+
+    // Priority 4: attack
+    // Use distance from selfPos to the nearest edge of oppBounds (body-to-body awareness).
+    // This accounts for the opponent's body width so the AI fires when its weapon can
+    // actually connect, not just when the sprite anchors are within attackRange.
+    {
+        float nearOppEdge = oppToRight ? view.oppBounds.left
+                                       : view.oppBounds.left + view.oppBounds.width;
+        float horizDist = (view.selfPos.x - nearOppEdge);
+        if (horizDist < 0.f)
+            horizDist = -horizDist;
+        if (horizDist < p.attackRange && absDy < p.attackAlignY) {
+            std::uniform_real_distribution<float> uni(0.f, 1.f);
+            if (uni(rng) >= p.missTimeProb) {
+                // Face toward opponent (update() processes movement before attack,
+                // so facing flips before the hit rect is evaluated).
+                if (oppToRight)
+                    out.right = true;
+                else
+                    out.left = true;
+                out.attack = true;
+                return out;
+            }
+        }
+    }
+
+    // Priority 5: positioning
+    {
+        std::uniform_real_distribution<float> uni(0.f, 1.f);
+        float gap = absDx;
+
+        if (gap > p.preferredGapX + 20.f) {
+            // Too far — close in, gated by aggression
+            if (uni(rng) < p.aggression) {
+                out.right = oppToRight;
+                out.left = !oppToRight;
+            }
+        } else if (gap < p.preferredGapX - 20.f) {
+            // Too close — back off
+            out.right = !oppToRight;
+            out.left = oppToRight;
+        }
+
+        // Y steering
+        if (dy < -20.f)
+            out.up = true;
+        else if (dy > 20.f)
+            out.down = true;
+    }
+
+    return out;
+}
+
+// ── AiController ────────────────────────────────────────────────────────────
+
+AiController::AiController(const AiParams& params, std::mt19937& rng)
+    : m_params(params), m_rng(rng) {}
+
+PlayerInput AiController::step(const AiView& view) {
+    // 1. Record fresh opponent snapshot; cap ring to reactionSteps+1 entries so
+    //    ring.front() is always the snapshot from exactly reactionSteps steps ago
+    //    at steady state, or the oldest available during startup.
+    m_ring.push_back({view.oppPos, view.oppBounds});
+    if (static_cast<int>(m_ring.size()) > m_params.reactionSteps + 1)
+        m_ring.pop_front();
+
+    // 2. Build delayed view: substitute ring.front() for opponent fields.
+    AiView delayedView = view;
+    delayedView.oppPos = m_ring.front().pos;
+    delayedView.oppBounds = m_ring.front().bounds;
+
+    // 3. Decision hold: re-decide every decisionEvery steps.
+    if (--m_holdCounter <= 0) {
+        m_heldDecision = decideAiInput(delayedView, m_params, m_rng);
+        m_holdCounter = m_params.decisionEvery;
+    }
+
+    // 4. Output filter: swing pacing — gate attack to at most one true per
+    //    swingEverySteps (update() clears m_p2Attack each step, so an un-gated
+    //    held attack=true would swing on every step of the hold window).
+    PlayerInput out = m_heldDecision;
+    if (m_swingCooldown > 0) {
+        --m_swingCooldown;
+        out.attack = false;
+    } else if (out.attack) {
+        m_swingCooldown = m_params.swingEverySteps;
+    }
+
+    return out;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "AnimatedGameObject.h"
 #include "Game.h"
 #include "NetworkManager.h"
+#include "ai.h"
 #include "asset_load.h"
 #include "debug.h"
 #include "key_bindings.h"
@@ -21,12 +22,13 @@
 static constexpr float kMenuW = 1024.f;
 static constexpr float kMenuH = 576.f;
 
-enum MenuState { MAIN_MENU, HOST_WAITING, JOIN_INPUT, READY_TO_START };
+enum MenuState { MAIN_MENU, HOST_WAITING, JOIN_INPUT, AI_DIFFICULTY, READY_TO_START };
 
 struct MenuResult {
     NetworkMode mode = NetworkMode::LOCAL;
     std::shared_ptr<NetworkManager> netManager;
     bool quit = false;
+    AiDifficulty ai = AiDifficulty::None;
 };
 
 // ── showEndscreen ─────────────────────────────────────────────────────────────
@@ -238,6 +240,10 @@ static MenuResult showMenu() {
     bool host_updated = false;
     bool join_updated = false;
     bool back_updated = false;
+    bool one_player_updated = false;
+    bool easy_updated = false;
+    bool medium_updated = false;
+    bool hard_updated = false;
 
     sf::RenderWindow startscreen(sf::VideoMode(1024, 576), "Dungeon Game", sf::Style::Default);
     startscreen.setView(makeLetterboxView({kMenuW, kMenuH}, startscreen.getSize()));
@@ -272,6 +278,31 @@ static MenuResult showMenu() {
     m_back->setPosition(100, 50);
     m_back->setScale(.25f);
 
+    // 1-player / AI-difficulty buttons
+    auto m_one_player = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
+    loadOrThrow(*m_one_player, resource_path + "start.png");
+    m_one_player->setOrigin();
+    m_one_player->setPosition(kMenuW / 2, 120);
+    m_one_player->setScale(.4f);
+
+    auto m_easy = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
+    loadOrThrow(*m_easy, resource_path + "start.png");
+    m_easy->setOrigin();
+    m_easy->setPosition(kMenuW / 2, 180);
+    m_easy->setScale(.4f);
+
+    auto m_medium = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
+    loadOrThrow(*m_medium, resource_path + "start.png");
+    m_medium->setOrigin();
+    m_medium->setPosition(kMenuW / 2, 300);
+    m_medium->setScale(.4f);
+
+    auto m_hard = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
+    loadOrThrow(*m_hard, resource_path + "start.png");
+    m_hard->setOrigin();
+    m_hard->setPosition(kMenuW / 2, 420);
+    m_hard->setScale(.4f);
+
     sf::Text localLabel("LOCAL", font, 40);
     localLabel.setFillColor(sf::Color::White);
     localLabel.setStyle(sf::Text::Bold);
@@ -286,6 +317,22 @@ static MenuResult showMenu() {
 
     sf::Text backLabel("BACK", font, 20);
     backLabel.setFillColor(sf::Color::White);
+
+    sf::Text onePlayerLabel("1 PLAYER", font, 36);
+    onePlayerLabel.setFillColor(sf::Color::Yellow);
+    onePlayerLabel.setStyle(sf::Text::Bold);
+
+    sf::Text easyLabel("EASY", font, 38);
+    easyLabel.setFillColor(sf::Color::Green);
+    easyLabel.setStyle(sf::Text::Bold);
+
+    sf::Text mediumLabel("MEDIUM", font, 38);
+    mediumLabel.setFillColor(sf::Color::Yellow);
+    mediumLabel.setStyle(sf::Text::Bold);
+
+    sf::Text hardLabel("HARD", font, 38);
+    hardLabel.setFillColor(sf::Color::Red);
+    hardLabel.setStyle(sf::Text::Bold);
 
     MenuResult result;
 
@@ -347,8 +394,34 @@ static MenuResult showMenu() {
                                  m_back->getPosition().y - (m_back->getHeight() / 4),
                                  m_back->getWidth() * m_back->getScale().x,
                                  m_back->getHeight() * m_back->getScale().y);
+        sf::Rect<float> onePlayerRect(
+            m_one_player->getPosition().x - (m_one_player->getWidth() / 4),
+            m_one_player->getPosition().y - (m_one_player->getHeight() / 4),
+            m_one_player->getWidth() * m_one_player->getScale().x,
+            m_one_player->getHeight() * m_one_player->getScale().y);
+        sf::Rect<float> easyRect(m_easy->getPosition().x - (m_easy->getWidth() / 4),
+                                 m_easy->getPosition().y - (m_easy->getHeight() / 4),
+                                 m_easy->getWidth() * m_easy->getScale().x,
+                                 m_easy->getHeight() * m_easy->getScale().y);
+        sf::Rect<float> mediumRect(m_medium->getPosition().x - (m_medium->getWidth() / 4),
+                                   m_medium->getPosition().y - (m_medium->getHeight() / 4),
+                                   m_medium->getWidth() * m_medium->getScale().x,
+                                   m_medium->getHeight() * m_medium->getScale().y);
+        sf::Rect<float> hardRect(m_hard->getPosition().x - (m_hard->getWidth() / 4),
+                                 m_hard->getPosition().y - (m_hard->getHeight() / 4),
+                                 m_hard->getWidth() * m_hard->getScale().x,
+                                 m_hard->getHeight() * m_hard->getScale().y);
 
         if (menuState == MAIN_MENU) {
+            if (onePlayerRect.contains(mousePos) && !one_player_updated) {
+                m_one_player->update(0.0f);
+                one_player_updated = true;
+                press.play();
+            } else if (!onePlayerRect.contains(mousePos) && one_player_updated) {
+                one_player_updated = false;
+                m_one_player->update(0.0f);
+                up.play();
+            }
             if (startRect.contains(mousePos) && !start_updated) {
                 m_start->update(0.0f);
                 start_updated = true;
@@ -386,7 +459,10 @@ static MenuResult showMenu() {
                 up.play();
             }
             if (sf::Mouse::isButtonPressed(sf::Mouse::Left)) {
-                if (startRect.contains(mousePos)) {
+                if (onePlayerRect.contains(mousePos)) {
+                    menuState = AI_DIFFICULTY;
+                    sf::sleep(sf::milliseconds(200));
+                } else if (startRect.contains(mousePos)) {
                     mode = NetworkMode::LOCAL;
                     menuState = READY_TO_START;
                     sf::sleep(sf::milliseconds(200));
@@ -449,6 +525,64 @@ static MenuResult showMenu() {
                 statusMessage = "";
                 sf::sleep(sf::milliseconds(200));
             }
+        } else if (menuState == AI_DIFFICULTY) {
+            if (easyRect.contains(mousePos) && !easy_updated) {
+                m_easy->update(0.0f);
+                easy_updated = true;
+                press.play();
+            } else if (!easyRect.contains(mousePos) && easy_updated) {
+                easy_updated = false;
+                m_easy->update(0.0f);
+                up.play();
+            }
+            if (mediumRect.contains(mousePos) && !medium_updated) {
+                m_medium->update(0.0f);
+                medium_updated = true;
+                press.play();
+            } else if (!mediumRect.contains(mousePos) && medium_updated) {
+                medium_updated = false;
+                m_medium->update(0.0f);
+                up.play();
+            }
+            if (hardRect.contains(mousePos) && !hard_updated) {
+                m_hard->update(0.0f);
+                hard_updated = true;
+                press.play();
+            } else if (!hardRect.contains(mousePos) && hard_updated) {
+                hard_updated = false;
+                m_hard->update(0.0f);
+                up.play();
+            }
+            if (backRect.contains(mousePos) && !back_updated) {
+                m_back->update(0.0f);
+                back_updated = true;
+                press.play();
+            } else if (!backRect.contains(mousePos) && back_updated) {
+                back_updated = false;
+                m_back->update(0.0f);
+                up.play();
+            }
+            if (sf::Mouse::isButtonPressed(sf::Mouse::Left)) {
+                if (easyRect.contains(mousePos)) {
+                    result.ai = AiDifficulty::Easy;
+                    mode = NetworkMode::LOCAL;
+                    menuState = READY_TO_START;
+                    sf::sleep(sf::milliseconds(200));
+                } else if (mediumRect.contains(mousePos)) {
+                    result.ai = AiDifficulty::Medium;
+                    mode = NetworkMode::LOCAL;
+                    menuState = READY_TO_START;
+                    sf::sleep(sf::milliseconds(200));
+                } else if (hardRect.contains(mousePos)) {
+                    result.ai = AiDifficulty::Hard;
+                    mode = NetworkMode::LOCAL;
+                    menuState = READY_TO_START;
+                    sf::sleep(sf::milliseconds(200));
+                } else if (backRect.contains(mousePos)) {
+                    menuState = MAIN_MENU;
+                    sf::sleep(sf::milliseconds(200));
+                }
+            }
         } else if (menuState == READY_TO_START) {
             if (startRect.contains(mousePos) && !start_updated) {
                 m_start->update(0.0f);
@@ -472,11 +606,19 @@ static MenuResult showMenu() {
         david.draw(startscreen);
 
         if (menuState == MAIN_MENU) {
+            m_one_player->draw(startscreen);
+            onePlayerLabel.setOrigin(onePlayerLabel.getGlobalBounds().width / 2,
+                                     onePlayerLabel.getGlobalBounds().height / 2);
+            onePlayerLabel.setPosition(m_one_player->getPosition().x,
+                                       m_one_player->getPosition().y);
+            startscreen.draw(onePlayerLabel);
+
             m_start->draw(startscreen);
             m_host->draw(startscreen);
             m_join->draw(startscreen);
             m_quit->draw(startscreen);
 
+            localLabel.setString("2 PLAYER");
             localLabel.setOrigin(localLabel.getGlobalBounds().width / 2,
                                  localLabel.getGlobalBounds().height / 2);
             localLabel.setPosition(m_start->getPosition().x, m_start->getPosition().y);
@@ -558,6 +700,37 @@ static MenuResult showMenu() {
                 statusText.setPosition(kMenuW / 2, 460);
                 startscreen.draw(statusText);
             }
+        } else if (menuState == AI_DIFFICULTY) {
+            m_back->draw(startscreen);
+            backLabel.setOrigin(backLabel.getGlobalBounds().width / 2,
+                                backLabel.getGlobalBounds().height / 2);
+            backLabel.setPosition(m_back->getPosition().x, m_back->getPosition().y);
+            startscreen.draw(backLabel);
+
+            sf::Text diffTitle("SELECT DIFFICULTY", font, 40);
+            diffTitle.setFillColor(sf::Color::White);
+            diffTitle.setStyle(sf::Text::Bold);
+            diffTitle.setOrigin(diffTitle.getGlobalBounds().width / 2, 0);
+            diffTitle.setPosition(kMenuW / 2, 80);
+            startscreen.draw(diffTitle);
+
+            m_easy->draw(startscreen);
+            easyLabel.setOrigin(easyLabel.getGlobalBounds().width / 2,
+                                easyLabel.getGlobalBounds().height / 2);
+            easyLabel.setPosition(m_easy->getPosition().x, m_easy->getPosition().y);
+            startscreen.draw(easyLabel);
+
+            m_medium->draw(startscreen);
+            mediumLabel.setOrigin(mediumLabel.getGlobalBounds().width / 2,
+                                  mediumLabel.getGlobalBounds().height / 2);
+            mediumLabel.setPosition(m_medium->getPosition().x, m_medium->getPosition().y);
+            startscreen.draw(mediumLabel);
+
+            m_hard->draw(startscreen);
+            hardLabel.setOrigin(hardLabel.getGlobalBounds().width / 2,
+                                hardLabel.getGlobalBounds().height / 2);
+            hardLabel.setPosition(m_hard->getPosition().x, m_hard->getPosition().y);
+            startscreen.draw(hardLabel);
         } else if (menuState == READY_TO_START) {
             m_start->draw(startscreen);
             localLabel.setString("START");
@@ -615,35 +788,47 @@ int main(int argc, char** argv) {
                 } else if (arg == "--seed") {
                     seed = static_cast<unsigned>(std::stoul(needValue(arg, i)));
                     haveSeed = true;
+                } else if (arg == "--ai") {
+                    std::string val(needValue(arg, i));
+                    if (val == "easy")
+                        config.ai = AiDifficulty::Easy;
+                    else if (val == "medium")
+                        config.ai = AiDifficulty::Medium;
+                    else if (val == "hard")
+                        config.ai = AiDifficulty::Hard;
+                    else
+                        throw std::runtime_error("--ai must be easy, medium, or hard");
                 } else if (arg == "--help") {
-                    std::cout << "Usage: dungeon_game [options]\n"
-                              << "  --frames N             Run N sim steps then exit\n"
-                              << "  --replay <file>        Drive P2 (robot) from replay file\n"
-                              << "  --replay-p1 <file>     Drive P1 (rocket) from replay file\n"
-                              << "  --screenshot-every N   Save screenshot every N steps\n"
-                              << "  --screenshot-dir <d>   Directory for screenshots (default: .)\n"
-                              << "  --seed <n>             Seed the RNG\n"
-                              << "\n"
-                              << "Key bindings can be customised by placing a controls.cfg file\n"
-                              << "next to the dungeon_game binary.  Example:\n"
-                              << "  p1_up = Num8\n"
-                              << "  p1_down = Num5\n"
-                              << "  p1_left = Num4\n"
-                              << "  p1_right = Num6\n"
-                              << "  p1_attack = Right\n"
-                              << "  p2_up = W\n"
-                              << "  p2_down = S\n"
-                              << "  p2_left = A\n"
-                              << "  p2_right = D\n"
-                              << "  p2_attack = Space\n"
-                              << "  slow_down = O\n"
-                              << "  speed_up = P\n"
-                              << "  skip_cooldown = K\n"
-                              << "\n"
-                              << "Replay format: one line per step — 'up down left right attack' "
-                                 "(0 or 1)\n"
-                              << "  Everything from '#' to end-of-line is ignored; blank lines "
-                                 "skipped.\n";
+                    std::cout
+                        << "Usage: dungeon_game [options]\n"
+                        << "  --frames N             Run N sim steps then exit\n"
+                        << "  --replay <file>        Drive P2 (robot) from replay file\n"
+                        << "  --replay-p1 <file>     Drive P1 (rocket) from replay file\n"
+                        << "  --screenshot-every N   Save screenshot every N steps\n"
+                        << "  --screenshot-dir <d>   Directory for screenshots (default: .)\n"
+                        << "  --seed <n>             Seed the RNG\n"
+                        << "  --ai <easy|medium|hard>   AI opponent for P2 (requires --frames)\n"
+                        << "\n"
+                        << "Key bindings can be customised by placing a controls.cfg file\n"
+                        << "next to the dungeon_game binary.  Example:\n"
+                        << "  p1_up = Num8\n"
+                        << "  p1_down = Num5\n"
+                        << "  p1_left = Num4\n"
+                        << "  p1_right = Num6\n"
+                        << "  p1_attack = Right\n"
+                        << "  p2_up = W\n"
+                        << "  p2_down = S\n"
+                        << "  p2_left = A\n"
+                        << "  p2_right = D\n"
+                        << "  p2_attack = Space\n"
+                        << "  slow_down = O\n"
+                        << "  speed_up = P\n"
+                        << "  skip_cooldown = K\n"
+                        << "\n"
+                        << "Replay format: one line per step — 'up down left right attack' "
+                           "(0 or 1)\n"
+                        << "  Everything from '#' to end-of-line is ignored; blank lines "
+                           "skipped.\n";
                     return 0;
                 } else {
                     std::cerr << "Error: unknown option '" << arg << "' (try --help)\n";
@@ -695,6 +880,8 @@ int main(int argc, char** argv) {
 
                 Game game(menu.mode, menu.netManager);
                 game.setBindings(bindings);
+                if (menu.ai != AiDifficulty::None)
+                    game.setAiOpponent(menu.ai);
                 auto [p1score, p2score, minutes, seconds, p1win, peerLeft] = game.run();
 
                 if (p1score > highscore)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(dungeon_tests
     test_harness.cpp
     test_loopback.cpp
     test_unit.cpp
+    test_ai.cpp
 )
 target_link_libraries(dungeon_tests PRIVATE dungeon_lib Catch2::Catch2WithMain)
 

--- a/tests/test_ai.cpp
+++ b/tests/test_ai.cpp
@@ -1,0 +1,303 @@
+// Unit tests for the AI decider + controller.
+// Pure functions only — no window, no display, no audio.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ai.h"
+#include "rng.h"
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+static AiView makeView(float selfX, float selfY, float oppX, float oppY,
+                       bool facingLeft = true, bool inCooldown = false) {
+    AiView v;
+    v.selfPos = {selfX, selfY};
+    v.selfBounds = {selfX - 60.f, selfY - 90.f, 120.f, 180.f}; // normalised positive rect
+    v.selfFacingLeft = facingLeft;
+    v.oppPos = {oppX, oppY};
+    v.oppBounds = {oppX - 60.f, oppY - 90.f, 120.f, 180.f};
+    // Hazards far off-screen
+    v.hazards = {sf::FloatRect{-2000.f, -2000.f, 1.f, 1.f},
+                 sf::FloatRect{-2000.f, -2000.f, 1.f, 1.f},
+                 sf::FloatRect{-2000.f, -2000.f, 1.f, 1.f}};
+    v.inCooldown = inCooldown;
+    v.selfScore = 0;
+    v.oppScore = 0;
+    v.step = 0;
+    return v;
+}
+
+// ── 1. In range + aligned + facing + missTimeProb=0 → attack ─────────────────
+
+TEST_CASE("ai: in range, aligned, facing, missTimeProb=0 → attack==true", "[ai]") {
+    AiParams p = paramsFor(AiDifficulty::Hard);
+    p.missTimeProb = 0.f;
+    p.mistakeProb = 0.f;
+
+    std::mt19937 rng(1);
+    // Self at 960, opponent to the LEFT at 700 (dx = -260 < attackRange=320)
+    // Facing left (selfFacingLeft=true), opponent is to the left → correct facing
+    AiView v = makeView(960.f, 400.f, 700.f, 400.f, /*facingLeft=*/true);
+
+    PlayerInput out = decideAiInput(v, p, rng);
+    REQUIRE(out.attack == true);
+}
+
+// ── 2. Beyond attackRange → no attack, moves toward opponent ─────────────────
+
+TEST_CASE("ai: beyond attackRange → no attack, moves toward opponent", "[ai]") {
+    AiParams p = paramsFor(AiDifficulty::Hard);
+    p.mistakeProb = 0.f;
+    p.aggression = 1.f;    // always close in
+    p.preferredGapX = 50.f; // preferred gap much less than actual distance
+
+    std::mt19937 rng(1);
+    // Opponent far to the right: dx=800 > attackRange=320
+    AiView v = makeView(500.f, 400.f, 1300.f, 400.f, /*facingLeft=*/false);
+
+    PlayerInput out = decideAiInput(v, p, rng);
+    REQUIRE(out.attack == false);
+    REQUIRE(out.right == true); // close in toward opponent (right)
+    REQUIRE(out.left == false);
+}
+
+// ── 3. Opponent behind (wrong facing) → turns toward opponent ─────────────────
+
+TEST_CASE("ai: opponent behind → turns toward opponent", "[ai]") {
+    AiParams p = paramsFor(AiDifficulty::Hard);
+    p.missTimeProb = 0.f;
+    p.mistakeProb = 0.f;
+
+    std::mt19937 rng(1);
+    // Self facing LEFT but opponent is to the RIGHT (dx=+200 < attackRange=320)
+    // In range and aligned, but facing wrong direction.
+    // Attack fires with right=true (turn+attack in same step).
+    AiView v = makeView(960.f, 400.f, 1160.f, 400.f, /*facingLeft=*/true);
+
+    PlayerInput out = decideAiInput(v, p, rng);
+    // Opponent is to the right → right=true (turning/facing toward opponent)
+    REQUIRE(out.right == true);
+    REQUIRE(out.left == false);
+}
+
+// ── 4. selfBounds intersecting a hazard → moves out, overrides attack ────────
+
+TEST_CASE("ai: selfBounds in hazard → moves out, no attack", "[ai]") {
+    AiParams p = paramsFor(AiDifficulty::Hard);
+    p.hazardMargin = 80.f; // Hard preset is 0 (pure aggressor); set explicitly for this test
+    p.mistakeProb = 0.f;
+    p.missTimeProb = 0.f;
+
+    std::mt19937 rng(1);
+    AiView v = makeView(960.f, 400.f, 300.f, 400.f, /*facingLeft=*/true);
+    // Place a hazard overlapping the inflated selfBounds
+    // selfBounds = {900, 310, 120, 180}; inflated by 80 → {820, 230, 280, 340}
+    // Hazard at x=830, width=20 → overlaps inflated bounds
+    v.hazards[0] = sf::FloatRect{830.f, 250.f, 20.f, 300.f};
+
+    PlayerInput out = decideAiInput(v, p, rng);
+    REQUIRE(out.attack == false);
+    // Hazard centre x=840, self centre x=960 → hazard to the left → move right
+    REQUIRE(out.right == true);
+}
+
+// ── 5. inCooldown → all-false ─────────────────────────────────────────────────
+
+TEST_CASE("ai: inCooldown → all-false", "[ai]") {
+    AiParams p = paramsFor(AiDifficulty::Hard);
+    std::mt19937 rng(42);
+    AiView v = makeView(960.f, 400.f, 300.f, 400.f, true, /*inCooldown=*/true);
+
+    PlayerInput out = decideAiInput(v, p, rng);
+    REQUIRE(!out.up);
+    REQUIRE(!out.down);
+    REQUIRE(!out.left);
+    REQUIRE(!out.right);
+    REQUIRE(!out.attack);
+}
+
+// ── 6. Determinism: same view seq + same seed → identical output seq ──────────
+
+TEST_CASE("ai: determinism — same seed and view seq → identical PlayerInput seq", "[ai]") {
+    AiParams p = paramsFor(AiDifficulty::Easy); // mistakeProb=0.15 exercises rng path
+    p.decisionEvery = 1;                        // re-decide every step for more rng draws
+
+    AiView v = makeView(960.f, 400.f, 400.f, 400.f, true);
+
+    auto run = [&]() {
+        std::mt19937 rng(99);
+        AiController ctrl(p, rng);
+        std::vector<PlayerInput> seq;
+        for (int i = 0; i < 40; ++i) {
+            v.step = i;
+            seq.push_back(ctrl.step(v));
+        }
+        return seq;
+    };
+
+    auto seq1 = run();
+    auto seq2 = run();
+
+    REQUIRE(seq1.size() == seq2.size());
+    for (std::size_t i = 0; i < seq1.size(); ++i) {
+        REQUIRE(seq1[i].up == seq2[i].up);
+        REQUIRE(seq1[i].down == seq2[i].down);
+        REQUIRE(seq1[i].left == seq2[i].left);
+        REQUIRE(seq1[i].right == seq2[i].right);
+        REQUIRE(seq1[i].attack == seq2[i].attack);
+    }
+}
+
+// ── 7. Reaction delay: teleport at step k → old pos seen until k+reactionSteps
+
+TEST_CASE("ai: reaction delay — teleport seen after reactionSteps", "[ai]") {
+    AiParams p = paramsFor(AiDifficulty::Easy); // reactionSteps=18
+    p.mistakeProb = 0.f;
+    p.decisionEvery = 1; // re-decide every step
+    p.missTimeProb = 0.f;
+    p.aggression = 1.f;
+    p.preferredGapX = 50.f;
+
+    std::mt19937 rng(7);
+    AiController ctrl(p, rng);
+
+    // Phase 1: opponent starts to the right (dx > 0). AI should move right.
+    AiView v = makeView(500.f, 400.f, 1400.f, 400.f, false);
+
+    // Run reactionSteps-1 steps: AI should still see old (right-side) position.
+    PlayerInput last_before;
+    for (int i = 0; i < p.reactionSteps - 1; ++i) {
+        v.step = i;
+        last_before = ctrl.step(v);
+    }
+    // Should be moving right (toward opponent on the right)
+    REQUIRE(last_before.right == true);
+
+    // Now teleport opponent to far left — AI should NOT react immediately
+    v.oppPos = {100.f, 400.f};
+    v.oppBounds = {40.f, 310.f, 120.f, 180.f};
+    v.step = p.reactionSteps - 1;
+    PlayerInput at_teleport = ctrl.step(v);
+    // Still sees old position (reactionSteps - 1 steps of new pos; need reactionSteps)
+    REQUIRE(at_teleport.right == true);
+
+    // After reactionSteps more steps with opponent on the left, AI should see new pos
+    PlayerInput after;
+    for (int i = 0; i < p.reactionSteps; ++i) {
+        v.step = p.reactionSteps + i;
+        after = ctrl.step(v);
+    }
+    // Now should be moving left (toward opponent on the left)
+    REQUIRE(after.left == true);
+}
+
+// ── 8. Swing pacing: no two attack==true closer than swingEverySteps ──────────
+
+TEST_CASE("ai: swing pacing — attacks spaced by at least swingEverySteps", "[ai]") {
+    AiParams p = paramsFor(AiDifficulty::Hard);
+    p.mistakeProb = 0.f;
+    p.missTimeProb = 0.f;
+    p.decisionEvery = 1; // re-decide every step → attack fires whenever in range
+
+    std::mt19937 rng(3);
+    AiController ctrl(p, rng);
+
+    AiView v = makeView(960.f, 400.f, 700.f, 400.f, true); // opponent in range
+
+    int last_attack_step = -1000;
+    int min_gap = 9999;
+
+    for (int i = 0; i < 300; ++i) {
+        v.step = i;
+        PlayerInput out = ctrl.step(v);
+        if (out.attack) {
+            int gap = i - last_attack_step;
+            if (last_attack_step >= 0)
+                min_gap = std::min(min_gap, gap);
+            last_attack_step = i;
+        }
+    }
+
+    REQUIRE(min_gap >= p.swingEverySteps); // no two attacks closer than swingEverySteps
+}
+
+// ── 9. paramsFor sanity ───────────────────────────────────────────────────────
+
+TEST_CASE("ai: paramsFor sanity — Easy harder than Medium harder than Hard", "[ai]") {
+    AiParams easy = paramsFor(AiDifficulty::Easy);
+    AiParams med = paramsFor(AiDifficulty::Medium);
+    AiParams hard = paramsFor(AiDifficulty::Hard);
+
+    REQUIRE(easy.reactionSteps > med.reactionSteps);
+    REQUIRE(med.reactionSteps > hard.reactionSteps);
+
+    REQUIRE(easy.mistakeProb > med.mistakeProb);
+    REQUIRE(med.mistakeProb > hard.mistakeProb);
+
+    REQUIRE(easy.attackRange < med.attackRange);
+    REQUIRE(med.attackRange < hard.attackRange);
+
+    REQUIRE(easy.preferredGapX > med.preferredGapX);
+    REQUIRE(med.preferredGapX > hard.preferredGapX);
+
+    REQUIRE(easy.aggression < med.aggression);
+    REQUIRE(med.aggression < hard.aggression);
+}
+
+// ── 9b. decisionEvery hold: output changes only on boundary ───────────────────
+
+TEST_CASE("ai: decisionEvery hold — output constant within hold window", "[ai]") {
+    AiParams p = paramsFor(AiDifficulty::Hard);
+    p.decisionEvery = 6;
+    p.reactionSteps = 0; // zero reaction delay so ring.front() = current view immediately
+    p.aggression = 1.f;  // always close in (eliminates rng variability in positioning)
+    p.mistakeProb = 0.f;
+    p.missTimeProb = 0.f;
+    p.swingEverySteps = 1000; // suppress swing filter interference
+
+    std::mt19937 rng(5);
+    AiController ctrl(p, rng);
+
+    // View A: opponent to the left → expect left movement
+    AiView vA = makeView(960.f, 400.f, 400.f, 400.f, true);
+    // View B: opponent far above and to the right (beyond range) → expect up + right positioning
+    AiView vB = makeView(960.f, 700.f, 1800.f, 100.f, false);
+    vB.hazards = vA.hazards;
+
+    // Steps 0..5 (first hold window): all use vA
+    PlayerInput step0 = ctrl.step(vA);
+    std::vector<PlayerInput> window1;
+    window1.push_back(step0);
+    for (int i = 1; i < p.decisionEvery; ++i) {
+        vA.step = i;
+        window1.push_back(ctrl.step(vA));
+    }
+    // Within the window, all outputs should equal step0
+    for (int i = 1; i < p.decisionEvery; ++i) {
+        REQUIRE(window1[static_cast<std::size_t>(i)].left ==
+                window1[0].left);
+        REQUIRE(window1[static_cast<std::size_t>(i)].right ==
+                window1[0].right);
+        REQUIRE(window1[static_cast<std::size_t>(i)].up ==
+                window1[0].up);
+        REQUIRE(window1[static_cast<std::size_t>(i)].down ==
+                window1[0].down);
+    }
+
+    // Step decisionEvery: re-decide with vB — output should differ
+    vB.step = p.decisionEvery;
+    PlayerInput newDecision = ctrl.step(vB);
+    // vB has opponent far to the right and no attack → should move right (not left)
+    REQUIRE(newDecision.right == true);
+    REQUIRE(newDecision.left == false);
+
+    // Steps decisionEvery+1..2*decisionEvery-1: should all match newDecision
+    for (int i = 1; i < p.decisionEvery; ++i) {
+        vB.step = p.decisionEvery + i;
+        PlayerInput held = ctrl.step(vB);
+        REQUIRE(held.left == newDecision.left);
+        REQUIRE(held.right == newDecision.right);
+        REQUIRE(held.up == newDecision.up);
+        REQUIRE(held.down == newDecision.down);
+    }
+}

--- a/tests/test_ai.cpp
+++ b/tests/test_ai.cpp
@@ -8,8 +8,8 @@
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
-static AiView makeView(float selfX, float selfY, float oppX, float oppY,
-                       bool facingLeft = true, bool inCooldown = false) {
+static AiView makeView(float selfX, float selfY, float oppX, float oppY, bool facingLeft = true,
+                       bool inCooldown = false) {
     AiView v;
     v.selfPos = {selfX, selfY};
     v.selfBounds = {selfX - 60.f, selfY - 90.f, 120.f, 180.f}; // normalised positive rect
@@ -48,7 +48,7 @@ TEST_CASE("ai: in range, aligned, facing, missTimeProb=0 → attack==true", "[ai
 TEST_CASE("ai: beyond attackRange → no attack, moves toward opponent", "[ai]") {
     AiParams p = paramsFor(AiDifficulty::Hard);
     p.mistakeProb = 0.f;
-    p.aggression = 1.f;    // always close in
+    p.aggression = 1.f;     // always close in
     p.preferredGapX = 50.f; // preferred gap much less than actual distance
 
     std::mt19937 rng(1);
@@ -274,14 +274,10 @@ TEST_CASE("ai: decisionEvery hold — output constant within hold window", "[ai]
     }
     // Within the window, all outputs should equal step0
     for (int i = 1; i < p.decisionEvery; ++i) {
-        REQUIRE(window1[static_cast<std::size_t>(i)].left ==
-                window1[0].left);
-        REQUIRE(window1[static_cast<std::size_t>(i)].right ==
-                window1[0].right);
-        REQUIRE(window1[static_cast<std::size_t>(i)].up ==
-                window1[0].up);
-        REQUIRE(window1[static_cast<std::size_t>(i)].down ==
-                window1[0].down);
+        REQUIRE(window1[static_cast<std::size_t>(i)].left == window1[0].left);
+        REQUIRE(window1[static_cast<std::size_t>(i)].right == window1[0].right);
+        REQUIRE(window1[static_cast<std::size_t>(i)].up == window1[0].up);
+        REQUIRE(window1[static_cast<std::size_t>(i)].down == window1[0].down);
     }
 
     // Step decisionEvery: re-decide with vB — output should differ

--- a/tests/test_ai.cpp
+++ b/tests/test_ai.cpp
@@ -43,6 +43,31 @@ TEST_CASE("ai: in range, aligned, facing, missTimeProb=0 → attack==true", "[ai
     REQUIRE(out.attack == true);
 }
 
+// ── 1b. Near-edge (body-to-body) attack: wide opponent to the right ───────────
+// Mirrors the real posture makeAiView normalises: the opponent (rocket) sits to
+// the RIGHT of the robot. The attack check must use the NEAR (left) edge of a
+// normalised oppBounds, not the anchor/centre — here the anchor is out of range
+// but the near edge is in range, so a body-aware AI still attacks. This is the
+// oppToRight branch of nearOppEdge; a non-normalised (negative-width) oppBounds
+// would pick the far edge and wrongly decline the attack.
+
+TEST_CASE("ai: near-edge attack — wide opponent to the right, anchor out but edge in", "[ai]") {
+    AiParams p = paramsFor(AiDifficulty::Hard); // attackRange=320, attackAlignY=80
+    p.missTimeProb = 0.f;
+    p.mistakeProb = 0.f;
+
+    std::mt19937 rng(1);
+    // Robot at x=960; opponent anchor at x=1410 (dx=+450 > attackRange → anchor out of range).
+    AiView v = makeView(960.f, 400.f, 1410.f, 400.f, /*facingLeft=*/false);
+    // Wide opponent: near (left) edge at 1260 → edge distance 300 < attackRange=320.
+    v.oppBounds = sf::FloatRect{1260.f, 310.f, 300.f, 180.f};
+
+    PlayerInput out = decideAiInput(v, p, rng);
+    REQUIRE(out.attack == true); // fires on near-edge distance, not the far anchor
+    REQUIRE(out.right == true);  // faces toward opponent (to the right)
+    REQUIRE(out.left == false);
+}
+
 // ── 2. Beyond attackRange → no attack, moves toward opponent ─────────────────
 
 TEST_CASE("ai: beyond attackRange → no attack, moves toward opponent", "[ai]") {
@@ -223,7 +248,7 @@ TEST_CASE("ai: swing pacing — attacks spaced by at least swingEverySteps", "[a
 
 // ── 9. paramsFor sanity ───────────────────────────────────────────────────────
 
-TEST_CASE("ai: paramsFor sanity — Easy harder than Medium harder than Hard", "[ai]") {
+TEST_CASE("ai: paramsFor sanity — params scale with difficulty (Easy < Medium < Hard)", "[ai]") {
     AiParams easy = paramsFor(AiDifficulty::Easy);
     AiParams med = paramsFor(AiDifficulty::Medium);
     AiParams hard = paramsFor(AiDifficulty::Hard);

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -17,7 +17,9 @@
 
 #include "Game.h"
 #include "NetworkManager.h"
+#include "ai.h"
 #include "debug.h"
+#include "rng.h"
 
 // Absolute path to tests/data/ is injected at build time via CMake define.
 #ifndef TESTS_DATA_DIR
@@ -451,4 +453,73 @@ TEST_CASE("integration: HOST game detects peer loss", "[integration]") {
     auto [result, s] = runGame(cfg, NetworkMode::HOST, hostMgr);
 
     REQUIRE(std::get<5>(result) == true); // peerLeft
+}
+
+// ── 20. AI Hard scores on idle P1 ────────────────────────────────────────────
+// rng::seed(42), Hard AI, 900 frames, P1 idle → robot (P2) scores at least once.
+
+TEST_CASE("integration: AI Hard scores on idle P1 within 900 frames", "[integration]") {
+    rng::seed(42);
+    DebugConfig cfg;
+    cfg.frames = 900;
+    cfg.ai = AiDifficulty::Hard;
+    auto [t, s] = runGame(cfg);
+
+    REQUIRE(s.p2_score >= 1); // robot kills idle rocket at least once
+    REQUIRE(s.p1_score == 0); // idle rocket never damages robot
+}
+
+// ── 21. AI reproducibility ────────────────────────────────────────────────────
+// Two runs with identical seed → identical snapshot fields.
+
+TEST_CASE("integration: AI reproducibility — reseed 42 between runs gives identical snapshot",
+          "[integration]") {
+    DebugConfig cfg;
+    cfg.frames = 300;
+    cfg.ai = AiDifficulty::Hard;
+
+    rng::seed(42);
+    auto [t1, s1] = runGame(cfg);
+
+    rng::seed(42);
+    auto [t2, s2] = runGame(cfg);
+
+    REQUIRE(s1.p1_x == Catch::Approx(s2.p1_x).margin(0.001f));
+    REQUIRE(s1.p1_y == Catch::Approx(s2.p1_y).margin(0.001f));
+    REQUIRE(s1.p2_x == Catch::Approx(s2.p2_x).margin(0.001f));
+    REQUIRE(s1.p2_y == Catch::Approx(s2.p2_y).margin(0.001f));
+    REQUIRE(s1.p1_score == s2.p1_score);
+    REQUIRE(s1.p2_score == s2.p2_score);
+    REQUIRE(s1.wait == s2.wait);
+}
+
+// ── 22. AI Easy completes without crash ──────────────────────────────────────
+
+TEST_CASE("integration: AI Easy runs 600 frames without crash", "[integration]") {
+    rng::seed(7);
+    DebugConfig cfg;
+    cfg.frames = 600;
+    cfg.ai = AiDifficulty::Easy;
+    auto [t, s] = runGame(cfg);
+
+    REQUIRE(s.p1_score >= 0);
+    REQUIRE(s.p2_score >= 0);
+}
+
+// ── 23. Replay overrides AI ───────────────────────────────────────────────────
+// With both ai=Hard and replayPath set, the replay takes precedence (else-if
+// ordering).  The scripted P2 kill should happen, not AI behaviour.
+
+TEST_CASE("integration: replay overrides AI — replay kill wins over Hard AI", "[integration]") {
+    rng::seed(42);
+    DebugConfig cfg;
+    cfg.frames = 75;
+    cfg.ai = AiDifficulty::Hard;
+    cfg.replayPath = dataPath("p2_kill.replay");
+    auto [t, s] = runGame(cfg);
+
+    // Replay's scripted kill: p2_score==1, wait==true (same as test 2)
+    REQUIRE(s.p2_score == 1);
+    REQUIRE(s.p1_score == 0);
+    REQUIRE(s.wait == true);
 }

--- a/tests/test_unit.cpp
+++ b/tests/test_unit.cpp
@@ -88,6 +88,57 @@ TEST_CASE("objectBounds: negative scale.x produces negative-width rect (pinned q
     REQUIRE(r.height == Catch::Approx(180.f));
 }
 
+// ── normalizedBounds ─────────────────────────────────────────────────────────
+// normalizedBounds() is objectBounds() forced to positive width/height. It is
+// what the AI feeds its nearest-edge math (a left-facing fighter would otherwise
+// give a negative-width rect and the near edge would be computed as the far one).
+// Guards the helper for every sign combination; objectBounds() stays raw.
+
+TEST_CASE("normalizedBounds: normalises every scale-sign combination", "[geometry][unit]") {
+    StubGameObject obj;
+    obj.px = 500;
+    obj.py = 400;
+    obj.w = 119;
+    obj.h = 180;
+
+    SECTION("positive scale — unchanged") {
+        obj.sx = 2;
+        obj.sy = 2;
+        sf::FloatRect r = normalizedBounds(obj);
+        REQUIRE(r.left == Catch::Approx(500.f));
+        REQUIRE(r.top == Catch::Approx(400.f));
+        REQUIRE(r.width == Catch::Approx(238.f));
+        REQUIRE(r.height == Catch::Approx(360.f));
+    }
+    SECTION("negative scale.x — left shifts, width positive") {
+        obj.sx = -1;
+        obj.sy = 1;
+        sf::FloatRect r = normalizedBounds(obj);
+        REQUIRE(r.left == Catch::Approx(381.f)); // 500 + (-119)
+        REQUIRE(r.top == Catch::Approx(400.f));
+        REQUIRE(r.width == Catch::Approx(119.f));
+        REQUIRE(r.height == Catch::Approx(180.f));
+    }
+    SECTION("negative scale.y — top shifts, height positive") {
+        obj.sx = 1;
+        obj.sy = -1;
+        sf::FloatRect r = normalizedBounds(obj);
+        REQUIRE(r.left == Catch::Approx(500.f));
+        REQUIRE(r.top == Catch::Approx(220.f)); // 400 + (-180)
+        REQUIRE(r.width == Catch::Approx(119.f));
+        REQUIRE(r.height == Catch::Approx(180.f));
+    }
+    SECTION("both negative — both axes corrected") {
+        obj.sx = -1;
+        obj.sy = -1;
+        sf::FloatRect r = normalizedBounds(obj);
+        REQUIRE(r.left == Catch::Approx(381.f));
+        REQUIRE(r.top == Catch::Approx(220.f));
+        REQUIRE(r.width == Catch::Approx(119.f));
+        REQUIRE(r.height == Catch::Approx(180.f));
+    }
+}
+
 TEST_CASE("objectBounds: touching rects with negative-width rect do not crash",
           "[geometry][unit]") {
     StubGameObject a, b;


### PR DESCRIPTION
Closes #12.

Adds a single-player mode: an AI opponent that drives P2 through the same `PlayerInput` abstraction as keyboard/network/replay input, so it is fully deterministic and works with the debug harness.

## What's in it
- **`ai_difficulty.h` / `ai.h` / `ai.cpp`** — a pure decider `decideAiInput(view, params, rng) → PlayerInput` plus a thin stateful `AiController` (reaction-delay ring, decision-hold, swing-pacing filter). The decider is stateless and rng-seedable; the controller stores `std::mt19937&` (a reference to `rng::engine()`) so `rng::seed()` reproduces a run bit-for-bit.
- **Three difficulties** (`paramsFor`): Easy / Medium / Hard scale reaction delay, mistake rate, attack range/alignment, preferred gap, and aggression. Hard is a pure aggressor that ignores fire (documented deviation — any positive hazard margin traps it oscillating before the centre-arena fire).
- **Menu + CLI** — "1 PLAYER" → Easy/Medium/Hard sub-menu; `--ai <easy|medium|hard>` for the harness (a no-op without `--frames`, so it never bypasses the menu). Replay input shadows the AI (`else if` ordering), and keyboard P2 is gated off when an AI is active.
- **Decision priority**: inCooldown → mistake roll → hazard escape → attack → positioning. Attack uses **nearest-edge (body-to-body)** distance so the AI swings when its weapon can actually connect.

## Tests
- **11 unit tests** (`[ai]`, window-free): range/alignment/facing, near-edge attack, hazard escape, cooldown, determinism, reaction delay, swing pacing, decision-hold, and difficulty scaling.
- **4 integration tests**: Hard scores against an idle P1, run reproducibility across a re-seed, Easy crash-safety smoke, and replay-overrides-AI.

## Review notes
Two review rounds. Final round converged on one fix (applied here): `makeAiView` normalized `selfBounds` but passed `oppBounds` raw — a left-facing P1 yields a negative-width rect, so the nearest-edge math picked the far edge. Fixed via a shared `normalizedBounds()` helper (the raw negative-width `objectBounds()` is kept for collision, where SFML's normalization is load-bearing) and pinned with a new near-edge unit test.
