### PR TITLE
#28: menu system fixes + menu test harness (menu subset)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,23 @@ jobs:
             -instr-profile=build/cov/merged.profdata \
             -ignore-filename-regex='main\.cpp|tests/'
 
+      - name: Generate menu screenshots
+        env:
+          ALSOFT_DRIVERS: 'null'
+        run: |
+          for st in main_menu ai_difficulty host_waiting join_input ready_to_start; do
+            xvfb-run -a ./build/dungeon_game --menu-state "$st" --frames 2 \
+              --screenshot-every 1 --screenshot-dir "build/menu_shots/$st" || true
+          done
+          ls -R build/menu_shots || true
+
+      - name: Upload menu screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: menu-screenshots
+          path: build/menu_shots/
+
       - name: Check formatting (clang-format-18)
         run: |
           git ls-files 'src/*.cpp' 'include/*.h' 'tests/*.cpp' \

--- a/.gitignore
+++ b/.gitignore
@@ -504,5 +504,6 @@ dist/
 dungeon_game
 *.zip
 
-# CMake build tree
+# CMake build trees (build/, relbuild/, and other out-of-source dirs)
 build/
+relbuild/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ add_library(dungeon_lib STATIC
     src/rng.cpp
     src/key_bindings.cpp
     src/ai.cpp
+    src/menu.cpp
+    src/menu_button.cpp
 )
 
 target_include_directories(dungeon_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/include/AnimatedGameObject.h
+++ b/include/AnimatedGameObject.h
@@ -39,6 +39,8 @@ public:
 
     void setOrigin() override;
 
+    sf::FloatRect getGlobalBounds() const override;
+
 private:
     sf::Sprite m_sprite;
     sf::Texture m_texture;

--- a/include/Game.h
+++ b/include/Game.h
@@ -9,6 +9,7 @@
 #include "RegularGameObject.h"
 #include "ai.h"
 #include "debug.h"
+#include "game_canvas.h"
 #include "key_bindings.h"
 #include "replay.h"
 #include <SFML/Audio.hpp>
@@ -131,9 +132,6 @@ private:
 
     // Fixed-timestep state
     static constexpr float kFixedDt = 1.f / 60.f;
-    // Logical canvas size — all sim positions use these, never m_window.getSize().
-    static constexpr float kLogicalW = 1920.f;
-    static constexpr float kLogicalH = 1080.f;
     long long m_steps = 0;
     float m_accumulator = 0.f;
     float m_animTime = 0.f;

--- a/include/GameObject.h
+++ b/include/GameObject.h
@@ -42,4 +42,6 @@ public:
     virtual bool isValid() = 0;
 
     virtual void setOrigin() = 0;
+
+    virtual sf::FloatRect getGlobalBounds() const = 0;
 };

--- a/include/RegularGameObject.h
+++ b/include/RegularGameObject.h
@@ -37,6 +37,8 @@ public:
 
     void setOrigin() override;
 
+    sf::FloatRect getGlobalBounds() const override;
+
 private:
     sf::Sprite m_sprite;
     sf::Texture m_texture;

--- a/include/debug.h
+++ b/include/debug.h
@@ -16,6 +16,11 @@ struct DebugConfig {
     // so --ai without --frames is a silent no-op for the harness bypass check.
     AiDifficulty ai = AiDifficulty::None;
 
+    // Menu screenshot harness: set to a state name to drive showMenu() directly.
+    std::string menuState;
+
+    bool menuMode() const { return !menuState.empty(); }
+
     bool active() const {
         return frames > 0 || !replayPath.empty() || !replayPathP1.empty() || screenshotEvery > 0 ||
                quitAtStep >= 0;

--- a/include/game_canvas.h
+++ b/include/game_canvas.h
@@ -1,0 +1,3 @@
+#pragma once
+inline constexpr float kGameW = 1920.f;
+inline constexpr float kGameH = 1080.f;

--- a/include/menu.h
+++ b/include/menu.h
@@ -4,6 +4,7 @@
 #include "debug.h"
 #include "menu_layout.h"
 #include <memory>
+#include <string>
 
 struct MenuResult {
     NetworkMode mode = NetworkMode::LOCAL;
@@ -13,3 +14,7 @@ struct MenuResult {
 };
 
 MenuResult showMenu(const DebugConfig& cfg = {});
+
+// Map a --menu-state name ("main_menu", "host_waiting", …) to its enum.
+// Returns false for an unknown name. Single source of truth for valid state names.
+bool parseMenuState(const std::string& name, MenuState& out);

--- a/include/menu.h
+++ b/include/menu.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "NetworkManager.h"
+#include "ai_difficulty.h"
+#include "debug.h"
+#include "menu_layout.h"
+#include <memory>
+
+struct MenuResult {
+    NetworkMode mode = NetworkMode::LOCAL;
+    std::shared_ptr<NetworkManager> netManager;
+    bool quit = false;
+    AiDifficulty ai = AiDifficulty::None;
+};
+
+MenuResult showMenu(const DebugConfig& cfg = {});

--- a/include/menu_button.h
+++ b/include/menu_button.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <SFML/Graphics.hpp>
+#include <string>
+
+struct MenuButton {
+    sf::RectangleShape shape;
+    sf::Text label;
+
+    // Constructs button sized to `size`; call setPosition() before drawing.
+    MenuButton(sf::Vector2f size, const sf::Font& font, const std::string& text,
+               unsigned charSize = 34);
+
+    void setPosition(sf::Vector2f centre); // centres shape and label
+    void setHovered(bool hovered);         // switches fill colour
+    sf::FloatRect bounds() const;          // == shape.getGlobalBounds()
+    void draw(sf::RenderWindow& w) const;
+};

--- a/include/menu_layout.h
+++ b/include/menu_layout.h
@@ -1,0 +1,85 @@
+#pragma once
+#include "game_canvas.h"
+#include <SFML/Graphics.hpp>
+#include <string>
+#include <vector>
+
+// Logical canvas for menus / endscreen.
+inline constexpr float kMenuW = 1024.f;
+inline constexpr float kMenuH = 576.f;
+
+// Standard button geometry.
+inline constexpr float kBtnW = 280.f;
+inline constexpr float kBtnH = 60.f;
+inline constexpr float kBtnGap = 18.f;
+
+enum class MenuState { MAIN_MENU, HOST_WAITING, JOIN_INPUT, AI_DIFFICULTY, READY_TO_START };
+
+// Returns the Y-center of each button in a vertical stack centered within canvasH.
+// Returns empty vector for count <= 0.
+inline std::vector<float> stackedButtonCenters(float canvasH, float btnH, float gap, int count) {
+    if (count <= 0)
+        return {};
+    float totalH = count * btnH + (count - 1) * gap;
+    float startY = (canvasH - totalH) / 2.f + btnH / 2.f;
+    std::vector<float> ys;
+    ys.reserve(static_cast<std::size_t>(count));
+    for (int i = 0; i < count; ++i)
+        ys.push_back(startY + static_cast<float>(i) * (btnH + gap));
+    return ys;
+}
+
+struct ButtonSpec {
+    sf::FloatRect rect;
+    std::string label;
+};
+
+// Returns ButtonSpec for every clickable button in the given state.
+// Rects are in kMenuW x kMenuH logical space.
+// MAIN_MENU:       5 stacked (1 PLAYER, 2 PLAYER, HOST, JOIN, QUIT)
+// AI_DIFFICULTY:   3 stacked (EASY, MEDIUM, HARD) + Back at top-left
+// HOST_WAITING:    Back only
+// JOIN_INPUT:      Back only
+// READY_TO_START:  START only (centered, no Back)
+inline std::vector<ButtonSpec> menuButtonRects(MenuState state) {
+    const sf::FloatRect backRect{20.f, 20.f, 120.f, 38.f};
+
+    if (state == MenuState::MAIN_MENU) {
+        auto ys = stackedButtonCenters(kMenuH, kBtnH, kBtnGap, 5);
+        return {
+            {{kMenuW / 2.f - kBtnW / 2.f, ys[0] - kBtnH / 2.f, kBtnW, kBtnH}, "1 PLAYER"},
+            {{kMenuW / 2.f - kBtnW / 2.f, ys[1] - kBtnH / 2.f, kBtnW, kBtnH}, "2 PLAYER"},
+            {{kMenuW / 2.f - kBtnW / 2.f, ys[2] - kBtnH / 2.f, kBtnW, kBtnH}, "HOST"},
+            {{kMenuW / 2.f - kBtnW / 2.f, ys[3] - kBtnH / 2.f, kBtnW, kBtnH}, "JOIN"},
+            {{kMenuW / 2.f - kBtnW / 2.f, ys[4] - kBtnH / 2.f, kBtnW, kBtnH}, "QUIT"},
+        };
+    }
+    if (state == MenuState::AI_DIFFICULTY) {
+        auto ys = stackedButtonCenters(kMenuH, kBtnH, kBtnGap, 3);
+        return {
+            {{kMenuW / 2.f - kBtnW / 2.f, ys[0] - kBtnH / 2.f, kBtnW, kBtnH}, "EASY"},
+            {{kMenuW / 2.f - kBtnW / 2.f, ys[1] - kBtnH / 2.f, kBtnW, kBtnH}, "MEDIUM"},
+            {{kMenuW / 2.f - kBtnW / 2.f, ys[2] - kBtnH / 2.f, kBtnW, kBtnH}, "HARD"},
+            {backRect, "BACK"},
+        };
+    }
+    if (state == MenuState::HOST_WAITING || state == MenuState::JOIN_INPUT) {
+        return {{backRect, "BACK"}};
+    }
+    // READY_TO_START
+    return {{{kMenuW / 2.f - kBtnW / 2.f, kMenuH / 2.f - kBtnH / 2.f, kBtnW, kBtnH}, "START"}};
+}
+
+// Semi-transparent backing panel for HOST_WAITING and JOIN_INPUT text.
+// Spans y=78–498 on a 576-high canvas, covering all text positions.
+inline sf::FloatRect menuInfoPanelRect() {
+    return {(kMenuW - 560.f) / 2.f, (kMenuH - 420.f) / 2.f, 560.f, 420.f};
+}
+
+// Pause button geometry (game window: kGameW x kGameH from game_canvas.h).
+// index 0 = Resume, index 1 = Quit to Menu.
+inline sf::FloatRect pauseButtonRect(int index) {
+    constexpr float w = 220.f, h = 55.f, gap = 16.f;
+    float top = kGameH / 2.f - h - gap / 2.f + static_cast<float>(index) * (h + gap);
+    return {kGameW / 2.f - w / 2.f, top, w, h};
+}

--- a/include/screenshot.h
+++ b/include/screenshot.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <SFML/Graphics.hpp>
+#include <string>
+
+// LCOV_EXCL_START — requires a live RenderWindow; not testable headless
+inline void captureScreenshot(const sf::RenderWindow& w, const std::string& path) {
+    sf::Texture t;
+    t.create(w.getSize().x, w.getSize().y);
+    t.update(w);
+    t.copyToImage().saveToFile(path);
+}
+// LCOV_EXCL_STOP

--- a/src/AnimatedGameObject.cpp
+++ b/src/AnimatedGameObject.cpp
@@ -98,6 +98,8 @@ void AnimatedGameObject::changeValid(bool a) { m_valid = a; }
 
 bool AnimatedGameObject::isValid() { return m_valid; }
 
+sf::FloatRect AnimatedGameObject::getGlobalBounds() const { return m_sprite.getGlobalBounds(); }
+
 void AnimatedGameObject::setOrigin() {
     if (m_sprite.getOrigin().x == 0) {
         m_sprite.setOrigin((m_sprite.getLocalBounds().width) / 2,

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -382,6 +382,8 @@ void Game::processEvents() {
                     m_paused = false;
                     background.play();
                 } else if (pauseButtonRect(1).contains(mp)) {
+                    if (m_networkManager) // graceful peer teardown, like the keyboard Q path
+                        m_networkManager->disconnect();
                     background.stop();
                     m_quitToMenu = true;
                     m_window.close();

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -6,23 +6,15 @@
 #include "asset_load.h"
 #include "geometry.h"
 #include "letterbox.h"
+#include "menu_button.h"
+#include "menu_layout.h"
 #include "resource_path.h"
 #include "rng.h"
+#include "screenshot.h"
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <iostream>
-
-// ── helpers ──────────────────────────────────────────────────────────────────
-
-// LCOV_EXCL_START — screenshot requires a live RenderWindow; not testable headless
-static void captureScreenshot(const sf::RenderWindow& w, const std::string& path) {
-    sf::Texture t;
-    t.create(w.getSize().x, w.getSize().y);
-    t.update(w);
-    t.copyToImage().saveToFile(path);
-}
-// LCOV_EXCL_STOP
 
 // ── toggleFullscreen ──────────────────────────────────────────────────────────
 // LCOV_EXCL_START — requires a display; not reachable from harness tests
@@ -41,7 +33,7 @@ void Game::toggleFullscreen() {
     // live on the shared context and should survive, but verify visually.
     if (!m_debug.active())
         m_window.setVerticalSyncEnabled(true);
-    m_window.setView(makeLetterboxView({kLogicalW, kLogicalH}, m_window.getSize()));
+    m_window.setView(makeLetterboxView({kGameW, kGameH}, m_window.getSize()));
 }
 // LCOV_EXCL_STOP
 
@@ -64,7 +56,7 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
 
     loadOrThrow(*m_robot, resource_path + "robot.png");
     m_robot->setScale(-1.0f, 1.0f);
-    m_robot->setPosition(kLogicalW - (m_rocket->getWidth() + 150), 400);
+    m_robot->setPosition(kGameW - (m_rocket->getWidth() + 150), 400);
 
     m_arena.push_back(std::make_unique<RegularGameObject>());
     loadOrThrow(*m_arena[0], resource_path + "brick.png");
@@ -81,14 +73,14 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
         auto fire2 = std::make_unique<AnimatedGameObject>(216, 216, 5, 3, 10, 0);
         loadOrThrow(*fire2, resource_path + "fire.png");
         fire2->setScale(2.0f);
-        fire2->setPosition(kLogicalW / 2 - 5, 400);
+        fire2->setPosition(kGameW / 2 - 5, 400);
         m_arena.push_back(std::move(fire2));
     }
     {
         auto fire3 = std::make_unique<AnimatedGameObject>(216, 216, 5, 3, 10, 0);
         loadOrThrow(*fire3, resource_path + "fire.png");
         fire3->setScale(2.0f);
-        fire3->setPosition(kLogicalW - 100, 400);
+        fire3->setPosition(kGameW - 100, 400);
         m_arena.push_back(std::move(fire3));
     }
 
@@ -97,7 +89,7 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
     loadOrThrow(block, resource_path + "Blockt.ttf");
 
     pause_text = sf::Text("Cooldown", block, 400);
-    pause_text.setPosition(kLogicalW / 2 - 850, 100);
+    pause_text.setPosition(kGameW / 2 - 850, 100);
     pause_text.setFillColor(sf::Color::Black);
 
     info = sf::Text("a short intermission", font, 50);
@@ -107,9 +99,9 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
     m_rocketScoreText = sf::Text("Rocket Score: 0", font, 40);
     m_robotScoreText = sf::Text("Robot Score: 0", font, 40);
     timer = sf::Text("timer", tfont, 60);
-    timer.setPosition(kLogicalW / 2 - 60, 0);
+    timer.setPosition(kGameW / 2 - 60, 0);
     m_rocketScoreText.setPosition(10, 0);
-    m_robotScoreText.setPosition(kLogicalW - m_robotScoreText.getGlobalBounds().width, 0);
+    m_robotScoreText.setPosition(kGameW - m_robotScoreText.getGlobalBounds().width, 0);
     m_robotScoreText.setFillColor(sf::Color::Green);
     timer.setFillColor(sf::Color::Black);
     m_rocketScoreText.setFillColor(sf::Color::Blue);
@@ -192,7 +184,7 @@ std::tuple<int, int, float, int, bool, bool> Game::run() {
     // Apply display settings now that debug config is known.
     if (!m_debug.active())
         m_window.setVerticalSyncEnabled(true);
-    m_window.setView(makeLetterboxView({kLogicalW, kLogicalH}, m_window.getSize()));
+    m_window.setView(makeLetterboxView({kGameW, kGameH}, m_window.getSize()));
 
     sf::Clock clock;
     background.play();
@@ -377,10 +369,24 @@ void Game::processEvents() {
             break;
         case sf::Event::Resized:
             m_window.setView(
-                makeLetterboxView({kLogicalW, kLogicalH}, {event.size.width, event.size.height}));
+                makeLetterboxView({kGameW, kGameH}, {event.size.width, event.size.height}));
             break;
         case sf::Event::Closed:
             m_window.close();
+            break;
+        case sf::Event::MouseButtonReleased:
+            if (m_paused && event.mouseButton.button == sf::Mouse::Left) {
+                sf::Vector2f mp =
+                    m_window.mapPixelToCoords({event.mouseButton.x, event.mouseButton.y});
+                if (pauseButtonRect(0).contains(mp)) {
+                    m_paused = false;
+                    background.play();
+                } else if (pauseButtonRect(1).contains(mp)) {
+                    background.stop();
+                    m_quitToMenu = true;
+                    m_window.close();
+                }
+            }
             break;
         // LCOV_EXCL_STOP
         default:
@@ -473,7 +479,7 @@ void Game::update(sf::Time deltaT, float time) {
 
     if (m_p1Up) {
         if (m_rocket->getPosition().y < -(m_rocket->getHeight())) {
-            m_rocket->setPosition(m_rocket->getPosition().x, kLogicalH - m_rocket->getHeight());
+            m_rocket->setPosition(m_rocket->getPosition().x, kGameH - m_rocket->getHeight());
         }
 
         if (collision(*m_rocket, *m_robot)) {
@@ -484,7 +490,7 @@ void Game::update(sf::Time deltaT, float time) {
     }
 
     if (m_p1Down) {
-        if (m_rocket->getPosition().y > kLogicalH - m_rocket->getHeight()) {
+        if (m_rocket->getPosition().y > kGameH - m_rocket->getHeight()) {
             m_rocket->setPosition(m_rocket->getPosition().x, -(m_rocket->getHeight()));
         }
 
@@ -496,7 +502,7 @@ void Game::update(sf::Time deltaT, float time) {
     }
     if (m_p1Left) {
         if (m_rocket->getPosition().x < -(m_rocket->getWidth())) {
-            m_rocket->setPosition(kLogicalW, m_rocket->getPosition().y);
+            m_rocket->setPosition(kGameW, m_rocket->getPosition().y);
         }
         if (!m_p1FacingLeft) {
             m_rocket->setScale(-2.0f, 2);
@@ -515,7 +521,7 @@ void Game::update(sf::Time deltaT, float time) {
     if (m_p1Right) {
         m_rocket->setScale(2.0f, 2);
 
-        if (m_rocket->getPosition().x > kLogicalW) {
+        if (m_rocket->getPosition().x > kGameW) {
             m_rocket->setPosition(-(m_rocket->getWidth()), m_rocket->getPosition().y);
         }
 
@@ -534,7 +540,7 @@ void Game::update(sf::Time deltaT, float time) {
     }
     if (m_p2Up) {
         if (m_robot->getPosition().y < -(m_robot->getHeight())) {
-            m_robot->setPosition(m_robot->getPosition().x, kLogicalH - m_robot->getHeight());
+            m_robot->setPosition(m_robot->getPosition().x, kGameH - m_robot->getHeight());
         }
 
         if (collision(*m_rocket, *m_robot)) {
@@ -544,7 +550,7 @@ void Game::update(sf::Time deltaT, float time) {
         }
     }
     if (m_p2Down) {
-        if (m_robot->getPosition().y > kLogicalH - m_robot->getHeight()) {
+        if (m_robot->getPosition().y > kGameH - m_robot->getHeight()) {
             m_robot->setPosition(m_robot->getPosition().x, -(m_robot->getHeight()));
         }
 
@@ -556,7 +562,7 @@ void Game::update(sf::Time deltaT, float time) {
     }
     if (m_p2Left) {
         if (m_robot->getPosition().x < -(m_robot->getWidth())) {
-            m_robot->setPosition(kLogicalW, m_robot->getPosition().y);
+            m_robot->setPosition(kGameW, m_robot->getPosition().y);
         }
         m_robot->setScale(-1.0f, 1.0f);
         if (!m_p2FacingLeft) {
@@ -574,7 +580,7 @@ void Game::update(sf::Time deltaT, float time) {
     }
     if (m_p2Right) {
         m_robot->setScale(1.0f, 1.0f);
-        if (m_robot->getPosition().x > kLogicalW) {
+        if (m_robot->getPosition().x > kGameW) {
             m_robot->setPosition(-(m_robot->getWidth()), m_robot->getPosition().y);
         }
         if (m_p2FacingLeft) {
@@ -667,7 +673,7 @@ void Game::update(sf::Time deltaT, float time) {
     if (reset) {
         m_rocket->setScale(2.0f, 2);
         m_robot->setScale(-1.0f, 1.0f);
-        m_robot->setPosition(kLogicalW - (m_rocket->getWidth() + 150), 400);
+        m_robot->setPosition(kGameW - (m_rocket->getWidth() + 150), 400);
         m_rocket->setPosition(m_rocket->getWidth() + 20, 400);
         m_p1FacingLeft = false;
         m_p2FacingLeft = true;
@@ -676,7 +682,7 @@ void Game::update(sf::Time deltaT, float time) {
 
     m_rocketScoreText.setString("Rocket Score: " + std::to_string(m_rocketScore));
     m_robotScoreText.setString("Robot Score: " + std::to_string(m_robotScore));
-    m_robotScoreText.setPosition(kLogicalW - m_robotScoreText.getGlobalBounds().width - 20, 0);
+    m_robotScoreText.setPosition(kGameW - m_robotScoreText.getGlobalBounds().width - 20, 0);
 }
 
 // ── render ────────────────────────────────────────────────────────────────────
@@ -735,16 +741,30 @@ void Game::render() {
         m_window.draw(info);
     }
     if (m_paused) {
-        sf::RectangleShape overlay(sf::Vector2f(kLogicalW, kLogicalH));
+        sf::RectangleShape overlay(sf::Vector2f(kGameW, kGameH));
         overlay.setFillColor(sf::Color(0, 0, 0, 140));
         m_window.draw(overlay);
-        sf::Text txt("PAUSED\nEsc: resume   Q: quit to menu", font, 60);
+
+        auto r0 = pauseButtonRect(0);
+        auto r1 = pauseButtonRect(1);
+        sf::Vector2f mousePos = m_window.mapPixelToCoords(sf::Mouse::getPosition(m_window));
+
+        sf::Text txt("PAUSED", font, 60);
         txt.setFillColor(sf::Color::White);
         txt.setStyle(sf::Text::Bold);
-        auto bounds = txt.getLocalBounds();
-        txt.setOrigin(bounds.width / 2.f, bounds.height / 2.f);
-        txt.setPosition(kLogicalW / 2.f, kLogicalH / 2.f);
+        auto tlb = txt.getLocalBounds();
+        txt.setOrigin(tlb.left + tlb.width / 2.f, tlb.top + tlb.height / 2.f);
+        txt.setPosition(kGameW / 2.f, r0.top - 60.f);
         m_window.draw(txt);
+
+        MenuButton resumeBtn({r0.width, r0.height}, font, "Resume");
+        MenuButton quitBtn({r1.width, r1.height}, font, "Quit to Menu");
+        resumeBtn.setPosition({r0.left + r0.width / 2.f, r0.top + r0.height / 2.f});
+        quitBtn.setPosition({r1.left + r1.width / 2.f, r1.top + r1.height / 2.f});
+        resumeBtn.setHovered(r0.contains(mousePos));
+        quitBtn.setHovered(r1.contains(mousePos));
+        resumeBtn.draw(m_window);
+        quitBtn.draw(m_window);
     }
     // NOTE: m_window.display() is called by run() so screenshots can be
     // captured between draw and swap.

--- a/src/RegularGameObject.cpp
+++ b/src/RegularGameObject.cpp
@@ -65,6 +65,8 @@ void RegularGameObject::changeValid(bool a) { m_valid = a; }
 
 bool RegularGameObject::isValid() { return m_valid; }
 
+sf::FloatRect RegularGameObject::getGlobalBounds() const { return m_sprite.getGlobalBounds(); }
+
 void RegularGameObject::setOrigin() {
     m_sprite.setOrigin((m_sprite.getLocalBounds().width) / 2,
                        (m_sprite.getLocalBounds().height) / 2);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -229,15 +229,8 @@ int main(int argc, char** argv) {
                         throw std::runtime_error("--ai must be easy, medium, or hard");
                 } else if (arg == "--menu-state") {
                     std::string val(needValue(arg, i));
-                    static const char* validStates[] = {"main_menu", "host_waiting", "join_input",
-                                                        "ai_difficulty", "ready_to_start"};
-                    bool found = false;
-                    for (const char* s : validStates)
-                        if (val == s) {
-                            found = true;
-                            break;
-                        }
-                    if (!found) {
+                    MenuState parsed; // validate against the single source of truth (menu.cpp)
+                    if (!parseMenuState(val, parsed)) {
                         std::cerr << "Error: unknown --menu-state '" << val
                                   << "' (valid: main_menu host_waiting join_input ai_difficulty "
                                      "ready_to_start)\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "debug.h"
 #include "key_bindings.h"
 #include "letterbox.h"
+#include "menu.h"
 #include "resource_path.h"
 #include "rng.h"
 #include <SFML/Graphics.hpp>
@@ -17,19 +18,6 @@
 #include <stdexcept>
 #include <string>
 #include <tuple>
-
-// Logical canvas size for the menu / endscreen windows.
-static constexpr float kMenuW = 1024.f;
-static constexpr float kMenuH = 576.f;
-
-enum MenuState { MAIN_MENU, HOST_WAITING, JOIN_INPUT, AI_DIFFICULTY, READY_TO_START };
-
-struct MenuResult {
-    NetworkMode mode = NetworkMode::LOCAL;
-    std::shared_ptr<NetworkManager> netManager;
-    bool quit = false;
-    AiDifficulty ai = AiDifficulty::None;
-};
 
 // ── showEndscreen ─────────────────────────────────────────────────────────────
 // Show the post-game results screen.  Returns true if the player wants to play
@@ -120,14 +108,8 @@ static bool showEndscreen(int highscore, int p1score, int p2score, float minutes
     bool playAgain = false;
 
     while (endscreen.isOpen()) {
-        sf::Rect<float> srect(sf::Vector2f(m_start->getPosition().x - (m_start->getWidth() / 4),
-                                           m_start->getPosition().y - (m_start->getHeight() / 4)),
-                              sf::Vector2f(m_start->getWidth() * m_start->getScale().x,
-                                           m_start->getHeight() * m_start->getScale().y));
-        sf::Rect<float> qrect(sf::Vector2f(m_quit->getPosition().x - (m_quit->getWidth() / 4),
-                                           m_quit->getPosition().y - (m_quit->getHeight() / 4)),
-                              sf::Vector2f(m_quit->getWidth() * m_quit->getScale().x,
-                                           m_quit->getHeight() * m_quit->getScale().y));
+        sf::FloatRect srect = m_start->getGlobalBounds();
+        sf::FloatRect qrect = m_quit->getGlobalBounds();
 
         sf::Vector2f mousePos = endscreen.mapPixelToCoords(sf::Mouse::getPosition(endscreen));
 
@@ -201,559 +183,6 @@ static bool showEndscreen(int highscore, int p1score, int p2score, float minutes
     return playAgain;
 }
 
-// ── showMenu ──────────────────────────────────────────────────────────────────
-// Runs the start screen menu loop.  Returns the selected game mode, network
-// manager, and a quit flag (true if the user closed the window without starting).
-
-static MenuResult showMenu() {
-    MenuState menuState = MAIN_MENU;
-    NetworkMode mode = NetworkMode::LOCAL;
-    std::shared_ptr<NetworkManager> netManager = nullptr;
-    std::string ipInput = "127.0.0.1";
-    std::string statusMessage;
-    std::string hostIpAddress;
-
-    RegularGameObject david = RegularGameObject();
-    loadOrThrow(david, resource_path + "david_background.png");
-
-    sf::Music background;
-    loadOrThrow(background, resource_path + "m_start_background.wav");
-    background.play();
-    background.setVolume(60);
-    background.setLoop(true);
-
-    sf::SoundBuffer down_buffer;
-    sf::SoundBuffer up_buffer;
-    loadOrThrow(down_buffer, resource_path + "ButtonOn.wav");
-    loadOrThrow(up_buffer, resource_path + "ButtonOff.wav");
-
-    sf::Sound press;
-    sf::Sound up;
-    press.setBuffer(down_buffer);
-    up.setBuffer(up_buffer);
-
-    sf::Font font;
-    loadOrThrow(font, resource_path + "oswald.ttf");
-
-    bool start_updated = false;
-    bool quit_updated = false;
-    bool host_updated = false;
-    bool join_updated = false;
-    bool back_updated = false;
-    bool one_player_updated = false;
-    bool easy_updated = false;
-    bool medium_updated = false;
-    bool hard_updated = false;
-
-    sf::RenderWindow startscreen(sf::VideoMode(1024, 576), "Dungeon Game", sf::Style::Default);
-    startscreen.setView(makeLetterboxView({kMenuW, kMenuH}, startscreen.getSize()));
-
-    auto m_start = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
-    loadOrThrow(*m_start, resource_path + "start.png");
-    m_start->setOrigin();
-    m_start->setPosition(kMenuW / 2, 200);
-    m_start->setScale(.4f);
-
-    auto m_host = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
-    loadOrThrow(*m_host, resource_path + "start.png");
-    m_host->setOrigin();
-    m_host->setPosition(kMenuW / 2, 320);
-    m_host->setScale(.4f);
-
-    auto m_join = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
-    loadOrThrow(*m_join, resource_path + "start.png");
-    m_join->setOrigin();
-    m_join->setPosition(kMenuW / 2, 440);
-    m_join->setScale(.4f);
-
-    auto m_quit = std::make_unique<AnimatedGameObject>(1332, 300, 2, 1, 2, 0);
-    loadOrThrow(*m_quit, resource_path + "quit.png");
-    m_quit->setOrigin();
-    m_quit->setPosition(kMenuW / 2, 520);
-    m_quit->setScale(.3f);
-
-    auto m_back = std::make_unique<AnimatedGameObject>(1332, 300, 2, 1, 2, 0);
-    loadOrThrow(*m_back, resource_path + "quit.png");
-    m_back->setOrigin();
-    m_back->setPosition(100, 50);
-    m_back->setScale(.25f);
-
-    // 1-player / AI-difficulty buttons
-    auto m_one_player = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
-    loadOrThrow(*m_one_player, resource_path + "start.png");
-    m_one_player->setOrigin();
-    m_one_player->setPosition(kMenuW / 2, 120);
-    m_one_player->setScale(.4f);
-
-    auto m_easy = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
-    loadOrThrow(*m_easy, resource_path + "start.png");
-    m_easy->setOrigin();
-    m_easy->setPosition(kMenuW / 2, 180);
-    m_easy->setScale(.4f);
-
-    auto m_medium = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
-    loadOrThrow(*m_medium, resource_path + "start.png");
-    m_medium->setOrigin();
-    m_medium->setPosition(kMenuW / 2, 300);
-    m_medium->setScale(.4f);
-
-    auto m_hard = std::make_unique<AnimatedGameObject>(1331, 300, 2, 1, 2, 0);
-    loadOrThrow(*m_hard, resource_path + "start.png");
-    m_hard->setOrigin();
-    m_hard->setPosition(kMenuW / 2, 420);
-    m_hard->setScale(.4f);
-
-    sf::Text localLabel("LOCAL", font, 40);
-    localLabel.setFillColor(sf::Color::White);
-    localLabel.setStyle(sf::Text::Bold);
-
-    sf::Text hostLabel("HOST", font, 40);
-    hostLabel.setFillColor(sf::Color::Green);
-    hostLabel.setStyle(sf::Text::Bold);
-
-    sf::Text joinLabel("JOIN", font, 40);
-    joinLabel.setFillColor(sf::Color::Blue);
-    joinLabel.setStyle(sf::Text::Bold);
-
-    sf::Text backLabel("BACK", font, 20);
-    backLabel.setFillColor(sf::Color::White);
-
-    sf::Text onePlayerLabel("1 PLAYER", font, 36);
-    onePlayerLabel.setFillColor(sf::Color::Yellow);
-    onePlayerLabel.setStyle(sf::Text::Bold);
-
-    sf::Text easyLabel("EASY", font, 38);
-    easyLabel.setFillColor(sf::Color::Green);
-    easyLabel.setStyle(sf::Text::Bold);
-
-    sf::Text mediumLabel("MEDIUM", font, 38);
-    mediumLabel.setFillColor(sf::Color::Yellow);
-    mediumLabel.setStyle(sf::Text::Bold);
-
-    sf::Text hardLabel("HARD", font, 38);
-    hardLabel.setFillColor(sf::Color::Red);
-    hardLabel.setStyle(sf::Text::Bold);
-
-    MenuResult result;
-
-    while (startscreen.isOpen()) {
-        sf::Event event;
-        while (startscreen.pollEvent(event)) {
-            if (event.type == sf::Event::Closed) {
-                background.stop();
-                startscreen.close();
-                result.quit = true;
-                return result;
-            }
-            if (event.type == sf::Event::Resized) {
-                startscreen.setView(
-                    makeLetterboxView({kMenuW, kMenuH}, {event.size.width, event.size.height}));
-            }
-            if (menuState == JOIN_INPUT && event.type == sf::Event::TextEntered) {
-                if (event.text.unicode == '\b' && !ipInput.empty()) {
-                    ipInput.pop_back();
-                } else if (event.text.unicode == '\r' || event.text.unicode == '\n') {
-                    netManager = std::make_shared<NetworkManager>();
-                    statusMessage = "Connecting...";
-                    if (netManager->connectToHost(ipInput)) {
-                        mode = NetworkMode::CLIENT;
-                        menuState = READY_TO_START;
-                        statusMessage = "Connected! Click START to begin";
-                    } else {
-                        statusMessage = "Failed to connect (invalid IP or host unreachable)";
-                        netManager = nullptr;
-                    }
-                } else if (event.text.unicode < 128 && event.text.unicode != '\b' &&
-                           ipInput.length() < 30) {
-                    char c = static_cast<char>(event.text.unicode);
-                    if ((c >= '0' && c <= '9') || c == '.' || c == ':')
-                        ipInput += c;
-                }
-            }
-        }
-
-        sf::Vector2f mousePos = startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen));
-
-        sf::Rect<float> startRect(m_start->getPosition().x - (m_start->getWidth() / 4),
-                                  m_start->getPosition().y - (m_start->getHeight() / 4),
-                                  m_start->getWidth() * m_start->getScale().x,
-                                  m_start->getHeight() * m_start->getScale().y);
-        sf::Rect<float> hostRect(m_host->getPosition().x - (m_host->getWidth() / 4),
-                                 m_host->getPosition().y - (m_host->getHeight() / 4),
-                                 m_host->getWidth() * m_host->getScale().x,
-                                 m_host->getHeight() * m_host->getScale().y);
-        sf::Rect<float> joinRect(m_join->getPosition().x - (m_join->getWidth() / 4),
-                                 m_join->getPosition().y - (m_join->getHeight() / 4),
-                                 m_join->getWidth() * m_join->getScale().x,
-                                 m_join->getHeight() * m_join->getScale().y);
-        sf::Rect<float> quitRect(m_quit->getPosition().x - (m_quit->getWidth() / 4),
-                                 m_quit->getPosition().y - (m_quit->getHeight() / 4),
-                                 m_quit->getWidth() * m_quit->getScale().x,
-                                 m_quit->getHeight() * m_quit->getScale().y);
-        sf::Rect<float> backRect(m_back->getPosition().x - (m_back->getWidth() / 4),
-                                 m_back->getPosition().y - (m_back->getHeight() / 4),
-                                 m_back->getWidth() * m_back->getScale().x,
-                                 m_back->getHeight() * m_back->getScale().y);
-        sf::Rect<float> onePlayerRect(
-            m_one_player->getPosition().x - (m_one_player->getWidth() / 4),
-            m_one_player->getPosition().y - (m_one_player->getHeight() / 4),
-            m_one_player->getWidth() * m_one_player->getScale().x,
-            m_one_player->getHeight() * m_one_player->getScale().y);
-        sf::Rect<float> easyRect(m_easy->getPosition().x - (m_easy->getWidth() / 4),
-                                 m_easy->getPosition().y - (m_easy->getHeight() / 4),
-                                 m_easy->getWidth() * m_easy->getScale().x,
-                                 m_easy->getHeight() * m_easy->getScale().y);
-        sf::Rect<float> mediumRect(m_medium->getPosition().x - (m_medium->getWidth() / 4),
-                                   m_medium->getPosition().y - (m_medium->getHeight() / 4),
-                                   m_medium->getWidth() * m_medium->getScale().x,
-                                   m_medium->getHeight() * m_medium->getScale().y);
-        sf::Rect<float> hardRect(m_hard->getPosition().x - (m_hard->getWidth() / 4),
-                                 m_hard->getPosition().y - (m_hard->getHeight() / 4),
-                                 m_hard->getWidth() * m_hard->getScale().x,
-                                 m_hard->getHeight() * m_hard->getScale().y);
-
-        if (menuState == MAIN_MENU) {
-            if (onePlayerRect.contains(mousePos) && !one_player_updated) {
-                m_one_player->update(0.0f);
-                one_player_updated = true;
-                press.play();
-            } else if (!onePlayerRect.contains(mousePos) && one_player_updated) {
-                one_player_updated = false;
-                m_one_player->update(0.0f);
-                up.play();
-            }
-            if (startRect.contains(mousePos) && !start_updated) {
-                m_start->update(0.0f);
-                start_updated = true;
-                press.play();
-            } else if (!startRect.contains(mousePos) && start_updated) {
-                start_updated = false;
-                m_start->update(0.0f);
-                up.play();
-            }
-            if (hostRect.contains(mousePos) && !host_updated) {
-                m_host->update(0.0f);
-                host_updated = true;
-                press.play();
-            } else if (!hostRect.contains(mousePos) && host_updated) {
-                host_updated = false;
-                m_host->update(0.0f);
-                up.play();
-            }
-            if (joinRect.contains(mousePos) && !join_updated) {
-                m_join->update(0.0f);
-                join_updated = true;
-                press.play();
-            } else if (!joinRect.contains(mousePos) && join_updated) {
-                join_updated = false;
-                m_join->update(0.0f);
-                up.play();
-            }
-            if (quitRect.contains(mousePos) && !quit_updated) {
-                m_quit->update(0.0f);
-                quit_updated = true;
-                press.play();
-            } else if (!quitRect.contains(mousePos) && quit_updated) {
-                quit_updated = false;
-                m_quit->update(0.0f);
-                up.play();
-            }
-            if (sf::Mouse::isButtonPressed(sf::Mouse::Left)) {
-                if (onePlayerRect.contains(mousePos)) {
-                    menuState = AI_DIFFICULTY;
-                    sf::sleep(sf::milliseconds(200));
-                } else if (startRect.contains(mousePos)) {
-                    mode = NetworkMode::LOCAL;
-                    menuState = READY_TO_START;
-                    sf::sleep(sf::milliseconds(200));
-                } else if (hostRect.contains(mousePos)) {
-                    netManager = std::make_shared<NetworkManager>();
-                    if (netManager->startHost()) {
-                        mode = NetworkMode::HOST;
-                        menuState = HOST_WAITING;
-                        hostIpAddress = sf::IpAddress::getLocalAddress().toString();
-                        statusMessage = "Waiting for player 2...";
-                    } else {
-                        statusMessage = "Failed to start host!";
-                        netManager = nullptr;
-                    }
-                    sf::sleep(sf::milliseconds(200));
-                } else if (joinRect.contains(mousePos)) {
-                    menuState = JOIN_INPUT;
-                    statusMessage = "Enter host IP address";
-                    sf::sleep(sf::milliseconds(200));
-                } else if (quitRect.contains(mousePos)) {
-                    background.stop();
-                    startscreen.close();
-                    result.quit = true;
-                    return result;
-                }
-            }
-        } else if (menuState == HOST_WAITING) {
-            if (netManager && netManager->waitForClient(sf::milliseconds(100))) {
-                menuState = READY_TO_START;
-                statusMessage = "Player 2 connected! Click START to begin";
-            }
-            if (backRect.contains(mousePos) && !back_updated) {
-                m_back->update(0.0f);
-                back_updated = true;
-                press.play();
-            } else if (!backRect.contains(mousePos) && back_updated) {
-                back_updated = false;
-                m_back->update(0.0f);
-                up.play();
-            }
-            if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && backRect.contains(mousePos)) {
-                menuState = MAIN_MENU;
-                netManager = nullptr;
-                statusMessage = "";
-                sf::sleep(sf::milliseconds(200));
-            }
-        } else if (menuState == JOIN_INPUT) {
-            if (backRect.contains(mousePos) && !back_updated) {
-                m_back->update(0.0f);
-                back_updated = true;
-                press.play();
-            } else if (!backRect.contains(mousePos) && back_updated) {
-                back_updated = false;
-                m_back->update(0.0f);
-                up.play();
-            }
-            if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && backRect.contains(mousePos)) {
-                menuState = MAIN_MENU;
-                ipInput = "127.0.0.1";
-                statusMessage = "";
-                sf::sleep(sf::milliseconds(200));
-            }
-        } else if (menuState == AI_DIFFICULTY) {
-            if (easyRect.contains(mousePos) && !easy_updated) {
-                m_easy->update(0.0f);
-                easy_updated = true;
-                press.play();
-            } else if (!easyRect.contains(mousePos) && easy_updated) {
-                easy_updated = false;
-                m_easy->update(0.0f);
-                up.play();
-            }
-            if (mediumRect.contains(mousePos) && !medium_updated) {
-                m_medium->update(0.0f);
-                medium_updated = true;
-                press.play();
-            } else if (!mediumRect.contains(mousePos) && medium_updated) {
-                medium_updated = false;
-                m_medium->update(0.0f);
-                up.play();
-            }
-            if (hardRect.contains(mousePos) && !hard_updated) {
-                m_hard->update(0.0f);
-                hard_updated = true;
-                press.play();
-            } else if (!hardRect.contains(mousePos) && hard_updated) {
-                hard_updated = false;
-                m_hard->update(0.0f);
-                up.play();
-            }
-            if (backRect.contains(mousePos) && !back_updated) {
-                m_back->update(0.0f);
-                back_updated = true;
-                press.play();
-            } else if (!backRect.contains(mousePos) && back_updated) {
-                back_updated = false;
-                m_back->update(0.0f);
-                up.play();
-            }
-            if (sf::Mouse::isButtonPressed(sf::Mouse::Left)) {
-                if (easyRect.contains(mousePos)) {
-                    result.ai = AiDifficulty::Easy;
-                    mode = NetworkMode::LOCAL;
-                    menuState = READY_TO_START;
-                    sf::sleep(sf::milliseconds(200));
-                } else if (mediumRect.contains(mousePos)) {
-                    result.ai = AiDifficulty::Medium;
-                    mode = NetworkMode::LOCAL;
-                    menuState = READY_TO_START;
-                    sf::sleep(sf::milliseconds(200));
-                } else if (hardRect.contains(mousePos)) {
-                    result.ai = AiDifficulty::Hard;
-                    mode = NetworkMode::LOCAL;
-                    menuState = READY_TO_START;
-                    sf::sleep(sf::milliseconds(200));
-                } else if (backRect.contains(mousePos)) {
-                    menuState = MAIN_MENU;
-                    sf::sleep(sf::milliseconds(200));
-                }
-            }
-        } else if (menuState == READY_TO_START) {
-            if (startRect.contains(mousePos) && !start_updated) {
-                m_start->update(0.0f);
-                start_updated = true;
-                press.play();
-            } else if (!startRect.contains(mousePos) && start_updated) {
-                start_updated = false;
-                m_start->update(0.0f);
-                up.play();
-            }
-            if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && startRect.contains(mousePos)) {
-                background.stop();
-                startscreen.close();
-                result.mode = mode;
-                result.netManager = netManager;
-                return result;
-            }
-        }
-
-        startscreen.clear();
-        david.draw(startscreen);
-
-        if (menuState == MAIN_MENU) {
-            m_one_player->draw(startscreen);
-            onePlayerLabel.setOrigin(onePlayerLabel.getGlobalBounds().width / 2,
-                                     onePlayerLabel.getGlobalBounds().height / 2);
-            onePlayerLabel.setPosition(m_one_player->getPosition().x,
-                                       m_one_player->getPosition().y);
-            startscreen.draw(onePlayerLabel);
-
-            m_start->draw(startscreen);
-            m_host->draw(startscreen);
-            m_join->draw(startscreen);
-            m_quit->draw(startscreen);
-
-            localLabel.setString("2 PLAYER");
-            localLabel.setOrigin(localLabel.getGlobalBounds().width / 2,
-                                 localLabel.getGlobalBounds().height / 2);
-            localLabel.setPosition(m_start->getPosition().x, m_start->getPosition().y);
-            startscreen.draw(localLabel);
-
-            hostLabel.setOrigin(hostLabel.getGlobalBounds().width / 2,
-                                hostLabel.getGlobalBounds().height / 2);
-            hostLabel.setPosition(m_host->getPosition().x, m_host->getPosition().y);
-            startscreen.draw(hostLabel);
-
-            joinLabel.setOrigin(joinLabel.getGlobalBounds().width / 2,
-                                joinLabel.getGlobalBounds().height / 2);
-            joinLabel.setPosition(m_join->getPosition().x, m_join->getPosition().y);
-            startscreen.draw(joinLabel);
-        } else if (menuState == HOST_WAITING) {
-            m_back->draw(startscreen);
-            backLabel.setOrigin(backLabel.getGlobalBounds().width / 2,
-                                backLabel.getGlobalBounds().height / 2);
-            backLabel.setPosition(m_back->getPosition().x, m_back->getPosition().y);
-            startscreen.draw(backLabel);
-
-            sf::Text title("HOSTING GAME", font, 50);
-            title.setFillColor(sf::Color::Green);
-            title.setStyle(sf::Text::Bold);
-            title.setOrigin(title.getGlobalBounds().width / 2, 0);
-            title.setPosition(kMenuW / 2, 150);
-            startscreen.draw(title);
-
-            sf::Text ipText("Your IP: " + hostIpAddress, font, 35);
-            ipText.setFillColor(sf::Color::White);
-            ipText.setOrigin(ipText.getGlobalBounds().width / 2, 0);
-            ipText.setPosition(kMenuW / 2, 250);
-            startscreen.draw(ipText);
-
-            sf::Text statusText(statusMessage, font, 30);
-            statusText.setFillColor(sf::Color(200, 200, 200));
-            statusText.setOrigin(statusText.getGlobalBounds().width / 2, 0);
-            statusText.setPosition(kMenuW / 2, 350);
-            startscreen.draw(statusText);
-        } else if (menuState == JOIN_INPUT) {
-            m_back->draw(startscreen);
-            backLabel.setOrigin(backLabel.getGlobalBounds().width / 2,
-                                backLabel.getGlobalBounds().height / 2);
-            backLabel.setPosition(m_back->getPosition().x, m_back->getPosition().y);
-            startscreen.draw(backLabel);
-
-            sf::Text title("JOIN GAME", font, 50);
-            title.setFillColor(sf::Color::Blue);
-            title.setStyle(sf::Text::Bold);
-            title.setOrigin(title.getGlobalBounds().width / 2, 0);
-            title.setPosition(kMenuW / 2, 150);
-            startscreen.draw(title);
-
-            sf::Text prompt("Enter Host IP Address:", font, 30);
-            prompt.setFillColor(sf::Color::White);
-            prompt.setOrigin(prompt.getGlobalBounds().width / 2, 0);
-            prompt.setPosition(kMenuW / 2, 250);
-            startscreen.draw(prompt);
-
-            sf::Text ipText(ipInput, font, 40);
-            ipText.setFillColor(sf::Color::Green);
-            ipText.setOrigin(ipText.getGlobalBounds().width / 2, 0);
-            ipText.setPosition(kMenuW / 2, 320);
-            startscreen.draw(ipText);
-
-            sf::Text instruct("Press ENTER to connect", font, 25);
-            instruct.setFillColor(sf::Color(200, 200, 200));
-            instruct.setOrigin(instruct.getGlobalBounds().width / 2, 0);
-            instruct.setPosition(kMenuW / 2, 400);
-            startscreen.draw(instruct);
-
-            if (!statusMessage.empty()) {
-                sf::Text statusText(statusMessage, font, 22);
-                if (statusMessage.find("Failed") != std::string::npos)
-                    statusText.setFillColor(sf::Color::Red);
-                else
-                    statusText.setFillColor(sf::Color::Yellow);
-                statusText.setOrigin(statusText.getGlobalBounds().width / 2, 0);
-                statusText.setPosition(kMenuW / 2, 460);
-                startscreen.draw(statusText);
-            }
-        } else if (menuState == AI_DIFFICULTY) {
-            m_back->draw(startscreen);
-            backLabel.setOrigin(backLabel.getGlobalBounds().width / 2,
-                                backLabel.getGlobalBounds().height / 2);
-            backLabel.setPosition(m_back->getPosition().x, m_back->getPosition().y);
-            startscreen.draw(backLabel);
-
-            sf::Text diffTitle("SELECT DIFFICULTY", font, 40);
-            diffTitle.setFillColor(sf::Color::White);
-            diffTitle.setStyle(sf::Text::Bold);
-            diffTitle.setOrigin(diffTitle.getGlobalBounds().width / 2, 0);
-            diffTitle.setPosition(kMenuW / 2, 80);
-            startscreen.draw(diffTitle);
-
-            m_easy->draw(startscreen);
-            easyLabel.setOrigin(easyLabel.getGlobalBounds().width / 2,
-                                easyLabel.getGlobalBounds().height / 2);
-            easyLabel.setPosition(m_easy->getPosition().x, m_easy->getPosition().y);
-            startscreen.draw(easyLabel);
-
-            m_medium->draw(startscreen);
-            mediumLabel.setOrigin(mediumLabel.getGlobalBounds().width / 2,
-                                  mediumLabel.getGlobalBounds().height / 2);
-            mediumLabel.setPosition(m_medium->getPosition().x, m_medium->getPosition().y);
-            startscreen.draw(mediumLabel);
-
-            m_hard->draw(startscreen);
-            hardLabel.setOrigin(hardLabel.getGlobalBounds().width / 2,
-                                hardLabel.getGlobalBounds().height / 2);
-            hardLabel.setPosition(m_hard->getPosition().x, m_hard->getPosition().y);
-            startscreen.draw(hardLabel);
-        } else if (menuState == READY_TO_START) {
-            m_start->draw(startscreen);
-            localLabel.setString("START");
-            localLabel.setOrigin(localLabel.getGlobalBounds().width / 2,
-                                 localLabel.getGlobalBounds().height / 2);
-            localLabel.setPosition(m_start->getPosition().x, m_start->getPosition().y);
-            startscreen.draw(localLabel);
-
-            sf::Text statusText(statusMessage, font, 30);
-            statusText.setFillColor(sf::Color::Green);
-            statusText.setStyle(sf::Text::Bold);
-            statusText.setOrigin(statusText.getGlobalBounds().width / 2, 0);
-            statusText.setPosition(kMenuW / 2, 350);
-            startscreen.draw(statusText);
-        }
-
-        startscreen.display();
-    }
-
-    result.quit = true;
-    return result;
-}
-
 // ── main ──────────────────────────────────────────────────────────────────────
 
 int main(int argc, char** argv) {
@@ -798,6 +227,23 @@ int main(int argc, char** argv) {
                         config.ai = AiDifficulty::Hard;
                     else
                         throw std::runtime_error("--ai must be easy, medium, or hard");
+                } else if (arg == "--menu-state") {
+                    std::string val(needValue(arg, i));
+                    static const char* validStates[] = {"main_menu", "host_waiting", "join_input",
+                                                        "ai_difficulty", "ready_to_start"};
+                    bool found = false;
+                    for (const char* s : validStates)
+                        if (val == s) {
+                            found = true;
+                            break;
+                        }
+                    if (!found) {
+                        std::cerr << "Error: unknown --menu-state '" << val
+                                  << "' (valid: main_menu host_waiting join_input ai_difficulty "
+                                     "ready_to_start)\n";
+                        return 1;
+                    }
+                    config.menuState = val;
                 } else if (arg == "--help") {
                     std::cout
                         << "Usage: dungeon_game [options]\n"
@@ -808,6 +254,9 @@ int main(int argc, char** argv) {
                         << "  --screenshot-dir <d>   Directory for screenshots (default: .)\n"
                         << "  --seed <n>             Seed the RNG\n"
                         << "  --ai <easy|medium|hard>   AI opponent for P2 (requires --frames)\n"
+                        << "  --menu-state <name>    Screenshot the given menu state and exit\n"
+                        << "                         (main_menu|host_waiting|join_input|"
+                           "ai_difficulty|ready_to_start)\n"
                         << "\n"
                         << "Key bindings can be customised by placing a controls.cfg file\n"
                         << "next to the dungeon_game binary.  Example:\n"
@@ -838,6 +287,12 @@ int main(int argc, char** argv) {
                 std::cerr << "Error: " << e.what() << " (option '" << arg << "')\n";
                 return 1;
             }
+        }
+
+        // ── Menu harness bypass ───────────────────────────────────────────────────
+        if (config.menuMode()) {
+            showMenu(config);
+            return 0;
         }
 
         // ── Debug / harness bypass ────────────────────────────────────────────────
@@ -879,9 +334,14 @@ int main(int argc, char** argv) {
                 playAgain = false;
 
                 Game game(menu.mode, menu.netManager);
-                game.setBindings(bindings);
-                if (menu.ai != AiDifficulty::None)
+                if (menu.ai != AiDifficulty::None) {
+                    KeyBindings solo = bindings;
+                    solo.p1 = bindings.p2; // human P1 uses WASD in single-player
+                    game.setBindings(solo);
                     game.setAiOpponent(menu.ai);
+                } else {
+                    game.setBindings(bindings);
+                }
                 auto [p1score, p2score, minutes, seconds, p1win, peerLeft] = game.run();
 
                 if (p1score > highscore)

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -40,7 +40,7 @@ static MenuButton makeButton(const ButtonSpec& spec, const sf::Font& font) {
 }
 
 // Map a state-name string to MenuState enum.
-static bool parseMenuState(const std::string& name, MenuState& out) {
+bool parseMenuState(const std::string& name, MenuState& out) {
     if (name == "main_menu") {
         out = MenuState::MAIN_MENU;
         return true;
@@ -155,7 +155,9 @@ static void renderMenu(sf::RenderWindow& win, RegularGameObject& bg, const sf::F
     // Draw buttons on top of everything.
     for (const auto& spec : specs) {
         auto btn = makeButton(spec, font);
-        btn.setHovered(btn.bounds().contains(mousePos));
+        // Hover-test the raw layout rect (== click rect), not bounds(), which the
+        // outline inflates by 1.5px — otherwise a thin fringe highlights but doesn't click.
+        btn.setHovered(spec.rect.contains(mousePos));
         btn.draw(win);
     }
     // Note: caller is responsible for calling win.display().
@@ -195,14 +197,10 @@ MenuResult showMenu(const DebugConfig& cfg) {
     background.setLoop(true);
 
     sf::SoundBuffer down_buffer;
-    sf::SoundBuffer up_buffer;
     loadOrThrow(down_buffer, resource_path + "ButtonOn.wav");
-    loadOrThrow(up_buffer, resource_path + "ButtonOff.wav");
 
     sf::Sound press;
-    sf::Sound up;
     press.setBuffer(down_buffer);
-    up.setBuffer(up_buffer);
 
     sf::Font font;
     loadOrThrow(font, resource_path + "oswald.ttf");
@@ -216,11 +214,11 @@ MenuResult showMenu(const DebugConfig& cfg) {
         for (int frame = 0; frame < effectiveFrames; ++frame) {
             sf::Event event;
             while (startscreen.pollEvent(event)) {
-                if (event.type == sf::Event::Closed) {
+                if (event.type == sf::Event::Closed)
                     startscreen.close();
-                    goto harness_done;
-                }
             }
+            if (!startscreen.isOpen())
+                break;
             sf::Vector2f mousePos =
                 startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen));
             renderMenu(startscreen, david, font, menuState, ipInput, statusMessage, hostIpAddress,
@@ -231,7 +229,6 @@ MenuResult showMenu(const DebugConfig& cfg) {
             }
             startscreen.display();
         }
-    harness_done:
         startscreen.close();
         result.quit = true;
         return result;

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -1,0 +1,378 @@
+#include "menu.h"
+#include "RegularGameObject.h"
+#include "asset_load.h"
+#include "letterbox.h"
+#include "menu_button.h"
+#include "resource_path.h"
+#include "screenshot.h"
+#include <SFML/Audio.hpp>
+#include <SFML/Graphics.hpp>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// Build a MenuButton from a ButtonSpec, coloring label by button label text.
+static MenuButton makeButton(const ButtonSpec& spec, const sf::Font& font) {
+    MenuButton btn({spec.rect.width, spec.rect.height}, font, spec.label);
+    btn.setPosition(
+        {spec.rect.left + spec.rect.width / 2.f, spec.rect.top + spec.rect.height / 2.f});
+    if (spec.label == "1 PLAYER")
+        btn.label.setFillColor(sf::Color::Yellow);
+    else if (spec.label == "HOST")
+        btn.label.setFillColor(sf::Color::Green);
+    else if (spec.label == "JOIN")
+        btn.label.setFillColor(sf::Color::Blue);
+    else if (spec.label == "QUIT")
+        btn.label.setFillColor(sf::Color::Red);
+    else if (spec.label == "EASY")
+        btn.label.setFillColor(sf::Color::Green);
+    else if (spec.label == "MEDIUM")
+        btn.label.setFillColor(sf::Color::Yellow);
+    else if (spec.label == "HARD")
+        btn.label.setFillColor(sf::Color::Red);
+    else
+        btn.label.setFillColor(sf::Color::White);
+    return btn;
+}
+
+// Map a state-name string to MenuState enum.
+static bool parseMenuState(const std::string& name, MenuState& out) {
+    if (name == "main_menu") {
+        out = MenuState::MAIN_MENU;
+        return true;
+    }
+    if (name == "host_waiting") {
+        out = MenuState::HOST_WAITING;
+        return true;
+    }
+    if (name == "join_input") {
+        out = MenuState::JOIN_INPUT;
+        return true;
+    }
+    if (name == "ai_difficulty") {
+        out = MenuState::AI_DIFFICULTY;
+        return true;
+    }
+    if (name == "ready_to_start") {
+        out = MenuState::READY_TO_START;
+        return true;
+    }
+    return false;
+}
+
+// Center a text object horizontally on a given position.
+static void centerText(sf::Text& t, float x, float y) {
+    auto lb = t.getLocalBounds();
+    t.setOrigin(lb.left + lb.width / 2.f, lb.top);
+    t.setPosition(x, y);
+}
+
+// Render the current menu state into the window (shared between normal + harness loops).
+static void renderMenu(sf::RenderWindow& win, RegularGameObject& bg, const sf::Font& font,
+                       MenuState menuState, const std::string& ipInput,
+                       const std::string& statusMessage, const std::string& hostIpAddress,
+                       const sf::Vector2f& mousePos) {
+    win.clear();
+    bg.draw(win);
+
+    auto specs = menuButtonRects(menuState);
+
+    if (menuState == MenuState::HOST_WAITING || menuState == MenuState::JOIN_INPUT) {
+        // Semi-transparent panel first, then text, then button on top.
+        auto pr = menuInfoPanelRect();
+        sf::RectangleShape panel({pr.width, pr.height});
+        panel.setPosition(pr.left, pr.top);
+        panel.setFillColor(sf::Color(0, 0, 0, 180));
+        win.draw(panel);
+
+        if (menuState == MenuState::HOST_WAITING) {
+            sf::Text title("HOSTING GAME", font, 50);
+            title.setFillColor(sf::Color::Green);
+            title.setStyle(sf::Text::Bold);
+            centerText(title, kMenuW / 2.f, 150.f);
+            win.draw(title);
+
+            sf::Text ipText("Your IP: " + hostIpAddress, font, 35);
+            ipText.setFillColor(sf::Color::White);
+            centerText(ipText, kMenuW / 2.f, 250.f);
+            win.draw(ipText);
+
+            if (!statusMessage.empty()) {
+                sf::Text statusText(statusMessage, font, 30);
+                statusText.setFillColor(sf::Color(200, 200, 200));
+                centerText(statusText, kMenuW / 2.f, 350.f);
+                win.draw(statusText);
+            }
+        } else {
+            sf::Text title("JOIN GAME", font, 50);
+            title.setFillColor(sf::Color::Blue);
+            title.setStyle(sf::Text::Bold);
+            centerText(title, kMenuW / 2.f, 150.f);
+            win.draw(title);
+
+            sf::Text prompt("Enter Host IP Address:", font, 30);
+            prompt.setFillColor(sf::Color::White);
+            centerText(prompt, kMenuW / 2.f, 250.f);
+            win.draw(prompt);
+
+            sf::Text ipText(ipInput, font, 40);
+            ipText.setFillColor(sf::Color::Green);
+            centerText(ipText, kMenuW / 2.f, 320.f);
+            win.draw(ipText);
+
+            sf::Text instruct("Press ENTER to connect", font, 25);
+            instruct.setFillColor(sf::Color(200, 200, 200));
+            centerText(instruct, kMenuW / 2.f, 400.f);
+            win.draw(instruct);
+
+            if (!statusMessage.empty()) {
+                sf::Text statusText(statusMessage, font, 22);
+                statusText.setFillColor(statusMessage.find("Failed") != std::string::npos
+                                            ? sf::Color::Red
+                                            : sf::Color::Yellow);
+                centerText(statusText, kMenuW / 2.f, 460.f);
+                win.draw(statusText);
+            }
+        }
+    } else if (menuState == MenuState::AI_DIFFICULTY) {
+        sf::Text diffTitle("SELECT DIFFICULTY", font, 40);
+        diffTitle.setFillColor(sf::Color::White);
+        diffTitle.setStyle(sf::Text::Bold);
+        centerText(diffTitle, kMenuW / 2.f, 80.f);
+        win.draw(diffTitle);
+    } else if (menuState == MenuState::READY_TO_START && !statusMessage.empty()) {
+        sf::Text statusText(statusMessage, font, 30);
+        statusText.setFillColor(sf::Color::Green);
+        statusText.setStyle(sf::Text::Bold);
+        centerText(statusText, kMenuW / 2.f, 350.f);
+        win.draw(statusText);
+    }
+
+    // Draw buttons on top of everything.
+    for (const auto& spec : specs) {
+        auto btn = makeButton(spec, font);
+        btn.setHovered(btn.bounds().contains(mousePos));
+        btn.draw(win);
+    }
+    // Note: caller is responsible for calling win.display().
+}
+
+// ── showMenu ──────────────────────────────────────────────────────────────────
+
+MenuResult showMenu(const DebugConfig& cfg) {
+    MenuState menuState = MenuState::MAIN_MENU;
+    NetworkMode mode = NetworkMode::LOCAL;
+    std::shared_ptr<NetworkManager> netManager = nullptr;
+    std::string ipInput = "127.0.0.1";
+    std::string statusMessage;
+    std::string hostIpAddress;
+    MenuResult result;
+
+    // Harness: parse the requested state.
+    if (cfg.menuMode()) {
+        MenuState requested;
+        if (!parseMenuState(cfg.menuState, requested)) {
+            std::cerr << "showMenu: unknown menuState '" << cfg.menuState
+                      << "', defaulting to main_menu\n";
+        } else {
+            menuState = requested;
+        }
+        if (!cfg.screenshotDir.empty())
+            std::filesystem::create_directories(cfg.screenshotDir);
+    }
+
+    RegularGameObject david;
+    loadOrThrow(david, resource_path + "david_background.png");
+
+    sf::Music background;
+    loadOrThrow(background, resource_path + "m_start_background.wav");
+    background.play();
+    background.setVolume(60);
+    background.setLoop(true);
+
+    sf::SoundBuffer down_buffer;
+    sf::SoundBuffer up_buffer;
+    loadOrThrow(down_buffer, resource_path + "ButtonOn.wav");
+    loadOrThrow(up_buffer, resource_path + "ButtonOff.wav");
+
+    sf::Sound press;
+    sf::Sound up;
+    press.setBuffer(down_buffer);
+    up.setBuffer(up_buffer);
+
+    sf::Font font;
+    loadOrThrow(font, resource_path + "oswald.ttf");
+
+    sf::RenderWindow startscreen(sf::VideoMode(1024, 576), "Dungeon Game", sf::Style::Default);
+    startscreen.setView(makeLetterboxView({kMenuW, kMenuH}, startscreen.getSize()));
+
+    // ── Harness loop (bounded; exits after cfg.frames or window close) ─────────
+    if (cfg.menuMode()) {
+        const int effectiveFrames = (cfg.frames > 0 ? cfg.frames : 5);
+        for (int frame = 0; frame < effectiveFrames; ++frame) {
+            sf::Event event;
+            while (startscreen.pollEvent(event)) {
+                if (event.type == sf::Event::Closed) {
+                    startscreen.close();
+                    goto harness_done;
+                }
+            }
+            sf::Vector2f mousePos =
+                startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen));
+            renderMenu(startscreen, david, font, menuState, ipInput, statusMessage, hostIpAddress,
+                       mousePos);
+            if (cfg.screenshotEvery > 0 && frame % cfg.screenshotEvery == 0) {
+                captureScreenshot(startscreen,
+                                  cfg.screenshotDir + "/menu_" + std::to_string(frame) + ".png");
+            }
+            startscreen.display();
+        }
+    harness_done:
+        startscreen.close();
+        result.quit = true;
+        return result;
+    }
+
+    // ── Normal interactive loop ────────────────────────────────────────────────
+    while (startscreen.isOpen()) {
+        sf::Event event;
+        while (startscreen.pollEvent(event)) {
+            if (event.type == sf::Event::Closed) {
+                background.stop();
+                startscreen.close();
+                result.quit = true;
+                return result;
+            }
+            if (event.type == sf::Event::Resized) {
+                startscreen.setView(
+                    makeLetterboxView({kMenuW, kMenuH}, {event.size.width, event.size.height}));
+            }
+            if (menuState == MenuState::JOIN_INPUT && event.type == sf::Event::TextEntered) {
+                if (event.text.unicode == '\b' && !ipInput.empty()) {
+                    ipInput.pop_back();
+                } else if (event.text.unicode == '\r' || event.text.unicode == '\n') {
+                    netManager = std::make_shared<NetworkManager>();
+                    statusMessage = "Connecting...";
+                    if (netManager->connectToHost(ipInput)) {
+                        mode = NetworkMode::CLIENT;
+                        menuState = MenuState::READY_TO_START;
+                        statusMessage = "Connected! Click START to begin";
+                    } else {
+                        statusMessage = "Failed to connect (invalid IP or host unreachable)";
+                        netManager = nullptr;
+                    }
+                } else if (event.text.unicode < 128 && event.text.unicode != '\b' &&
+                           ipInput.length() < 30) {
+                    char c = static_cast<char>(event.text.unicode);
+                    if ((c >= '0' && c <= '9') || c == '.' || c == ':')
+                        ipInput += c;
+                }
+            }
+            if (event.type == sf::Event::MouseButtonReleased &&
+                event.mouseButton.button == sf::Mouse::Left) {
+                sf::Vector2f mp =
+                    startscreen.mapPixelToCoords({event.mouseButton.x, event.mouseButton.y});
+                auto specs = menuButtonRects(menuState);
+
+                if (menuState == MenuState::MAIN_MENU) {
+                    // specs: [0]=1PLAYER [1]=2PLAYER [2]=HOST [3]=JOIN [4]=QUIT
+                    if (specs[0].rect.contains(mp)) {
+                        menuState = MenuState::AI_DIFFICULTY;
+                        press.play();
+                    } else if (specs[1].rect.contains(mp)) {
+                        mode = NetworkMode::LOCAL;
+                        menuState = MenuState::READY_TO_START;
+                        press.play();
+                    } else if (specs[2].rect.contains(mp)) {
+                        netManager = std::make_shared<NetworkManager>();
+                        if (netManager->startHost()) {
+                            mode = NetworkMode::HOST;
+                            menuState = MenuState::HOST_WAITING;
+                            hostIpAddress = sf::IpAddress::getLocalAddress().toString();
+                            statusMessage = "Waiting for player 2...";
+                        } else {
+                            statusMessage = "Failed to start host!";
+                            netManager = nullptr;
+                        }
+                        press.play();
+                    } else if (specs[3].rect.contains(mp)) {
+                        menuState = MenuState::JOIN_INPUT;
+                        statusMessage = "Enter host IP address";
+                        press.play();
+                    } else if (specs[4].rect.contains(mp)) {
+                        background.stop();
+                        startscreen.close();
+                        result.quit = true;
+                        return result;
+                    }
+                } else if (menuState == MenuState::HOST_WAITING) {
+                    // specs: [0]=BACK
+                    if (specs[0].rect.contains(mp)) {
+                        menuState = MenuState::MAIN_MENU;
+                        netManager = nullptr;
+                        statusMessage = "";
+                        press.play();
+                    }
+                } else if (menuState == MenuState::JOIN_INPUT) {
+                    // specs: [0]=BACK
+                    if (specs[0].rect.contains(mp)) {
+                        menuState = MenuState::MAIN_MENU;
+                        ipInput = "127.0.0.1";
+                        statusMessage = "";
+                        press.play();
+                    }
+                } else if (menuState == MenuState::AI_DIFFICULTY) {
+                    // specs: [0]=EASY [1]=MEDIUM [2]=HARD [3]=BACK
+                    if (specs[0].rect.contains(mp)) {
+                        result.ai = AiDifficulty::Easy;
+                        mode = NetworkMode::LOCAL;
+                        menuState = MenuState::READY_TO_START;
+                        press.play();
+                    } else if (specs[1].rect.contains(mp)) {
+                        result.ai = AiDifficulty::Medium;
+                        mode = NetworkMode::LOCAL;
+                        menuState = MenuState::READY_TO_START;
+                        press.play();
+                    } else if (specs[2].rect.contains(mp)) {
+                        result.ai = AiDifficulty::Hard;
+                        mode = NetworkMode::LOCAL;
+                        menuState = MenuState::READY_TO_START;
+                        press.play();
+                    } else if (specs[3].rect.contains(mp)) {
+                        menuState = MenuState::MAIN_MENU;
+                        press.play();
+                    }
+                } else if (menuState == MenuState::READY_TO_START) {
+                    // specs: [0]=START
+                    if (specs[0].rect.contains(mp)) {
+                        background.stop();
+                        startscreen.close();
+                        result.mode = mode;
+                        result.netManager = netManager;
+                        return result;
+                    }
+                }
+            }
+        }
+
+        // Poll for client connection in HOST_WAITING.
+        if (menuState == MenuState::HOST_WAITING) {
+            if (netManager && netManager->waitForClient(sf::milliseconds(0))) {
+                menuState = MenuState::READY_TO_START;
+                statusMessage = "Player 2 connected! Click START to begin";
+            }
+        }
+
+        sf::Vector2f mousePos = startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen));
+        renderMenu(startscreen, david, font, menuState, ipInput, statusMessage, hostIpAddress,
+                   mousePos);
+        startscreen.display();
+    }
+
+    result.quit = true;
+    return result;
+}

--- a/src/menu_button.cpp
+++ b/src/menu_button.cpp
@@ -1,0 +1,33 @@
+#include "menu_button.h"
+
+static const sf::Color kNormalFill(50, 50, 60, 210);
+static const sf::Color kHoverFill(90, 90, 110, 230);
+static const sf::Color kOutlineColor(180, 180, 200, 180);
+
+MenuButton::MenuButton(sf::Vector2f size, const sf::Font& font, const std::string& text,
+                       unsigned charSize)
+    : label(text, font, charSize) {
+    shape.setSize(size);
+    shape.setOrigin(size.x / 2.f, size.y / 2.f);
+    shape.setFillColor(kNormalFill);
+    shape.setOutlineColor(kOutlineColor);
+    shape.setOutlineThickness(1.5f);
+}
+
+void MenuButton::setPosition(sf::Vector2f centre) {
+    shape.setPosition(centre);
+    auto lb = label.getLocalBounds();
+    label.setOrigin(lb.left + lb.width / 2.f, lb.top + lb.height / 2.f);
+    label.setPosition(centre);
+}
+
+void MenuButton::setHovered(bool hovered) {
+    shape.setFillColor(hovered ? kHoverFill : kNormalFill);
+}
+
+sf::FloatRect MenuButton::bounds() const { return shape.getGlobalBounds(); }
+
+void MenuButton::draw(sf::RenderWindow& w) const {
+    w.draw(shape);
+    w.draw(label);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,3 +71,18 @@ add_test(NAME smoke
     WORKING_DIRECTORY $<TARGET_FILE_DIR:dungeon_game>
 )
 set_tests_properties(smoke PROPERTIES LABELS "integration")
+
+# ── Menu harness CLI smoke tests ──────────────────────────────────────────────
+add_test(NAME menu_state_cli
+    COMMAND $<TARGET_FILE:dungeon_game>
+        --menu-state main_menu
+        --frames 3
+        --screenshot-dir $<TARGET_FILE_DIR:dungeon_game>/menu_smoke
+    WORKING_DIRECTORY $<TARGET_FILE_DIR:dungeon_game>
+)
+set_tests_properties(menu_state_cli PROPERTIES LABELS "integration")
+
+add_test(NAME menu_state_invalid
+    COMMAND $<TARGET_FILE:dungeon_game> --menu-state bogus
+)
+set_tests_properties(menu_state_invalid PROPERTIES WILL_FAIL TRUE LABELS "unit")

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -19,7 +19,9 @@
 #include "NetworkManager.h"
 #include "ai.h"
 #include "debug.h"
+#include "menu.h"
 #include "rng.h"
+#include <filesystem>
 
 // Absolute path to tests/data/ is injected at build time via CMake define.
 #ifndef TESTS_DATA_DIR
@@ -522,4 +524,39 @@ TEST_CASE("integration: replay overrides AI - replay kill wins over Hard AI", "[
     REQUIRE(s.p2_score == 1);
     REQUIRE(s.p1_score == 0);
     REQUIRE(s.wait == true);
+}
+
+// ── 24. Menu harness smoke test ───────────────────────────────────────────────
+// Calls showMenu() directly for each state; verifies no crash, returns quit=true,
+// and produces at least one screenshot PNG when screenshotEvery > 0.
+
+TEST_CASE("Menu harness smoke test", "[menu][integration]") {
+    for (const char* stateName :
+         {"main_menu", "ai_difficulty", "host_waiting", "join_input", "ready_to_start"}) {
+        auto tmpDir = std::filesystem::temp_directory_path() /
+                      ("dungeon_menu_test_" + std::string(stateName));
+        std::filesystem::remove_all(tmpDir);
+
+        DebugConfig cfg;
+        cfg.menuState = stateName;
+        cfg.screenshotDir = tmpDir.string();
+        cfg.screenshotEvery = 1; // gate is `> 0`; without this no PNG is written
+        cfg.frames = 3;
+
+        MenuResult r = showMenu(cfg);
+        REQUIRE(r.quit);
+
+        bool found = false;
+        if (std::filesystem::exists(tmpDir)) {
+            for (const auto& p : std::filesystem::directory_iterator(tmpDir)) {
+                if (p.path().extension() == ".png") {
+                    found = true;
+                    break;
+                }
+            }
+        }
+        REQUIRE(found);
+
+        std::filesystem::remove_all(tmpDir);
+    }
 }

--- a/tests/test_unit.cpp
+++ b/tests/test_unit.cpp
@@ -13,6 +13,8 @@
 #include "geometry.h"
 #include "key_bindings.h"
 #include "letterbox.h"
+#include "menu_button.h"
+#include "menu_layout.h"
 #include "replay.h"
 #include "sprite_anim.h"
 #include <sstream>
@@ -49,6 +51,10 @@ public:
     void changeValid(bool) override {}
     bool isValid() override { return true; }
     void setOrigin() override {}
+    sf::FloatRect getGlobalBounds() const override {
+        // Centered-origin convention: matches AnimatedGameObject post-setOrigin().
+        return {px - w * sx / 2.f, py - h * sy / 2.f, w * sx, h * sy};
+    }
 };
 
 // ── objectBounds ───────────────────────────────────────────────────────────────
@@ -522,4 +528,100 @@ TEST_CASE("loadBindings: all 13 fields parsed", "[key_bindings][unit]") {
     REQUIRE(b.slowDown == sf::Keyboard::F11);
     REQUIRE(b.speedUp == sf::Keyboard::F12);
     REQUIRE(b.skipCooldown == sf::Keyboard::Tab);
+}
+
+// ── menu_layout unit tests ────────────────────────────────────────────────────
+
+TEST_CASE("stackedButtonCenters: spacing between adjacent centers", "[menu][unit]") {
+    for (int count : {1, 2, 3, 4, 5, 6}) {
+        auto ys = stackedButtonCenters(kMenuH, kBtnH, kBtnGap, count);
+        REQUIRE(static_cast<int>(ys.size()) == count);
+        for (int i = 0; i + 1 < count; ++i)
+            REQUIRE(ys[static_cast<std::size_t>(i + 1)] - ys[static_cast<std::size_t>(i)] ==
+                    Catch::Approx(kBtnH + kBtnGap));
+    }
+}
+
+TEST_CASE("stackedButtonCenters: count <= 0 returns empty", "[menu][unit]") {
+    REQUIRE(stackedButtonCenters(kMenuH, kBtnH, kBtnGap, 0).empty());
+    REQUIRE(stackedButtonCenters(kMenuH, kBtnH, kBtnGap, -1).empty());
+}
+
+TEST_CASE("stackedButtonCenters: stack is centered within canvas", "[menu][unit]") {
+    for (int count : {1, 2, 3, 4, 5, 6}) {
+        auto ys = stackedButtonCenters(kMenuH, kBtnH, kBtnGap, count);
+        float mid = (ys.front() + ys.back()) / 2.f;
+        REQUIRE(mid == Catch::Approx(kMenuH / 2.f).margin(0.5f));
+    }
+}
+
+TEST_CASE("menuButtonRects: counts per state", "[menu][unit]") {
+    REQUIRE(menuButtonRects(MenuState::MAIN_MENU).size() == 5u);
+    REQUIRE(menuButtonRects(MenuState::AI_DIFFICULTY).size() == 4u);
+    REQUIRE(menuButtonRects(MenuState::HOST_WAITING).size() == 1u);
+    REQUIRE(menuButtonRects(MenuState::JOIN_INPUT).size() == 1u);
+    REQUIRE(menuButtonRects(MenuState::READY_TO_START).size() == 1u);
+}
+
+TEST_CASE("menuButtonRects: no two buttons overlap per state", "[menu][unit]") {
+    for (auto state : {MenuState::MAIN_MENU, MenuState::AI_DIFFICULTY, MenuState::HOST_WAITING,
+                       MenuState::JOIN_INPUT, MenuState::READY_TO_START}) {
+        auto specs = menuButtonRects(state);
+        for (std::size_t i = 0; i < specs.size(); ++i) {
+            for (std::size_t j = i + 1; j < specs.size(); ++j) {
+                INFO("state " << static_cast<int>(state) << " buttons " << i << " and " << j
+                              << " overlap");
+                REQUIRE(!specs[i].rect.intersects(specs[j].rect));
+            }
+        }
+    }
+}
+
+TEST_CASE("menuButtonRects: all rects fit within canvas", "[menu][unit]") {
+    sf::FloatRect canvas{0.f, 0.f, kMenuW, kMenuH};
+    for (auto state : {MenuState::MAIN_MENU, MenuState::AI_DIFFICULTY, MenuState::HOST_WAITING,
+                       MenuState::JOIN_INPUT, MenuState::READY_TO_START}) {
+        for (const auto& spec : menuButtonRects(state)) {
+            REQUIRE(spec.rect.left >= 0.f);
+            REQUIRE(spec.rect.top >= 0.f);
+            REQUIRE(spec.rect.left + spec.rect.width <= canvas.width);
+            REQUIRE(spec.rect.top + spec.rect.height <= canvas.height);
+        }
+    }
+}
+
+TEST_CASE("MenuButton::bounds equals drawn rect", "[menu][unit]") {
+    // getGlobalBounds() includes the outline thickness (1.5px expands each edge outward).
+    // left  = 300 - 200/2 - 1.5 = 198.5
+    // top   = 200 - 50/2  - 1.5 = 173.5
+    // width = 200 + 2*1.5 = 203, height = 50 + 2*1.5 = 53
+    sf::Font f{};
+    MenuButton btn({200.f, 50.f}, f, "Test");
+    btn.setPosition({300.f, 200.f});
+    REQUIRE(btn.bounds().left == Catch::Approx(198.5f));
+    REQUIRE(btn.bounds().top == Catch::Approx(173.5f));
+    REQUIRE(btn.bounds().width == Catch::Approx(203.f));
+    REQUIRE(btn.bounds().height == Catch::Approx(53.f));
+}
+
+TEST_CASE("pauseButtonRect: non-overlap and in-canvas", "[menu][unit]") {
+    auto r0 = pauseButtonRect(0);
+    auto r1 = pauseButtonRect(1);
+    REQUIRE(!r0.intersects(r1));
+    REQUIRE(r0.left >= 0.f);
+    REQUIRE(r0.top >= 0.f);
+    REQUIRE(r0.left + r0.width <= kGameW);
+    REQUIRE(r0.top + r0.height <= kGameH);
+    REQUIRE(r1.left >= 0.f);
+    REQUIRE(r1.top >= 0.f);
+    REQUIRE(r1.left + r1.width <= kGameW);
+    REQUIRE(r1.top + r1.height <= kGameH);
+}
+
+TEST_CASE("menuInfoPanelRect: covers expected text positions", "[menu][unit]") {
+    auto panel = menuInfoPanelRect();
+    for (float y : {150.f, 250.f, 320.f, 350.f, 400.f, 460.f}) {
+        INFO("panel should contain y=" << y);
+        REQUIRE(panel.contains(kMenuW / 2.f, y));
+    }
 }


### PR DESCRIPTION
Part 1 of #28 (the menu-system subset — findings 1–8; settings page and AI bug are separate).

**Root causes fixed:** every non-Quit button loaded `start.png` with the label baked into the sprite art (all read "Start game"); the hit-box formula hardcoded scale=0.5 while the menu uses .25–.4; button Y positions were hardcoded ignoring rendered heights.

**Fix (structural):** a `MenuButton` value type (`sf::RectangleShape` + `sf::Text`) whose `bounds()` == the drawn rect by construction; a pure `menu_layout.h` (constants + `stackedButtonCenters` + `menuButtonRects`) making non-overlap and hit-rect equality **unit-testable without a window**; `getGlobalBounds()` on the GameObject hierarchy; a backing panel for Host/Join text; the pause menu rebuilt on `MenuButton` + mouse nav; 1-player uses WASD bindings; a `--menu-state` screenshot harness.

**Validation:** window-free locally (0-warning `-Werror` build, 79/79 unit tests incl. the new menu-layout/hit-rect tests, clang-format v18). Windowed integration + menu screenshot smoke tests run on CI under headless `xvfb`. CI also uploads a `menu-screenshots` artifact (one render per menu state) for visual review.

Plan: `28a_menu_PLAN.md` (converged over 2 review rounds).