### PR TITLE
#28: in-game settings / key-binding screen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           ALSOFT_DRIVERS: 'null'
         run: |
-          for st in main_menu ai_difficulty host_waiting join_input ready_to_start; do
+          for st in main_menu ai_difficulty host_waiting join_input ready_to_start settings; do
             xvfb-run -a ./build/dungeon_game --menu-state "$st" --frames 2 \
               --screenshot-every 1 --screenshot-dir "build/menu_shots/$st" || true
           done

--- a/include/key_bindings.h
+++ b/include/key_bindings.h
@@ -40,6 +40,9 @@ std::string nameFromKey(sf::Keyboard::Key key);
 // Safe to round-trip through loadBindings.
 void saveBindings(const KeyBindings& b, std::ostream& out);
 
+// F11/F12 and the current debug bindings cannot be assigned to player actions.
+bool isReservedKey(sf::Keyboard::Key key, const KeyBindings& b);
+
 // Return a copy of b with the binding at rowIdx changed to newKey.
 // rowIdx mapping: 0=p1_up 1=p1_down 2=p1_left 3=p1_right 4=p1_attack
 //                 5=p2_up 6=p2_down 7=p2_left 8=p2_right 9=p2_attack

--- a/include/key_bindings.h
+++ b/include/key_bindings.h
@@ -35,3 +35,14 @@ KeyBindings loadBindings(std::istream& in);
 // nameFromKey returns "Unknown" for keys not in the table.
 sf::Keyboard::Key keyFromName(const std::string& name);
 std::string nameFromKey(sf::Keyboard::Key key);
+
+// Write all 13 bindings to out in "field = KeyName" format (same as controls.cfg).
+// Safe to round-trip through loadBindings.
+void saveBindings(const KeyBindings& b, std::ostream& out);
+
+// Return a copy of b with the binding at rowIdx changed to newKey.
+// rowIdx mapping: 0=p1_up 1=p1_down 2=p1_left 3=p1_right 4=p1_attack
+//                 5=p2_up 6=p2_down 7=p2_left 8=p2_right 9=p2_attack
+// If newKey is already bound to another slot, the two slots are swapped.
+// If rowIdx already holds newKey, b is returned unchanged.
+KeyBindings applyBindingEdit(KeyBindings b, int rowIdx, sf::Keyboard::Key newKey);

--- a/include/menu.h
+++ b/include/menu.h
@@ -2,6 +2,7 @@
 #include "NetworkManager.h"
 #include "ai_difficulty.h"
 #include "debug.h"
+#include "key_bindings.h"
 #include "menu_layout.h"
 #include <memory>
 #include <string>
@@ -13,7 +14,7 @@ struct MenuResult {
     AiDifficulty ai = AiDifficulty::None;
 };
 
-MenuResult showMenu(const DebugConfig& cfg = {});
+MenuResult showMenu(KeyBindings& bindings, const DebugConfig& cfg = {});
 
 // Map a --menu-state name ("main_menu", "host_waiting", …) to its enum.
 // Returns false for an unknown name. Single source of truth for valid state names.

--- a/include/menu_layout.h
+++ b/include/menu_layout.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "game_canvas.h"
+#include "key_bindings.h"
 #include <SFML/Graphics.hpp>
 #include <string>
 #include <vector>
@@ -13,7 +14,19 @@ inline constexpr float kBtnW = 280.f;
 inline constexpr float kBtnH = 60.f;
 inline constexpr float kBtnGap = 18.f;
 
-enum class MenuState { MAIN_MENU, HOST_WAITING, JOIN_INPUT, AI_DIFFICULTY, READY_TO_START };
+// Settings-screen row geometry.
+inline constexpr float kSettingsRowW = 380.f;
+inline constexpr float kSettingsRowH = 38.f;
+inline constexpr float kSettingsRowGap = 8.f;
+
+enum class MenuState {
+    MAIN_MENU,
+    HOST_WAITING,
+    JOIN_INPUT,
+    AI_DIFFICULTY,
+    READY_TO_START,
+    SETTINGS
+};
 
 // Returns the Y-center of each button in a vertical stack centered within canvasH.
 // Returns empty vector for count <= 0.
@@ -36,22 +49,27 @@ struct ButtonSpec {
 
 // Returns ButtonSpec for every clickable button in the given state.
 // Rects are in kMenuW x kMenuH logical space.
-// MAIN_MENU:       5 stacked (1 PLAYER, 2 PLAYER, HOST, JOIN, QUIT)
+// MAIN_MENU:       6 stacked (1 PLAYER, 2 PLAYER, HOST, JOIN, CONTROLS, QUIT)
 // AI_DIFFICULTY:   3 stacked (EASY, MEDIUM, HARD) + Back at top-left
 // HOST_WAITING:    Back only
 // JOIN_INPUT:      Back only
 // READY_TO_START:  START only (centered, no Back)
+// SETTINGS:        (empty — layout driven by settingsButtonSpecs)
 inline std::vector<ButtonSpec> menuButtonRects(MenuState state) {
     const sf::FloatRect backRect{20.f, 20.f, 120.f, 38.f};
 
+    if (state == MenuState::SETTINGS)
+        return {};
+
     if (state == MenuState::MAIN_MENU) {
-        auto ys = stackedButtonCenters(kMenuH, kBtnH, kBtnGap, 5);
+        auto ys = stackedButtonCenters(kMenuH, kBtnH, kBtnGap, 6);
         return {
             {{kMenuW / 2.f - kBtnW / 2.f, ys[0] - kBtnH / 2.f, kBtnW, kBtnH}, "1 PLAYER"},
             {{kMenuW / 2.f - kBtnW / 2.f, ys[1] - kBtnH / 2.f, kBtnW, kBtnH}, "2 PLAYER"},
             {{kMenuW / 2.f - kBtnW / 2.f, ys[2] - kBtnH / 2.f, kBtnW, kBtnH}, "HOST"},
             {{kMenuW / 2.f - kBtnW / 2.f, ys[3] - kBtnH / 2.f, kBtnW, kBtnH}, "JOIN"},
-            {{kMenuW / 2.f - kBtnW / 2.f, ys[4] - kBtnH / 2.f, kBtnW, kBtnH}, "QUIT"},
+            {{kMenuW / 2.f - kBtnW / 2.f, ys[4] - kBtnH / 2.f, kBtnW, kBtnH}, "CONTROLS"},
+            {{kMenuW / 2.f - kBtnW / 2.f, ys[5] - kBtnH / 2.f, kBtnW, kBtnH}, "QUIT"},
         };
     }
     if (state == MenuState::AI_DIFFICULTY) {
@@ -69,6 +87,58 @@ inline std::vector<ButtonSpec> menuButtonRects(MenuState state) {
     // READY_TO_START
     return {{{kMenuW / 2.f - kBtnW / 2.f, kMenuH / 2.f - kBtnH / 2.f, kBtnW, kBtnH}, "START"}};
 }
+
+// Settings screen: 12 specs in fixed order.
+// [0-4]  P1 UP/DOWN/LEFT/RIGHT/ATTACK (left column, x-centre=256)
+// [5-9]  P2 UP/DOWN/LEFT/RIGHT/ATTACK (right column, x-centre=768)
+// [10]   RESET TO DEFAULTS (centered)
+// [11]   BACK (top-left)
+inline std::vector<ButtonSpec> settingsButtonSpecs(const KeyBindings& b) {
+    const sf::FloatRect backRect{20.f, 20.f, 120.f, 38.f};
+    const float rowY0 = 120.f;
+    const float rowStep = kSettingsRowH + kSettingsRowGap;
+    const float p1x = 256.f - kSettingsRowW / 2.f;
+    const float p2x = 768.f - kSettingsRowW / 2.f;
+
+    struct Row {
+        const char* action;
+        sf::Keyboard::Key key;
+    };
+    const Row p1rows[5] = {
+        {"UP", b.p1.up},       {"DOWN", b.p1.down},     {"LEFT", b.p1.left},
+        {"RIGHT", b.p1.right}, {"ATTACK", b.p1.attack},
+    };
+    const Row p2rows[5] = {
+        {"UP", b.p2.up},       {"DOWN", b.p2.down},     {"LEFT", b.p2.left},
+        {"RIGHT", b.p2.right}, {"ATTACK", b.p2.attack},
+    };
+
+    std::vector<ButtonSpec> specs;
+    specs.reserve(12);
+
+    for (int i = 0; i < 5; ++i) {
+        std::string label =
+            std::string(p1rows[i].action) + "  [" + nameFromKey(p1rows[i].key) + "]";
+        specs.push_back(
+            {{p1x, rowY0 + static_cast<float>(i) * rowStep, kSettingsRowW, kSettingsRowH}, label});
+    }
+    for (int i = 0; i < 5; ++i) {
+        std::string label =
+            std::string(p2rows[i].action) + "  [" + nameFromKey(p2rows[i].key) + "]";
+        specs.push_back(
+            {{p2x, rowY0 + static_cast<float>(i) * rowStep, kSettingsRowW, kSettingsRowH}, label});
+    }
+    // RESET
+    specs.push_back({{kMenuW / 2.f - kBtnW / 2.f, 400.f, kBtnW, kBtnH}, "RESET TO DEFAULTS"});
+    // BACK
+    specs.push_back({backRect, "BACK"});
+
+    return specs;
+}
+
+// Returns the x-centre and y position for the "PLAYER 1" / "PLAYER 2" column headers.
+// col 0 = P1 (x=256), col 1 = P2 (x=768), y = 90.
+inline sf::Vector2f settingsColumnHeaderPos(int col) { return {col == 0 ? 256.f : 768.f, 90.f}; }
 
 // Semi-transparent backing panel for HOST_WAITING and JOIN_INPUT text.
 // Spans y=78–498 on a 576-high canvas, covering all text positions.

--- a/src/key_bindings.cpp
+++ b/src/key_bindings.cpp
@@ -121,6 +121,11 @@ KeyBindings defaultBindings() {
     return b;
 }
 
+bool isReservedKey(sf::Keyboard::Key key, const KeyBindings& b) {
+    return key == sf::Keyboard::F11 || key == sf::Keyboard::F12 || key == b.slowDown ||
+           key == b.speedUp || key == b.skipCooldown;
+}
+
 // ── loadBindings ──────────────────────────────────────────────────────────────
 
 static std::string trim(const std::string& s) {

--- a/src/key_bindings.cpp
+++ b/src/key_bindings.cpp
@@ -1,6 +1,7 @@
 #include "key_bindings.h"
 #include <algorithm>
 #include <iostream>
+#include <ostream>
 #include <sstream>
 #include <string>
 
@@ -184,5 +185,44 @@ KeyBindings loadBindings(std::istream& in) {
             b.skipCooldown = k;
         // Unknown fields silently ignored (forward-compat)
     }
+    return b;
+}
+
+// ── saveBindings ──────────────────────────────────────────────────────────────
+
+void saveBindings(const KeyBindings& b, std::ostream& out) {
+    out << "# Dungeon Game key bindings\n";
+    out << "p1_up = " << nameFromKey(b.p1.up) << "\n";
+    out << "p1_down = " << nameFromKey(b.p1.down) << "\n";
+    out << "p1_left = " << nameFromKey(b.p1.left) << "\n";
+    out << "p1_right = " << nameFromKey(b.p1.right) << "\n";
+    out << "p1_attack = " << nameFromKey(b.p1.attack) << "\n";
+    out << "p2_up = " << nameFromKey(b.p2.up) << "\n";
+    out << "p2_down = " << nameFromKey(b.p2.down) << "\n";
+    out << "p2_left = " << nameFromKey(b.p2.left) << "\n";
+    out << "p2_right = " << nameFromKey(b.p2.right) << "\n";
+    out << "p2_attack = " << nameFromKey(b.p2.attack) << "\n";
+    out << "slow_down = " << nameFromKey(b.slowDown) << "\n";
+    out << "speed_up = " << nameFromKey(b.speedUp) << "\n";
+    out << "skip_cooldown = " << nameFromKey(b.skipCooldown) << "\n";
+}
+
+// ── applyBindingEdit ──────────────────────────────────────────────────────────
+
+KeyBindings applyBindingEdit(KeyBindings b, int rowIdx, sf::Keyboard::Key newKey) {
+    sf::Keyboard::Key* slots[10] = {
+        &b.p1.up, &b.p1.down, &b.p1.left, &b.p1.right, &b.p1.attack,
+        &b.p2.up, &b.p2.down, &b.p2.left, &b.p2.right, &b.p2.attack,
+    };
+    if (*slots[rowIdx] == newKey)
+        return b;
+    // Scan for conflict and swap if found.
+    for (int i = 0; i < 10; ++i) {
+        if (i != rowIdx && *slots[i] == newKey) {
+            *slots[i] = *slots[rowIdx];
+            break;
+        }
+    }
+    *slots[rowIdx] = newKey;
     return b;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -233,7 +233,7 @@ int main(int argc, char** argv) {
                     if (!parseMenuState(val, parsed)) {
                         std::cerr << "Error: unknown --menu-state '" << val
                                   << "' (valid: main_menu host_waiting join_input ai_difficulty "
-                                     "ready_to_start)\n";
+                                     "ready_to_start settings)\n";
                         return 1;
                     }
                     config.menuState = val;
@@ -249,7 +249,7 @@ int main(int argc, char** argv) {
                         << "  --ai <easy|medium|hard>   AI opponent for P2 (requires --frames)\n"
                         << "  --menu-state <name>    Screenshot the given menu state and exit\n"
                         << "                         (main_menu|host_waiting|join_input|"
-                           "ai_difficulty|ready_to_start)\n"
+                           "ai_difficulty|ready_to_start|settings)\n"
                         << "\n"
                         << "Key bindings can be customised by placing a controls.cfg file\n"
                         << "next to the dungeon_game binary.  Example:\n"
@@ -282,9 +282,20 @@ int main(int argc, char** argv) {
             }
         }
 
+        // ── Load key bindings (exe-relative controls.cfg, absent → defaults) ──────
+        KeyBindings bindings = defaultBindings();
+        {
+            namespace fs = std::filesystem;
+            fs::path cfgPath = fs::path(exe_dir_path) / "controls.cfg";
+            if (fs::exists(cfgPath)) {
+                std::ifstream f(cfgPath);
+                bindings = loadBindings(f);
+            }
+        }
+
         // ── Menu harness bypass ───────────────────────────────────────────────────
         if (config.menuMode()) {
-            showMenu(config);
+            showMenu(bindings, config);
             return 0;
         }
 
@@ -305,20 +316,9 @@ int main(int argc, char** argv) {
             return 0;
         }
 
-        // ── Load key bindings (exe-relative controls.cfg, absent → defaults) ──────
-        KeyBindings bindings = defaultBindings();
-        {
-            namespace fs = std::filesystem;
-            fs::path cfgPath = fs::path(exe_dir_path) / "controls.cfg";
-            if (fs::exists(cfgPath)) {
-                std::ifstream f(cfgPath);
-                bindings = loadBindings(f);
-            }
-        }
-
         // ── Normal menu / game loop ───────────────────────────────────────────────
         while (true) {
-            MenuResult menu = showMenu();
+            MenuResult menu = showMenu(bindings);
             if (menu.quit)
                 break;
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -1,6 +1,7 @@
 #include "menu.h"
 #include "RegularGameObject.h"
 #include "asset_load.h"
+#include "key_bindings.h"
 #include "letterbox.h"
 #include "menu_button.h"
 #include "resource_path.h"
@@ -8,6 +9,7 @@
 #include <SFML/Audio.hpp>
 #include <SFML/Graphics.hpp>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -61,6 +63,10 @@ bool parseMenuState(const std::string& name, MenuState& out) {
         out = MenuState::READY_TO_START;
         return true;
     }
+    if (name == "settings") {
+        out = MenuState::SETTINGS;
+        return true;
+    }
     return false;
 }
 
@@ -75,9 +81,40 @@ static void centerText(sf::Text& t, float x, float y) {
 static void renderMenu(sf::RenderWindow& win, RegularGameObject& bg, const sf::Font& font,
                        MenuState menuState, const std::string& ipInput,
                        const std::string& statusMessage, const std::string& hostIpAddress,
-                       const sf::Vector2f& mousePos) {
+                       const sf::Vector2f& mousePos, const KeyBindings& bindings,
+                       int capturingIdx) {
     win.clear();
     bg.draw(win);
+
+    if (menuState == MenuState::SETTINGS) {
+        sf::Text title("CONTROLS", font, 40);
+        title.setFillColor(sf::Color::White);
+        title.setStyle(sf::Text::Bold);
+        centerText(title, kMenuW / 2.f, 30.f);
+        win.draw(title);
+
+        const char* headers[2] = {"PLAYER 1", "PLAYER 2"};
+        for (int col = 0; col < 2; ++col) {
+            sf::Text hdr(headers[col], font, 24);
+            hdr.setFillColor(sf::Color(200, 200, 200));
+            auto pos = settingsColumnHeaderPos(col);
+            centerText(hdr, pos.x, pos.y);
+            win.draw(hdr);
+        }
+
+        auto specs = settingsButtonSpecs(bindings);
+        for (int i = 0; i < static_cast<int>(specs.size()); ++i) {
+            auto btn = makeButton(specs[static_cast<std::size_t>(i)], font);
+            if (i == capturingIdx) {
+                btn.label.setString("Press a key...");
+                btn.shape.setFillColor({80, 80, 0});
+                btn.label.setFillColor(sf::Color::Yellow);
+            }
+            btn.setHovered(specs[static_cast<std::size_t>(i)].rect.contains(mousePos));
+            btn.draw(win);
+        }
+        return;
+    }
 
     auto specs = menuButtonRects(menuState);
 
@@ -165,7 +202,7 @@ static void renderMenu(sf::RenderWindow& win, RegularGameObject& bg, const sf::F
 
 // ── showMenu ──────────────────────────────────────────────────────────────────
 
-MenuResult showMenu(const DebugConfig& cfg) {
+MenuResult showMenu(KeyBindings& bindings, const DebugConfig& cfg) {
     MenuState menuState = MenuState::MAIN_MENU;
     NetworkMode mode = NetworkMode::LOCAL;
     std::shared_ptr<NetworkManager> netManager = nullptr;
@@ -173,6 +210,7 @@ MenuResult showMenu(const DebugConfig& cfg) {
     std::string statusMessage;
     std::string hostIpAddress;
     MenuResult result;
+    int capturingIdx = -1;
 
     // Harness: parse the requested state.
     if (cfg.menuMode()) {
@@ -222,7 +260,7 @@ MenuResult showMenu(const DebugConfig& cfg) {
             sf::Vector2f mousePos =
                 startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen));
             renderMenu(startscreen, david, font, menuState, ipInput, statusMessage, hostIpAddress,
-                       mousePos);
+                       mousePos, bindings, capturingIdx);
             if (cfg.screenshotEvery > 0 && frame % cfg.screenshotEvery == 0) {
                 captureScreenshot(startscreen,
                                   cfg.screenshotDir + "/menu_" + std::to_string(frame) + ".png");
@@ -247,6 +285,26 @@ MenuResult showMenu(const DebugConfig& cfg) {
             if (event.type == sf::Event::Resized) {
                 startscreen.setView(
                     makeLetterboxView({kMenuW, kMenuH}, {event.size.width, event.size.height}));
+            }
+            if (event.type == sf::Event::KeyPressed) {
+                if (menuState == MenuState::SETTINGS) {
+                    if (capturingIdx >= 0) {
+                        if (event.key.code == sf::Keyboard::Escape) {
+                            capturingIdx = -1;
+                        } else if (nameFromKey(event.key.code) == "Unknown") {
+                            // Key not in kKeyTable (IME, multimedia, etc.) — silently cancel.
+                            capturingIdx = -1;
+                        } else {
+                            bindings = applyBindingEdit(bindings, capturingIdx, event.key.code);
+                            std::ofstream f(std::filesystem::path(exe_dir_path) / "controls.cfg");
+                            saveBindings(bindings, f);
+                            capturingIdx = -1;
+                        }
+                    } else if (event.key.code == sf::Keyboard::Escape) {
+                        capturingIdx = -1;
+                        menuState = MenuState::MAIN_MENU;
+                    }
+                }
             }
             if (menuState == MenuState::JOIN_INPUT && event.type == sf::Event::TextEntered) {
                 if (event.text.unicode == '\b' && !ipInput.empty()) {
@@ -273,10 +331,10 @@ MenuResult showMenu(const DebugConfig& cfg) {
                 event.mouseButton.button == sf::Mouse::Left) {
                 sf::Vector2f mp =
                     startscreen.mapPixelToCoords({event.mouseButton.x, event.mouseButton.y});
-                auto specs = menuButtonRects(menuState);
 
                 if (menuState == MenuState::MAIN_MENU) {
-                    // specs: [0]=1PLAYER [1]=2PLAYER [2]=HOST [3]=JOIN [4]=QUIT
+                    auto specs = menuButtonRects(menuState);
+                    // specs: [0]=1PLAYER [1]=2PLAYER [2]=HOST [3]=JOIN [4]=CONTROLS [5]=QUIT
                     if (specs[0].rect.contains(mp)) {
                         menuState = MenuState::AI_DIFFICULTY;
                         press.play();
@@ -301,12 +359,17 @@ MenuResult showMenu(const DebugConfig& cfg) {
                         statusMessage = "Enter host IP address";
                         press.play();
                     } else if (specs[4].rect.contains(mp)) {
+                        menuState = MenuState::SETTINGS;
+                        capturingIdx = -1;
+                        press.play();
+                    } else if (specs[5].rect.contains(mp)) {
                         background.stop();
                         startscreen.close();
                         result.quit = true;
                         return result;
                     }
                 } else if (menuState == MenuState::HOST_WAITING) {
+                    auto specs = menuButtonRects(menuState);
                     // specs: [0]=BACK
                     if (specs[0].rect.contains(mp)) {
                         menuState = MenuState::MAIN_MENU;
@@ -315,6 +378,7 @@ MenuResult showMenu(const DebugConfig& cfg) {
                         press.play();
                     }
                 } else if (menuState == MenuState::JOIN_INPUT) {
+                    auto specs = menuButtonRects(menuState);
                     // specs: [0]=BACK
                     if (specs[0].rect.contains(mp)) {
                         menuState = MenuState::MAIN_MENU;
@@ -323,6 +387,7 @@ MenuResult showMenu(const DebugConfig& cfg) {
                         press.play();
                     }
                 } else if (menuState == MenuState::AI_DIFFICULTY) {
+                    auto specs = menuButtonRects(menuState);
                     // specs: [0]=EASY [1]=MEDIUM [2]=HARD [3]=BACK
                     if (specs[0].rect.contains(mp)) {
                         result.ai = AiDifficulty::Easy;
@@ -344,6 +409,7 @@ MenuResult showMenu(const DebugConfig& cfg) {
                         press.play();
                     }
                 } else if (menuState == MenuState::READY_TO_START) {
+                    auto specs = menuButtonRects(menuState);
                     // specs: [0]=START
                     if (specs[0].rect.contains(mp)) {
                         background.stop();
@@ -351,6 +417,31 @@ MenuResult showMenu(const DebugConfig& cfg) {
                         result.mode = mode;
                         result.netManager = netManager;
                         return result;
+                    }
+                } else if (menuState == MenuState::SETTINGS) {
+                    auto specs = settingsButtonSpecs(bindings);
+                    // specs: [0-9]=binding rows [10]=RESET [11]=BACK
+                    bool handled = false;
+                    for (int i = 0; i < 10; ++i) {
+                        if (specs[static_cast<std::size_t>(i)].rect.contains(mp)) {
+                            capturingIdx = i;
+                            press.play();
+                            handled = true;
+                            break;
+                        }
+                    }
+                    if (!handled) {
+                        if (specs[10].rect.contains(mp)) {
+                            bindings = defaultBindings();
+                            std::ofstream f(std::filesystem::path(exe_dir_path) / "controls.cfg");
+                            saveBindings(bindings, f);
+                            capturingIdx = -1;
+                            press.play();
+                        } else if (specs[11].rect.contains(mp)) {
+                            menuState = MenuState::MAIN_MENU;
+                            capturingIdx = -1;
+                            press.play();
+                        }
                     }
                 }
             }
@@ -366,7 +457,7 @@ MenuResult showMenu(const DebugConfig& cfg) {
 
         sf::Vector2f mousePos = startscreen.mapPixelToCoords(sf::Mouse::getPosition(startscreen));
         renderMenu(startscreen, david, font, menuState, ipInput, statusMessage, hostIpAddress,
-                   mousePos);
+                   mousePos, bindings, capturingIdx);
         startscreen.display();
     }
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -77,6 +77,23 @@ static void centerText(sf::Text& t, float x, float y) {
     t.setPosition(x, y);
 }
 
+static void saveControls(const KeyBindings& bindings, std::string& statusMessage) {
+    std::ofstream f(std::filesystem::path(exe_dir_path) / "controls.cfg");
+    if (!f) {
+        statusMessage = "Failed to save controls.cfg";
+        return;
+    }
+
+    saveBindings(bindings, f);
+    f.flush();
+    if (!f) {
+        statusMessage = "Failed to save controls.cfg";
+        return;
+    }
+
+    statusMessage.clear();
+}
+
 // Render the current menu state into the window (shared between normal + harness loops).
 static void renderMenu(sf::RenderWindow& win, RegularGameObject& bg, const sf::Font& font,
                        MenuState menuState, const std::string& ipInput,
@@ -105,13 +122,22 @@ static void renderMenu(sf::RenderWindow& win, RegularGameObject& bg, const sf::F
         auto specs = settingsButtonSpecs(bindings);
         for (int i = 0; i < static_cast<int>(specs.size()); ++i) {
             auto btn = makeButton(specs[static_cast<std::size_t>(i)], font);
+            btn.setHovered(specs[static_cast<std::size_t>(i)].rect.contains(mousePos));
             if (i == capturingIdx) {
                 btn.label.setString("Press a key...");
                 btn.shape.setFillColor({80, 80, 0});
                 btn.label.setFillColor(sf::Color::Yellow);
+                btn.setPosition(btn.shape.getPosition());
             }
-            btn.setHovered(specs[static_cast<std::size_t>(i)].rect.contains(mousePos));
             btn.draw(win);
+        }
+        if (!statusMessage.empty()) {
+            sf::Text statusText(statusMessage, font, 22);
+            statusText.setFillColor(statusMessage.find("Failed") != std::string::npos
+                                        ? sf::Color::Red
+                                        : sf::Color::Yellow);
+            centerText(statusText, kMenuW / 2.f, 480.f);
+            win.draw(statusText);
         }
         return;
     }
@@ -294,10 +320,12 @@ MenuResult showMenu(KeyBindings& bindings, const DebugConfig& cfg) {
                         } else if (nameFromKey(event.key.code) == "Unknown") {
                             // Key not in kKeyTable (IME, multimedia, etc.) — silently cancel.
                             capturingIdx = -1;
+                        } else if (isReservedKey(event.key.code, bindings)) {
+                            capturingIdx = -1;
+                            statusMessage = "Reserved key";
                         } else {
                             bindings = applyBindingEdit(bindings, capturingIdx, event.key.code);
-                            std::ofstream f(std::filesystem::path(exe_dir_path) / "controls.cfg");
-                            saveBindings(bindings, f);
+                            saveControls(bindings, statusMessage);
                             capturingIdx = -1;
                         }
                     } else if (event.key.code == sf::Keyboard::Escape) {
@@ -361,6 +389,7 @@ MenuResult showMenu(KeyBindings& bindings, const DebugConfig& cfg) {
                     } else if (specs[4].rect.contains(mp)) {
                         menuState = MenuState::SETTINGS;
                         capturingIdx = -1;
+                        statusMessage.clear();
                         press.play();
                     } else if (specs[5].rect.contains(mp)) {
                         background.stop();
@@ -425,6 +454,7 @@ MenuResult showMenu(KeyBindings& bindings, const DebugConfig& cfg) {
                     for (int i = 0; i < 10; ++i) {
                         if (specs[static_cast<std::size_t>(i)].rect.contains(mp)) {
                             capturingIdx = i;
+                            statusMessage.clear();
                             press.play();
                             handled = true;
                             break;
@@ -433,8 +463,7 @@ MenuResult showMenu(KeyBindings& bindings, const DebugConfig& cfg) {
                     if (!handled) {
                         if (specs[10].rect.contains(mp)) {
                             bindings = defaultBindings();
-                            std::ofstream f(std::filesystem::path(exe_dir_path) / "controls.cfg");
-                            saveBindings(bindings, f);
+                            saveControls(bindings, statusMessage);
                             capturingIdx = -1;
                             press.play();
                         } else if (specs[11].rect.contains(mp)) {

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -531,8 +531,8 @@ TEST_CASE("integration: replay overrides AI - replay kill wins over Hard AI", "[
 // and produces at least one screenshot PNG when screenshotEvery > 0.
 
 TEST_CASE("Menu harness smoke test", "[menu][integration]") {
-    for (const char* stateName :
-         {"main_menu", "ai_difficulty", "host_waiting", "join_input", "ready_to_start"}) {
+    for (const char* stateName : {"main_menu", "ai_difficulty", "host_waiting", "join_input",
+                                  "ready_to_start", "settings"}) {
         auto tmpDir = std::filesystem::temp_directory_path() /
                       ("dungeon_menu_test_" + std::string(stateName));
         std::filesystem::remove_all(tmpDir);
@@ -543,7 +543,8 @@ TEST_CASE("Menu harness smoke test", "[menu][integration]") {
         cfg.screenshotEvery = 1; // gate is `> 0`; without this no PNG is written
         cfg.frames = 3;
 
-        MenuResult r = showMenu(cfg);
+        KeyBindings bindings = defaultBindings();
+        MenuResult r = showMenu(bindings, cfg);
         REQUIRE(r.quit);
 
         bool found = false;

--- a/tests/test_unit.cpp
+++ b/tests/test_unit.cpp
@@ -719,6 +719,20 @@ TEST_CASE("saveBindings preserves non-default bindings", "[key_bindings][unit]")
     REQUIRE(reloaded.p1.down == defaultBindings().p1.down);
 }
 
+TEST_CASE("isReservedKey: rejects hard-coded and current debug keys", "[key_bindings][unit]") {
+    auto b = defaultBindings();
+    REQUIRE(isReservedKey(sf::Keyboard::F11, b));
+    REQUIRE(isReservedKey(sf::Keyboard::F12, b));
+    REQUIRE(isReservedKey(b.slowDown, b));
+    REQUIRE(isReservedKey(b.speedUp, b));
+    REQUIRE(isReservedKey(b.skipCooldown, b));
+    REQUIRE_FALSE(isReservedKey(sf::Keyboard::F3, b));
+
+    b.slowDown = sf::Keyboard::F1;
+    REQUIRE(isReservedKey(sf::Keyboard::F1, b));
+    REQUIRE_FALSE(isReservedKey(sf::Keyboard::O, b));
+}
+
 TEST_CASE("applyBindingEdit: sets new key with no conflict", "[key_bindings][unit]") {
     auto b = defaultBindings();
     // F3 is not used by any default binding

--- a/tests/test_unit.cpp
+++ b/tests/test_unit.cpp
@@ -13,6 +13,7 @@
 #include "geometry.h"
 #include "key_bindings.h"
 #include "letterbox.h"
+#include "menu.h"
 #include "menu_button.h"
 #include "menu_layout.h"
 #include "replay.h"
@@ -556,16 +557,17 @@ TEST_CASE("stackedButtonCenters: stack is centered within canvas", "[menu][unit]
 }
 
 TEST_CASE("menuButtonRects: counts per state", "[menu][unit]") {
-    REQUIRE(menuButtonRects(MenuState::MAIN_MENU).size() == 5u);
+    REQUIRE(menuButtonRects(MenuState::MAIN_MENU).size() == 6u);
     REQUIRE(menuButtonRects(MenuState::AI_DIFFICULTY).size() == 4u);
     REQUIRE(menuButtonRects(MenuState::HOST_WAITING).size() == 1u);
     REQUIRE(menuButtonRects(MenuState::JOIN_INPUT).size() == 1u);
     REQUIRE(menuButtonRects(MenuState::READY_TO_START).size() == 1u);
+    REQUIRE(menuButtonRects(MenuState::SETTINGS).size() == 0u);
 }
 
 TEST_CASE("menuButtonRects: no two buttons overlap per state", "[menu][unit]") {
     for (auto state : {MenuState::MAIN_MENU, MenuState::AI_DIFFICULTY, MenuState::HOST_WAITING,
-                       MenuState::JOIN_INPUT, MenuState::READY_TO_START}) {
+                       MenuState::JOIN_INPUT, MenuState::READY_TO_START, MenuState::SETTINGS}) {
         auto specs = menuButtonRects(state);
         for (std::size_t i = 0; i < specs.size(); ++i) {
             for (std::size_t j = i + 1; j < specs.size(); ++j) {
@@ -580,7 +582,7 @@ TEST_CASE("menuButtonRects: no two buttons overlap per state", "[menu][unit]") {
 TEST_CASE("menuButtonRects: all rects fit within canvas", "[menu][unit]") {
     sf::FloatRect canvas{0.f, 0.f, kMenuW, kMenuH};
     for (auto state : {MenuState::MAIN_MENU, MenuState::AI_DIFFICULTY, MenuState::HOST_WAITING,
-                       MenuState::JOIN_INPUT, MenuState::READY_TO_START}) {
+                       MenuState::JOIN_INPUT, MenuState::READY_TO_START, MenuState::SETTINGS}) {
         for (const auto& spec : menuButtonRects(state)) {
             REQUIRE(spec.rect.left >= 0.f);
             REQUIRE(spec.rect.top >= 0.f);
@@ -624,4 +626,145 @@ TEST_CASE("menuInfoPanelRect: covers expected text positions", "[menu][unit]") {
         INFO("panel should contain y=" << y);
         REQUIRE(panel.contains(kMenuW / 2.f, y));
     }
+}
+
+// ── settings screen unit tests ────────────────────────────────────────────────
+
+TEST_CASE("parseMenuState: 'settings' maps to SETTINGS", "[settings][unit]") {
+    MenuState out;
+    REQUIRE(parseMenuState("settings", out));
+    REQUIRE(out == MenuState::SETTINGS);
+}
+
+TEST_CASE("settingsButtonSpecs: returns 12 specs", "[settings][unit]") {
+    auto b = defaultBindings();
+    auto specs = settingsButtonSpecs(b);
+    REQUIRE(specs.size() == 12u);
+}
+
+TEST_CASE("settingsButtonSpecs: no two rects overlap", "[settings][unit]") {
+    auto b = defaultBindings();
+    auto specs = settingsButtonSpecs(b);
+    for (std::size_t i = 0; i < specs.size(); ++i) {
+        for (std::size_t j = i + 1; j < specs.size(); ++j) {
+            INFO("specs " << i << " and " << j << " overlap");
+            REQUIRE(!specs[i].rect.intersects(specs[j].rect));
+        }
+    }
+}
+
+TEST_CASE("settingsButtonSpecs: all rects fit in canvas", "[settings][unit]") {
+    auto b = defaultBindings();
+    auto specs = settingsButtonSpecs(b);
+    for (const auto& spec : specs) {
+        REQUIRE(spec.rect.left >= 0.f);
+        REQUIRE(spec.rect.top >= 0.f);
+        REQUIRE(spec.rect.left + spec.rect.width <= kMenuW);
+        REQUIRE(spec.rect.top + spec.rect.height <= kMenuH);
+    }
+}
+
+TEST_CASE("settingsButtonSpecs: labels encode correct key names", "[settings][unit]") {
+    auto b = defaultBindings();
+    auto specs = settingsButtonSpecs(b);
+    // P1 rows [0-4]
+    REQUIRE(specs[0].label.find(nameFromKey(b.p1.up)) != std::string::npos);
+    REQUIRE(specs[1].label.find(nameFromKey(b.p1.down)) != std::string::npos);
+    REQUIRE(specs[2].label.find(nameFromKey(b.p1.left)) != std::string::npos);
+    REQUIRE(specs[3].label.find(nameFromKey(b.p1.right)) != std::string::npos);
+    REQUIRE(specs[4].label.find(nameFromKey(b.p1.attack)) != std::string::npos);
+    // P2 rows [5-9]
+    REQUIRE(specs[5].label.find(nameFromKey(b.p2.up)) != std::string::npos);
+    REQUIRE(specs[6].label.find(nameFromKey(b.p2.down)) != std::string::npos);
+    REQUIRE(specs[7].label.find(nameFromKey(b.p2.left)) != std::string::npos);
+    REQUIRE(specs[8].label.find(nameFromKey(b.p2.right)) != std::string::npos);
+    REQUIRE(specs[9].label.find(nameFromKey(b.p2.attack)) != std::string::npos);
+    // RESET and BACK labels
+    REQUIRE(specs[10].label == "RESET TO DEFAULTS");
+    REQUIRE(specs[11].label == "BACK");
+}
+
+// ── saveBindings + applyBindingEdit unit tests ────────────────────────────────
+
+TEST_CASE("saveBindings round-trips with loadBindings", "[key_bindings][unit]") {
+    auto orig = defaultBindings();
+    std::ostringstream oss;
+    saveBindings(orig, oss);
+    std::istringstream iss(oss.str());
+    auto reloaded = loadBindings(iss);
+    REQUIRE(reloaded.p1.up == orig.p1.up);
+    REQUIRE(reloaded.p1.down == orig.p1.down);
+    REQUIRE(reloaded.p1.left == orig.p1.left);
+    REQUIRE(reloaded.p1.right == orig.p1.right);
+    REQUIRE(reloaded.p1.attack == orig.p1.attack);
+    REQUIRE(reloaded.p2.up == orig.p2.up);
+    REQUIRE(reloaded.p2.down == orig.p2.down);
+    REQUIRE(reloaded.p2.left == orig.p2.left);
+    REQUIRE(reloaded.p2.right == orig.p2.right);
+    REQUIRE(reloaded.p2.attack == orig.p2.attack);
+    REQUIRE(reloaded.slowDown == orig.slowDown);
+    REQUIRE(reloaded.speedUp == orig.speedUp);
+    REQUIRE(reloaded.skipCooldown == orig.skipCooldown);
+}
+
+TEST_CASE("saveBindings preserves non-default bindings", "[key_bindings][unit]") {
+    auto b = defaultBindings();
+    b.p1.up = sf::Keyboard::F1;
+    std::ostringstream oss;
+    saveBindings(b, oss);
+    std::istringstream iss(oss.str());
+    auto reloaded = loadBindings(iss);
+    REQUIRE(reloaded.p1.up == sf::Keyboard::F1);
+    // Other fields unchanged from defaults
+    REQUIRE(reloaded.p1.down == defaultBindings().p1.down);
+}
+
+TEST_CASE("applyBindingEdit: sets new key with no conflict", "[key_bindings][unit]") {
+    auto b = defaultBindings();
+    // F3 is not used by any default binding
+    auto result = applyBindingEdit(b, 0, sf::Keyboard::F3);
+    REQUIRE(result.p1.up == sf::Keyboard::F3);
+    // Other slots unchanged
+    REQUIRE(result.p1.down == b.p1.down);
+}
+
+TEST_CASE("applyBindingEdit: swap on conflict", "[key_bindings][unit]") {
+    auto b = defaultBindings();
+    // rowIdx 0 = p1.up (Numpad8); newKey = b.p2.up (W) which is rowIdx 5
+    sf::Keyboard::Key oldP1Up = b.p1.up;
+    auto result = applyBindingEdit(b, 0, b.p2.up);
+    REQUIRE(result.p1.up == sf::Keyboard::W); // p2.up moved to p1.up
+    REQUIRE(result.p2.up == oldP1Up);         // old p1.up swapped to p2.up
+}
+
+TEST_CASE("applyBindingEdit: no-op when same key", "[key_bindings][unit]") {
+    auto b = defaultBindings();
+    auto result = applyBindingEdit(b, 0, b.p1.up);
+    REQUIRE(result.p1.up == b.p1.up);
+    REQUIRE(result.p1.down == b.p1.down);
+    REQUIRE(result.p2.up == b.p2.up);
+}
+
+TEST_CASE("applyBindingEdit: swap at P1/P2 boundary (rowIdx=4 vs rowIdx=5)",
+          "[key_bindings][unit]") {
+    auto b = defaultBindings();
+    // rowIdx 4 = p1.attack (Right); rowIdx 5 = p2.up (W)
+    sf::Keyboard::Key oldP1Attack = b.p1.attack;
+    auto result = applyBindingEdit(b, 4, b.p2.up);
+    REQUIRE(result.p1.attack == sf::Keyboard::W);
+    REQUIRE(result.p2.up == oldP1Attack);
+}
+
+TEST_CASE("saveBindings: field names match loadBindings expectations", "[key_bindings][unit]") {
+    auto b = defaultBindings();
+    std::ostringstream oss;
+    saveBindings(b, oss);
+    const std::string out = oss.str();
+    REQUIRE(out.find("speed_up = ") != std::string::npos);
+    REQUIRE(out.find("slow_down = ") != std::string::npos);
+    REQUIRE(out.find("skip_cooldown = ") != std::string::npos);
+    // Confirm struct-member spelling is NOT used directly
+    REQUIRE(out.find("speedUp") == std::string::npos);
+    REQUIRE(out.find("slowDown") == std::string::npos);
+    REQUIRE(out.find("skipCooldown") == std::string::npos);
 }


### PR DESCRIPTION
Completes #28. Adds an in-game settings screen so players can view and remap key bindings without hand-editing `controls.cfg`.

- **Access:** a new "CONTROLS" button on the main menu (now 6 buttons, fits the canvas) → `MenuState::SETTINGS`.
- **Screen:** two-column grid (P1 left, P2 right) of `MenuButton` rows showing `ACTION [KeyName]`, plus RESET + BACK. Click a row → capture mode ("Press a key...") → next key rebinds; Esc/unmapped keys cancel; conflicts SWAP; every edit persists to `controls.cfg`.
- **Pure/testable:** `settingsButtonSpecs(KeyBindings)` (layout, window-free unit-tested for count/non-overlap/canvas-fit), `saveBindings`/`applyBindingEdit` (round-trip + swap tested). Reuses the #28a MenuButton/menu_layout patterns.
- `--menu-state settings` renders on CI for the screenshot artifact.

**Validation:** window-free — 0-warning `-Werror` build, 93/93 unit tests (+12 new), clang-format v18 clean. The 6-button main menu + settings screen render on CI (headless xvfb). Plan: `28c_settings_PLAN.md` (converged over 2 review rounds).