### PR TITLE
#28: fix Easy AI unable to hit near arena bottom

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -152,8 +152,6 @@ void Game::setAiOpponent(AiDifficulty d) {
 
 AiView Game::makeAiView() const {
     AiView view;
-    view.selfPos = m_robot->getPosition();
-
     // Both bounds must be normalised to positive width/height: either fighter
     // may face left (scale.x = -1), which makes objectBounds negative-width.
     // The decider's nearest-edge math needs a canonical left/width, so use
@@ -161,10 +159,13 @@ AiView Game::makeAiView() const {
     // P1 faces left while the robot is to its left — otherwise nearOppEdge
     // picks the far edge and the AI thinks it is a full body-width too far).
     view.selfBounds = normalizedBounds(*m_robot);
+    view.selfPos = m_robot->getPosition();
+    view.selfPos.y += view.selfBounds.height * 0.5f; // anchor → body centre
 
     view.selfFacingLeft = m_p2FacingLeft;
-    view.oppPos = m_rocket->getPosition();
     view.oppBounds = normalizedBounds(*m_rocket);
+    view.oppPos = m_rocket->getPosition();
+    view.oppPos.y += view.oppBounds.height * 0.5f; // anchor → body centre
 
     // arena[0] is the brick floor; arena[1..3] are the three fire hazards.
     for (int i = 0; i < 3; ++i)
@@ -479,9 +480,10 @@ void Game::update(sf::Time deltaT, float time) {
     sf::Vector2f p1movement(0.0f, 0.0f);
     sf::Vector2f p2movement(0.0f, 0.0f);
 
+    const float rocketH = m_rocket->getHeight() * m_rocket->getScale().y; // rendered: 68*2=136
     if (m_p1Up) {
-        if (m_rocket->getPosition().y < -(m_rocket->getHeight())) {
-            m_rocket->setPosition(m_rocket->getPosition().x, kGameH - m_rocket->getHeight());
+        if (m_rocket->getPosition().y < -rocketH) {
+            m_rocket->setPosition(m_rocket->getPosition().x, kGameH - rocketH);
         }
 
         if (collision(*m_rocket, *m_robot)) {
@@ -492,8 +494,8 @@ void Game::update(sf::Time deltaT, float time) {
     }
 
     if (m_p1Down) {
-        if (m_rocket->getPosition().y > kGameH - m_rocket->getHeight()) {
-            m_rocket->setPosition(m_rocket->getPosition().x, -(m_rocket->getHeight()));
+        if (m_rocket->getPosition().y > kGameH - rocketH) {
+            m_rocket->setPosition(m_rocket->getPosition().x, -rocketH);
         }
 
         if (collision(*m_rocket, *m_robot)) {

--- a/tests/data/p1_down.replay
+++ b/tests/data/p1_down.replay
@@ -1,6 +1,6 @@
-# p1_down.replay — P1 moves down 30 steps
+# p1_down.replay — P1 moves down (used for 27-step test)
 # P1 starts at y=400; m_speed=1200, dt=1/60 → 20 px/step.
-# After 30 steps: y=1000 (wrap triggers at y>1012, not reached here).
+# After 27 steps: y=940 (wrap triggers at y>1080-136=944, not reached in 27 steps).
 # Used with --replay-p1.
 # up down left right attack
 0 1 0 0 0

--- a/tests/test_ai.cpp
+++ b/tests/test_ai.cpp
@@ -284,7 +284,8 @@ TEST_CASE("ai: bottom-of-arena old anchor geometry -> no attack (pre-fix behavio
 
     std::mt19937 rng(1);
     // Robot anchor at bottom (y=900); rocket anchor at bottom (y=1012).
-    // horizDist = |500 - (350+120)| = 30 < attackRange=200, so only absDy blocks attack.
+    // makeView sets oppBounds.left = oppX-60 = 290, so nearOppEdge = 290+120 = 410;
+    // horizDist = |500 - 410| = 90 < attackRange=200, so only absDy blocks attack.
     AiView v = makeView(500.f, 900.f, 350.f, 1012.f, /*facingLeft=*/true);
 
     PlayerInput out = decideAiInput(v, p, rng);
@@ -305,7 +306,7 @@ TEST_CASE("ai: bottom-of-arena centre-Y geometry -> attack fires (post-fix behav
 
     std::mt19937 rng(1);
     // Robot centre at Y=990; rocket centre at Y=1012 (post-fix makeAiView output).
-    // horizDist = |500 - (350+120)| = 30 < attackRange=200 ✓
+    // horizDist = |500 - ((350-60)+120)| = |500-410| = 90 < attackRange=200 ✓
     // absDy = 22 < attackAlignY=40 ✓  dy=22 > Y-steer threshold=20.
     AiView v = makeView(500.f, 990.f, 350.f, 1012.f, /*facingLeft=*/true);
 

--- a/tests/test_ai.cpp
+++ b/tests/test_ai.cpp
@@ -270,6 +270,50 @@ TEST_CASE("ai: paramsFor sanity - params scale with difficulty (Easy < Medium < 
     REQUIRE(med.aggression < hard.aggression);
 }
 
+// ── 10. Bottom-of-arena: OLD anchor geometry -> no attack (why fix was needed) ─
+// With the pre-fix anchor Y convention (before makeAiView centre-Y shift):
+//   robot anchor Y=900, rocket anchor Y=1012 → absDy=112 > Easy attackAlignY=40
+// → decideAiInput cannot attack even though the sprites are at the arena bottom
+//   and vertically close.  This test pins that broken geometry so it is clear
+//   why the centre-Y fix in makeAiView() was necessary.
+
+TEST_CASE("ai: bottom-of-arena old anchor geometry -> no attack (pre-fix behaviour)", "[ai]") {
+    AiParams p = paramsFor(AiDifficulty::Easy);
+    p.mistakeProb = 0.f;
+    p.missTimeProb = 0.f;
+
+    std::mt19937 rng(1);
+    // Robot anchor at bottom (y=900); rocket anchor at bottom (y=1012).
+    // horizDist = |500 - (350+120)| = 30 < attackRange=200, so only absDy blocks attack.
+    AiView v = makeView(500.f, 900.f, 350.f, 1012.f, /*facingLeft=*/true);
+
+    PlayerInput out = decideAiInput(v, p, rng);
+    REQUIRE(out.attack == false); // absDy=112 > attackAlignY=40 -> blocked
+    REQUIRE(out.down == true);    // dy=112 > 20 -> AI steers down trying to align
+}
+
+// ── 11. Bottom-of-arena: post-fix centre-Y geometry -> attack fires ───────────
+// With the fixed centre-Y convention (makeAiView shifts by selfBounds.height*0.5):
+//   robot centre Y=990, rocket centre Y=1012 → absDy=22 < Easy attackAlignY=40
+// → attack fires.  Together with test 10 this proves the fix is in makeAiView(),
+//   not in decideAiInput or AiParams.
+
+TEST_CASE("ai: bottom-of-arena centre-Y geometry -> attack fires (post-fix behaviour)", "[ai]") {
+    AiParams p = paramsFor(AiDifficulty::Easy);
+    p.mistakeProb = 0.f;
+    p.missTimeProb = 0.f;
+
+    std::mt19937 rng(1);
+    // Robot centre at Y=990; rocket centre at Y=1012 (post-fix makeAiView output).
+    // horizDist = |500 - (350+120)| = 30 < attackRange=200 ✓
+    // absDy = 22 < attackAlignY=40 ✓  dy=22 > Y-steer threshold=20.
+    AiView v = makeView(500.f, 990.f, 350.f, 1012.f, /*facingLeft=*/true);
+
+    PlayerInput out = decideAiInput(v, p, rng);
+    REQUIRE(out.attack == true); // absDy=22 < attackAlignY=40 -> fires
+    REQUIRE(out.left == true);   // opponent is to the left
+}
+
 // ── 9b. decisionEvery hold: output changes only on boundary ───────────────────
 
 TEST_CASE("ai: decisionEvery hold - output constant within hold window", "[ai]") {

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -342,17 +342,17 @@ TEST_CASE("integration: determinism - same replay twice gives identical snapshot
 }
 
 // ── 14. P1 moves down ────────────────────────────────────────────────────────
-// P1 moves down 30 steps.  m_speed=1200, dt=1/60 -> 20 px/step.
-// Starting y=400; wrap triggers at y>(1080-68)=1012, not reached in 30 steps.
+// P1 moves down 27 steps.  m_speed=1200, dt=1/60 -> 20 px/step.
+// Starting y=400; wrap triggers at y>(1080-136)=944, not reached in 27 steps.
 
 TEST_CASE("integration: P1 moves down - p1_y increases 20 px per step", "[integration]") {
     DebugConfig cfg;
-    cfg.frames = 30;
+    cfg.frames = 27;
     cfg.replayPathP1 = dataPath("p1_down.replay");
     auto [t, s] = runGame(cfg);
 
-    // 30 steps × 20 px/step = 600; 400 + 600 = 1000.
-    REQUIRE(s.p1_y == Catch::Approx(1000.f).margin(1.f));
+    // 27 steps × 20 px/step = 540; 400 + 540 = 940.
+    REQUIRE(s.p1_y == Catch::Approx(940.f).margin(1.f));
 }
 
 // ── 15. P2 moves up ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Part of #28. Fixes the Easy AI being unable to attack P1 when the rocket hugs the bottom of the screen.

**Root cause (two compounding bugs):**
1. `AnimatedGameObject::getHeight()` returns the *unscaled* frame height, so the rocket's Y-wrap (scale 2.0, 68px→136px) fired at Y=1012 while the robot (scale 1.0) wraps at 900 — leaving the rocket ~112px of exclusive bottom territory the AI robot could not follow into.
2. `makeAiView()` compared top-left sprite anchors, not body centres; the differing rendered heights left a ~44px vertical gap even after fix 1 — still exceeding Easy's tight `attackAlignY=40`.

**Fix:** use rendered height (`getHeight()*getScale().y`) at the rocket Y-wrap sites; shift `selfPos.y`/`oppPos.y` to body centres in `makeAiView()`. No change to `decideAiInput`, `AiParams`, or difficulty tuning — this fixes reachability rather than weakening Easy.

**Tests:** new window-free AI unit tests documenting the old-anchor (absDy=112 → no attack) vs centre-Y (absDy=22 → attack) geometry; integration test 14 updated for the corrected wrap boundary (944). Windowed integration validated on CI (headless xvfb).

The sibling X-wrap bug (same unscaled-`getWidth()` pattern) is tracked separately in #33.