### PR TITLE
docs: reflect shipped AI (#12) + replay (#13) control sources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,9 @@ the other before the clock runs out wins. It runs as a native desktop window (ma
 Windows) — there is no server component beyond optional peer-to-peer online play.
 
 The game supports several **control sources** that all feed the same movement/attack logic:
-local shared-keyboard (player 1 numpad, player 2 WASD), online host/client over TCP, and
-(planned) a single-player AI opponent. See [docs/architecture.md](docs/architecture.md).
+local shared-keyboard (player 1 numpad, player 2 WASD), online host/client over TCP, a
+single-player AI opponent (Easy/Medium/Hard), and a scripted replay/debug harness. See
+[docs/architecture.md](docs/architecture.md).
 
 ## Build, run, test
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,8 +22,10 @@ Every mode ultimately drives the same per-player movement/attack booleans consum
 - **Online** — one peer hosts, the other joins over TCP. The client samples its keyboard into a
   `PlayerInput`, sends it to the host; the host simulates authoritatively and streams `GameState`
   back. See `NetworkManager`.
-- **AI (planned, #12)** — a `state → PlayerInput` function drives player 2 from game state.
-- **Replay/debug (planned, #13)** — a scripted sequence of `PlayerInput`s feeds player 2.
+- **AI (#12)** — the pure `decideAiInput(AiView, AiParams, rng) → PlayerInput` decider drives
+  player 2 from a snapshot of game state, with Easy/Medium/Hard difficulty presets. See `ai.h`/`ai.cpp`.
+- **Replay/debug (#13)** — the debug harness feeds a scripted sequence of `PlayerInput`s (loaded via
+  `--replay`/`--replay-p1`) through the same path. See `replay.h`/`replay.cpp` and `debug.h`.
 
 `PlayerInput` (`NetworkManager.h`) is the shared abstraction. New control sources should produce
 a `PlayerInput` per frame rather than reaching into `Game` internals.
@@ -89,6 +91,6 @@ detected, full state is sent every frame with no interpolation, and join input i
 
 SFML opens a real window and audio device, so **logic that must be unit-tested should not depend
 on the window**: packet round-trips (`PlayerInput`/`GameState`), collision/overlap math, animation
-frame indexing, `GameState` capture/apply, and (planned) AI decisions are all pure functions of
+frame indexing, `GameState` capture/apply, and AI decisions are all pure functions of
 data and should be reachable without constructing a `Game`/window. CI runs the windowed paths
 headless under `xvfb` on Linux (see [contributing.md](contributing.md)).


### PR DESCRIPTION
Post-overhaul doc accuracy fix. The AI (#12) and replay/debug (#13) control sources shipped (in PRs #22 and #17), but `docs/architecture.md` and `CLAUDE.md` still described them as `(planned)`.

- `docs/architecture.md`: the AI and replay/debug control-source bullets now describe the shipped `decideAiInput` decider (Easy/Medium/Hard) and the `--replay` harness; dropped `(planned)` from the testability-seams line.
- `CLAUDE.md` (and `AGENTS.md` via symlink): the control-sources sentence now lists the AI opponent and replay harness as present.

Docs-only; no code changes.
