### PR TITLE
release: bundle SFML frameworks in macOS zip + fix rpath

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,9 +90,25 @@ jobs:
       - name: Stage (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-          mkdir dungeon-game-macos
-          cp build/dungeon_game   dungeon-game-macos/
-          cp -r build/assets      dungeon-game-macos/
+          mkdir -p dungeon-game-macos/Frameworks
+          cp build/dungeon_game dungeon-game-macos/
+          cp -R build/assets    dungeon-game-macos/
+          # SFML 2.6.2 on macOS does NOT static-link its third-party libs — it links
+          # bundled frameworks via @rpath (pointed at the build tree). Bundle those
+          # frameworks next to the binary and repoint the rpath so the zip is portable.
+          fwsrc=build/_deps/sfml-src/extlibs/libs-osx/Frameworks
+          for fw in freetype OpenAL vorbisenc vorbisfile vorbis ogg FLAC; do
+            cp -R "$fwsrc/$fw.framework" dungeon-game-macos/Frameworks/
+          done
+          bin=dungeon-game-macos/dungeon_game
+          old_rpath=$(otool -l "$bin" | awk '$1=="path"{print $2; exit}')
+          [ -n "$old_rpath" ] && install_name_tool -delete_rpath "$old_rpath" "$bin"
+          install_name_tool -add_rpath @executable_path/Frameworks "$bin"
+          # Sanity: the executable-relative rpath must be present and the stale
+          # build-tree rpath (…/libs-osx/…) must be gone, else the zip won't launch.
+          rpaths=$(otool -l "$bin" | awk '$1=="path"{print $2}')
+          echo "$rpaths" | grep -qx "@executable_path/Frameworks" || { echo "rpath fix missing"; exit 1; }
+          echo "$rpaths" | grep -q "libs-osx" && { echo "stale build-tree rpath remains"; exit 1; } || true
 
       - name: Stage (Linux)
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
Fixes the v1.0.0 macOS zip, which aborted at launch with `dyld: Library not loaded: @rpath/../Frameworks/freetype.framework`.

**Cause:** SFML 2.6.2 on macOS links its bundled frameworks (freetype, OpenAL, vorbis/vorbisenc/vorbisfile, ogg, FLAC) via an `@rpath` pointed at the CI build tree — `BUILD_SHARED_LIBS=OFF` does not static-link them. The frameworks weren't in the zip and the rpath doesn't exist on a user's machine.

**Fix:** the macOS staging step now copies those 7 frameworks into `dungeon-game-macos/Frameworks/`, removes the stale build-tree rpath, and adds `@executable_path/Frameworks`. Verified locally by staging with the exact commands and running the binary (it launches and runs frames; previously aborted). A sanity check fails the job if the rpath fix doesn't take.

release.yml isn't exercised by PR CI, so I'll validate this end-to-end with a `workflow_dispatch` dry-run on master (download + run the produced macOS zip) before re-cutting the release.