### PR TITLE
release: auto-mark pre-release tags (rc/beta) as GitHub pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ jobs:
 
       - name: Create release
         uses: softprops/action-gh-release@v2
+        with:
+          # Mark pre-release-style tags (v1.0.0-rc1, v1.2.0-beta, …) as pre-releases
+          # so they don't show as "Latest"; a plain vX.Y.Z tag is a full release.
+          prerelease: ${{ contains(github.ref_name, '-') }}
 
   # ── Build + package per platform ─────────────────────────────────────────
   build:


### PR DESCRIPTION
Enables a release-candidate cycle: pushing a tag with a hyphen (e.g. `v1.0.0-rc1`) now publishes a GitHub **pre-release** (kept out of 'Latest'), while a plain `vX.Y.Z` tag remains a full release. One-line change to `create-release` (`prerelease: ${{ contains(github.ref_name, '-') }}`).