### PR TITLE
Add gamepad support (sf::Joystick to PlayerInput) — #29

### DIFF
--- a/include/Game.h
+++ b/include/Game.h
@@ -10,6 +10,7 @@
 #include "ai.h"
 #include "debug.h"
 #include "game_canvas.h"
+#include "gamepad.h"
 #include "key_bindings.h"
 #include "replay.h"
 #include <SFML/Audio.hpp>
@@ -170,4 +171,9 @@ private:
 
     // Key bindings (loaded from controls.cfg; defaults = original hard-coded keys).
     KeyBindings m_bindings = defaultBindings();
+
+    // Gamepad movement state. Indexed by player slot: [0]=P1, [1]=P2.
+    // Assigned each frame by pollGamepadInput(); attack is excluded (event-driven).
+    PlayerInput m_joyInput[2] = {};
+    void pollGamepadInput();
 };

--- a/include/Game.h
+++ b/include/Game.h
@@ -171,9 +171,4 @@ private:
 
     // Key bindings (loaded from controls.cfg; defaults = original hard-coded keys).
     KeyBindings m_bindings = defaultBindings();
-
-    // Gamepad movement state. Indexed by player slot: [0]=P1, [1]=P2.
-    // Assigned each frame by pollGamepadInput(); attack is excluded (event-driven).
-    PlayerInput m_joyInput[2] = {};
-    void pollGamepadInput();
 };

--- a/include/gamepad.h
+++ b/include/gamepad.h
@@ -31,9 +31,9 @@ inline PlayerInput axisToInput(float x, float y, float povX, float povY, float d
 //   id — joystick index (0 or 1)
 // If id is not connected, returns all-false. No prevAttack state needed.
 inline PlayerInput pollJoystick(unsigned id, float deadzone = kJoyDeadzone) {
+    // LCOV_EXCL_START — sf::Joystick hardware calls (incl. isConnected); not reachable in headless CI
     if (!sf::Joystick::isConnected(id))
         return {};
-    // LCOV_EXCL_START — sf::Joystick hardware calls; not reachable in headless CI
     float x = sf::Joystick::getAxisPosition(id, sf::Joystick::X);
     float y = sf::Joystick::getAxisPosition(id, sf::Joystick::Y);
     float povX = sf::Joystick::getAxisPosition(id, sf::Joystick::PovX);

--- a/include/gamepad.h
+++ b/include/gamepad.h
@@ -1,0 +1,43 @@
+#pragma once
+#include "NetworkManager.h" // PlayerInput
+#include <SFML/Window.hpp>  // sf::Joystick
+
+inline constexpr float kJoyDeadzone = 25.0f;
+inline constexpr unsigned kAttackButton = 0;
+
+// Pure: maps raw joystick axis values to a movement-only PlayerInput.
+//
+//   x, y       — left-stick axes      (sf::Joystick::X / Y),    range [-100, 100]
+//   povX, povY — D-pad POV axes       (sf::Joystick::PovX / Y), same range
+//   deadzone   — absolute threshold; |value| <= deadzone → no input
+//
+// Directions: +x=right, -x=left, +y=down, -y=up (SFML 2 analog convention).
+// Left-stick and POV hat are OR-combined per direction.
+// NOTE: sf::Joystick::PovY is inverted on Windows XInput (+100=up, -100=down).
+// If D-pad up/down are reversed on Windows, invert povY at the call site.
+// Attack is NOT part of this function — it is event-driven via JoystickButtonPressed.
+inline PlayerInput axisToInput(float x, float y, float povX, float povY, float deadzone) {
+    PlayerInput in;
+    in.right = (x > deadzone) || (povX > deadzone);
+    in.left = (x < -deadzone) || (povX < -deadzone);
+    // NOTE: sf::Joystick::PovY is inverted on Windows XInput (+100=up, -100=down).
+    // If D-pad up/down are reversed on Windows, pass -povY here.
+    in.down = (y > deadzone) || (povY > deadzone);
+    in.up = (y < -deadzone) || (povY < -deadzone);
+    return in;
+}
+
+// Thin sf::Joystick wrapper. Returns movement-only PlayerInput (attack always false).
+//   id — joystick index (0 or 1)
+// If id is not connected, returns all-false. No prevAttack state needed.
+inline PlayerInput pollJoystick(unsigned id, float deadzone = kJoyDeadzone) {
+    if (!sf::Joystick::isConnected(id))
+        return {};
+    // LCOV_EXCL_START — sf::Joystick hardware calls; not reachable in headless CI
+    float x = sf::Joystick::getAxisPosition(id, sf::Joystick::X);
+    float y = sf::Joystick::getAxisPosition(id, sf::Joystick::Y);
+    float povX = sf::Joystick::getAxisPosition(id, sf::Joystick::PovX);
+    float povY = sf::Joystick::getAxisPosition(id, sf::Joystick::PovY);
+    return axisToInput(x, y, povX, povY, deadzone);
+    // LCOV_EXCL_STOP
+}

--- a/include/gamepad.h
+++ b/include/gamepad.h
@@ -31,7 +31,8 @@ inline PlayerInput axisToInput(float x, float y, float povX, float povY, float d
 //   id — joystick index (0 or 1)
 // If id is not connected, returns all-false. No prevAttack state needed.
 inline PlayerInput pollJoystick(unsigned id, float deadzone = kJoyDeadzone) {
-    // LCOV_EXCL_START — sf::Joystick hardware calls (incl. isConnected); not reachable in headless CI
+    // LCOV_EXCL_START — sf::Joystick hardware calls (incl. isConnected); not reachable in headless
+    // CI
     if (!sf::Joystick::isConnected(id))
         return {};
     float x = sf::Joystick::getAxisPosition(id, sf::Joystick::X);

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -408,21 +408,22 @@ void Game::processEvents() {
                 }
             }
             break;
-        // LCOV_EXCL_STOP
+        // JoystickMoved is entirely hardware-driven (never fires in headless CI), so the
+        // whole case stays inside this LCOV exclusion block.
         case sf::Event::JoystickMoved: {
             // Event-driven movement: SFML fires JoystickMoved when any axis moves,
             // including return-to-center. We ASSIGN (not OR) so bools clear when
             // the stick centers — mirrors keyboard KeyPressed/KeyReleased exactly.
             // Mode gates mirror handlePlayerInput; debug guard keeps harness deterministic.
+            // NOTE: pollJoystick reads all axes, so under simultaneous keyboard + (drifting)
+            // gamepad on one player the gamepad state wins — acceptable per the
+            // one-control-source-at-a-time contract.
             if (!m_debug.active()) {
                 unsigned id = event.joystickMove.joystickId;
                 // P1 (rocket): joystick 0 in LOCAL or HOST.
                 if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::HOST) {
                     if (id == 0) {
-                        // LCOV_EXCL_START — sf::Joystick hardware read; not reachable in headless
-                        // CI
                         PlayerInput mv = pollJoystick(id);
-                        // LCOV_EXCL_STOP
                         m_p1Up = mv.up;
                         m_p1Down = mv.down;
                         m_p1Left = mv.left;
@@ -435,10 +436,7 @@ void Game::processEvents() {
                     !m_ai) {
                     unsigned joyP2 = (m_networkMode == NetworkMode::CLIENT) ? 0u : 1u;
                     if (id == joyP2) {
-                        // LCOV_EXCL_START — sf::Joystick hardware read; not reachable in headless
-                        // CI
                         PlayerInput mv = pollJoystick(id);
-                        // LCOV_EXCL_STOP
                         m_p2Up = mv.up;
                         m_p2Down = mv.down;
                         m_p2Left = mv.left;
@@ -448,6 +446,7 @@ void Game::processEvents() {
             }
             break;
         }
+        // LCOV_EXCL_STOP
         default:
             break;
         }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -214,6 +214,23 @@ std::tuple<int, int, float, int, bool, bool> Game::run() {
 
         processEvents();
 
+        // ── Gamepad movement: fresh axis poll → OR-merge into keyboard bools ─
+        // Single guard keeps harness/debug runs deterministic (no joystick calls).
+        if (!m_debug.active()) {
+            pollGamepadInput();
+            m_p1Up |= m_joyInput[0].up;
+            m_p1Down |= m_joyInput[0].down;
+            m_p1Left |= m_joyInput[0].left;
+            m_p1Right |= m_joyInput[0].right;
+
+            if (!m_ai) {
+                m_p2Up |= m_joyInput[1].up;
+                m_p2Down |= m_joyInput[1].down;
+                m_p2Left |= m_joyInput[1].left;
+                m_p2Right |= m_joyInput[1].right;
+            }
+        }
+
         // ── Network I/O: once per iteration (not per step) ───────────────────
         if (m_networkManager) {
             handleNetworkCommunication(sf::seconds(iterDt));
@@ -335,6 +352,30 @@ void Game::applyPlayerInput(const PlayerInput& in) {
     applyInputTo(m_p2Up, m_p2Left, m_p2Down, m_p2Right, m_p2Attack, in);
 }
 
+// ── pollGamepadInput ──────────────────────────────────────────────────────────
+// Called only from run()'s !m_debug.active() gate — no inner debug guard needed.
+
+void Game::pollGamepadInput() {
+    // LCOV_EXCL_START — sf::Joystick hardware calls; not reachable in headless CI
+
+    // P1 (rocket) — joystick 0 in LOCAL and HOST modes.
+    if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::HOST) {
+        m_joyInput[0] = pollJoystick(0);
+    } else {
+        m_joyInput[0] = {};
+    }
+
+    // P2 (robot) — joystick 1 in LOCAL, joystick 0 in CLIENT.
+    // Gated off when AI is driving P2.
+    if ((m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::CLIENT) && !m_ai) {
+        unsigned joyId = (m_networkMode == NetworkMode::CLIENT) ? 0u : 1u;
+        m_joyInput[1] = pollJoystick(joyId);
+    } else {
+        m_joyInput[1] = {};
+    }
+    // LCOV_EXCL_STOP
+}
+
 void Game::captureIfDue() {
     if (m_debug.screenshotEvery <= 0)
         return;
@@ -388,6 +429,20 @@ void Game::processEvents() {
                     background.stop();
                     m_quitToMenu = true;
                     m_window.close();
+                }
+            }
+            break;
+        case sf::Event::JoystickButtonPressed:
+            if (!m_debug.active() && event.joystickButton.button == kAttackButton) {
+                if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::HOST) {
+                    if (event.joystickButton.joystickId == 0)
+                        m_p1Attack = true;
+                }
+                if ((m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::CLIENT) &&
+                    !m_ai) {
+                    unsigned joyP2 = (m_networkMode == NetworkMode::CLIENT) ? 0u : 1u;
+                    if (event.joystickButton.joystickId == joyP2)
+                        m_p2Attack = true;
                 }
             }
             break;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -214,23 +214,6 @@ std::tuple<int, int, float, int, bool, bool> Game::run() {
 
         processEvents();
 
-        // ── Gamepad movement: fresh axis poll → OR-merge into keyboard bools ─
-        // Single guard keeps harness/debug runs deterministic (no joystick calls).
-        if (!m_debug.active()) {
-            pollGamepadInput();
-            m_p1Up |= m_joyInput[0].up;
-            m_p1Down |= m_joyInput[0].down;
-            m_p1Left |= m_joyInput[0].left;
-            m_p1Right |= m_joyInput[0].right;
-
-            if (!m_ai) {
-                m_p2Up |= m_joyInput[1].up;
-                m_p2Down |= m_joyInput[1].down;
-                m_p2Left |= m_joyInput[1].left;
-                m_p2Right |= m_joyInput[1].right;
-            }
-        }
-
         // ── Network I/O: once per iteration (not per step) ───────────────────
         if (m_networkManager) {
             handleNetworkCommunication(sf::seconds(iterDt));
@@ -352,30 +335,6 @@ void Game::applyPlayerInput(const PlayerInput& in) {
     applyInputTo(m_p2Up, m_p2Left, m_p2Down, m_p2Right, m_p2Attack, in);
 }
 
-// ── pollGamepadInput ──────────────────────────────────────────────────────────
-// Called only from run()'s !m_debug.active() gate — no inner debug guard needed.
-
-void Game::pollGamepadInput() {
-    // LCOV_EXCL_START — sf::Joystick hardware calls; not reachable in headless CI
-
-    // P1 (rocket) — joystick 0 in LOCAL and HOST modes.
-    if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::HOST) {
-        m_joyInput[0] = pollJoystick(0);
-    } else {
-        m_joyInput[0] = {};
-    }
-
-    // P2 (robot) — joystick 1 in LOCAL, joystick 0 in CLIENT.
-    // Gated off when AI is driving P2.
-    if ((m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::CLIENT) && !m_ai) {
-        unsigned joyId = (m_networkMode == NetworkMode::CLIENT) ? 0u : 1u;
-        m_joyInput[1] = pollJoystick(joyId);
-    } else {
-        m_joyInput[1] = {};
-    }
-    // LCOV_EXCL_STOP
-}
-
 void Game::captureIfDue() {
     if (m_debug.screenshotEvery <= 0)
         return;
@@ -433,6 +392,9 @@ void Game::processEvents() {
             }
             break;
         case sf::Event::JoystickButtonPressed:
+            // NOTE: gamepad attack fires on button PRESS; P2 keyboard attack fires on
+            // key RELEASE (see handlePlayerInput — m_p2Attack = !isDown). Pre-existing
+            // discrepancy tracked in issue #37.
             if (!m_debug.active() && event.joystickButton.button == kAttackButton) {
                 if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::HOST) {
                     if (event.joystickButton.joystickId == 0)
@@ -447,6 +409,45 @@ void Game::processEvents() {
             }
             break;
         // LCOV_EXCL_STOP
+        case sf::Event::JoystickMoved: {
+            // Event-driven movement: SFML fires JoystickMoved when any axis moves,
+            // including return-to-center. We ASSIGN (not OR) so bools clear when
+            // the stick centers — mirrors keyboard KeyPressed/KeyReleased exactly.
+            // Mode gates mirror handlePlayerInput; debug guard keeps harness deterministic.
+            if (!m_debug.active()) {
+                unsigned id = event.joystickMove.joystickId;
+                // P1 (rocket): joystick 0 in LOCAL or HOST.
+                if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::HOST) {
+                    if (id == 0) {
+                        // LCOV_EXCL_START — sf::Joystick hardware read; not reachable in headless
+                        // CI
+                        PlayerInput mv = pollJoystick(id);
+                        // LCOV_EXCL_STOP
+                        m_p1Up = mv.up;
+                        m_p1Down = mv.down;
+                        m_p1Left = mv.left;
+                        m_p1Right = mv.right;
+                    }
+                }
+                // P2 (robot): joystick 1 in LOCAL, joystick 0 in CLIENT.
+                // Gated off when AI is driving P2.
+                if ((m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::CLIENT) &&
+                    !m_ai) {
+                    unsigned joyP2 = (m_networkMode == NetworkMode::CLIENT) ? 0u : 1u;
+                    if (id == joyP2) {
+                        // LCOV_EXCL_START — sf::Joystick hardware read; not reachable in headless
+                        // CI
+                        PlayerInput mv = pollJoystick(id);
+                        // LCOV_EXCL_STOP
+                        m_p2Up = mv.up;
+                        m_p2Down = mv.down;
+                        m_p2Left = mv.left;
+                        m_p2Right = mv.right;
+                    }
+                }
+            }
+            break;
+        }
         default:
             break;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(dungeon_tests
     test_loopback.cpp
     test_unit.cpp
     test_ai.cpp
+    test_gamepad.cpp
 )
 target_link_libraries(dungeon_tests PRIVATE dungeon_lib Catch2::Catch2WithMain)
 

--- a/tests/test_gamepad.cpp
+++ b/tests/test_gamepad.cpp
@@ -1,0 +1,124 @@
+// Unit tests for axisToInput (pure function, no hardware, no window).
+// pollJoystick is not tested here — it calls sf::Joystick and requires hardware.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "gamepad.h"
+
+TEST_CASE("axisToInput: all zeros, deadzone 25 → all-false", "[gamepad]") {
+    PlayerInput in = axisToInput(0.f, 0.f, 0.f, 0.f, 25.f);
+    CHECK(!in.up);
+    CHECK(!in.down);
+    CHECK(!in.left);
+    CHECK(!in.right);
+    CHECK(!in.attack);
+}
+
+TEST_CASE("axisToInput: axis exactly at deadzone → no direction", "[gamepad]") {
+    // |x| == deadzone: condition is x > deadzone, so exactly equal → no fire
+    PlayerInput in = axisToInput(25.f, 0.f, 0.f, 0.f, 25.f);
+    CHECK(!in.right);
+    CHECK(!in.left);
+}
+
+TEST_CASE("axisToInput: axis just above deadzone → direction fires", "[gamepad]") {
+    PlayerInput in = axisToInput(25.01f, 0.f, 0.f, 0.f, 25.f);
+    CHECK(in.right);
+    CHECK(!in.left);
+}
+
+TEST_CASE("axisToInput: left-stick four directions", "[gamepad]") {
+    SECTION("right") {
+        PlayerInput in = axisToInput(80.f, 0.f, 0.f, 0.f, 25.f);
+        CHECK(in.right);
+        CHECK(!in.left);
+        CHECK(!in.up);
+        CHECK(!in.down);
+    }
+    SECTION("left") {
+        PlayerInput in = axisToInput(-80.f, 0.f, 0.f, 0.f, 25.f);
+        CHECK(in.left);
+        CHECK(!in.right);
+        CHECK(!in.up);
+        CHECK(!in.down);
+    }
+    SECTION("down (+y)") {
+        PlayerInput in = axisToInput(0.f, 80.f, 0.f, 0.f, 25.f);
+        CHECK(in.down);
+        CHECK(!in.up);
+        CHECK(!in.left);
+        CHECK(!in.right);
+    }
+    SECTION("up (-y)") {
+        PlayerInput in = axisToInput(0.f, -80.f, 0.f, 0.f, 25.f);
+        CHECK(in.up);
+        CHECK(!in.down);
+        CHECK(!in.left);
+        CHECK(!in.right);
+    }
+}
+
+TEST_CASE("axisToInput: POV hat four directions", "[gamepad]") {
+    SECTION("pov right") {
+        PlayerInput in = axisToInput(0.f, 0.f, 100.f, 0.f, 25.f);
+        CHECK(in.right);
+        CHECK(!in.left);
+    }
+    SECTION("pov left") {
+        PlayerInput in = axisToInput(0.f, 0.f, -100.f, 0.f, 25.f);
+        CHECK(in.left);
+        CHECK(!in.right);
+    }
+    SECTION("pov down (+povY)") {
+        PlayerInput in = axisToInput(0.f, 0.f, 0.f, 100.f, 25.f);
+        CHECK(in.down);
+        CHECK(!in.up);
+    }
+    SECTION("pov up (-povY)") {
+        PlayerInput in = axisToInput(0.f, 0.f, 0.f, -100.f, 25.f);
+        CHECK(in.up);
+        CHECK(!in.down);
+    }
+}
+
+TEST_CASE("axisToInput: OR-combine same direction (stick + POV both right)", "[gamepad]") {
+    PlayerInput in = axisToInput(80.f, 0.f, 100.f, 0.f, 25.f);
+    CHECK(in.right);
+    CHECK(!in.left);
+}
+
+TEST_CASE("axisToInput: OR-combine opposing directions (stick right, pov left)", "[gamepad]") {
+    // Both right and left are set; they cancel in update()'s movement code — pin the behavior.
+    PlayerInput in = axisToInput(50.f, 0.f, -50.f, 0.f, 25.f);
+    CHECK(in.right);
+    CHECK(in.left);
+}
+
+TEST_CASE("axisToInput: diagonal (right + up)", "[gamepad]") {
+    PlayerInput in = axisToInput(80.f, -80.f, 0.f, 0.f, 25.f);
+    CHECK(in.right);
+    CHECK(in.up);
+    CHECK(!in.left);
+    CHECK(!in.down);
+}
+
+TEST_CASE("axisToInput: extreme values ±100", "[gamepad]") {
+    PlayerInput pos = axisToInput(100.f, 100.f, 100.f, 100.f, 25.f);
+    CHECK(pos.right);
+    CHECK(pos.down);
+
+    PlayerInput neg = axisToInput(-100.f, -100.f, -100.f, -100.f, 25.f);
+    CHECK(neg.left);
+    CHECK(neg.up);
+}
+
+TEST_CASE("axisToInput: zero deadzone, zero value → right=false (> not >=)", "[gamepad]") {
+    PlayerInput in = axisToInput(0.f, 0.f, 0.f, 0.f, 0.f);
+    CHECK(!in.right);
+}
+
+TEST_CASE("axisToInput: zero deadzone, small positive → right=true", "[gamepad]") {
+    // Pins > vs >=: with deadzone=0 a tiny positive value must fire.
+    PlayerInput in = axisToInput(0.001f, 0.f, 0.f, 0.f, 0.f);
+    CHECK(in.right);
+}

--- a/tests/test_gamepad.cpp
+++ b/tests/test_gamepad.cpp
@@ -1,11 +1,11 @@
 // Unit tests for axisToInput (pure function, no hardware, no window).
-// pollJoystick is not tested here — it calls sf::Joystick and requires hardware.
+// pollJoystick is not tested here - it calls sf::Joystick and requires hardware.
 
 #include <catch2/catch_test_macros.hpp>
 
 #include "gamepad.h"
 
-TEST_CASE("axisToInput: all zeros, deadzone 25 → all-false", "[gamepad]") {
+TEST_CASE("axisToInput: all zeros, deadzone 25 -> all-false", "[gamepad]") {
     PlayerInput in = axisToInput(0.f, 0.f, 0.f, 0.f, 25.f);
     CHECK(!in.up);
     CHECK(!in.down);
@@ -14,14 +14,14 @@ TEST_CASE("axisToInput: all zeros, deadzone 25 → all-false", "[gamepad]") {
     CHECK(!in.attack);
 }
 
-TEST_CASE("axisToInput: axis exactly at deadzone → no direction", "[gamepad]") {
-    // |x| == deadzone: condition is x > deadzone, so exactly equal → no fire
+TEST_CASE("axisToInput: axis exactly at deadzone -> no direction", "[gamepad]") {
+    // |x| == deadzone: condition is x > deadzone, so exactly equal -> no fire
     PlayerInput in = axisToInput(25.f, 0.f, 0.f, 0.f, 25.f);
     CHECK(!in.right);
     CHECK(!in.left);
 }
 
-TEST_CASE("axisToInput: axis just above deadzone → direction fires", "[gamepad]") {
+TEST_CASE("axisToInput: axis just above deadzone -> direction fires", "[gamepad]") {
     PlayerInput in = axisToInput(25.01f, 0.f, 0.f, 0.f, 25.f);
     CHECK(in.right);
     CHECK(!in.left);
@@ -88,7 +88,7 @@ TEST_CASE("axisToInput: OR-combine same direction (stick + POV both right)", "[g
 }
 
 TEST_CASE("axisToInput: OR-combine opposing directions (stick right, pov left)", "[gamepad]") {
-    // Both right and left are set; they cancel in update()'s movement code — pin the behavior.
+    // Both right and left are set; they cancel in update()'s movement code - pin the behavior.
     PlayerInput in = axisToInput(50.f, 0.f, -50.f, 0.f, 25.f);
     CHECK(in.right);
     CHECK(in.left);
@@ -102,7 +102,7 @@ TEST_CASE("axisToInput: diagonal (right + up)", "[gamepad]") {
     CHECK(!in.down);
 }
 
-TEST_CASE("axisToInput: extreme values ±100", "[gamepad]") {
+TEST_CASE("axisToInput: extreme values +/-100", "[gamepad]") {
     PlayerInput pos = axisToInput(100.f, 100.f, 100.f, 100.f, 25.f);
     CHECK(pos.right);
     CHECK(pos.down);
@@ -112,13 +112,43 @@ TEST_CASE("axisToInput: extreme values ±100", "[gamepad]") {
     CHECK(neg.up);
 }
 
-TEST_CASE("axisToInput: zero deadzone, zero value → right=false (> not >=)", "[gamepad]") {
+TEST_CASE("axisToInput: zero deadzone, zero value -> right=false (> not >=)", "[gamepad]") {
     PlayerInput in = axisToInput(0.f, 0.f, 0.f, 0.f, 0.f);
     CHECK(!in.right);
 }
 
-TEST_CASE("axisToInput: zero deadzone, small positive → right=true", "[gamepad]") {
+TEST_CASE("axisToInput: zero deadzone, small positive -> right=true", "[gamepad]") {
     // Pins > vs >=: with deadzone=0 a tiny positive value must fire.
     PlayerInput in = axisToInput(0.001f, 0.f, 0.f, 0.f, 0.f);
     CHECK(in.right);
+}
+
+TEST_CASE("axisToInput: negative boundary pin, value at -deadzone -> no direction", "[gamepad]") {
+    // Mirrors the positive boundary: -25 with deadzone 25 must NOT fire left or up.
+    PlayerInput in = axisToInput(-25.f, -25.f, -25.f, -25.f, 25.f);
+    CHECK(!in.left);
+    CHECK(!in.up);
+    CHECK(!in.right);
+    CHECK(!in.down);
+    CHECK(!in.attack);
+}
+
+TEST_CASE("axisToInput: attack is always false (movement-only function)", "[gamepad]") {
+    // axisToInput is movement-only; attack is event-driven via JoystickButtonPressed.
+    SECTION("directional input") {
+        PlayerInput in = axisToInput(80.f, -80.f, 0.f, 0.f, 25.f);
+        CHECK(in.right);
+        CHECK(in.up);
+        CHECK(!in.attack);
+    }
+    SECTION("POV input") {
+        PlayerInput in = axisToInput(0.f, 0.f, 100.f, -100.f, 25.f);
+        CHECK(in.right);
+        CHECK(in.up);
+        CHECK(!in.attack);
+    }
+    SECTION("extreme values") {
+        PlayerInput in = axisToInput(100.f, 100.f, 100.f, 100.f, 25.f);
+        CHECK(!in.attack);
+    }
 }


### PR DESCRIPTION
Closes #29. Adds gamepad as a first-class control source without special-casing the update loop — everything flows through the `PlayerInput` invariant.

- **Pure mapping** (`include/gamepad.h`): `axisToInput(...)` maps analog stick + D-pad POV (with deadzone) to movement bools — window-free unit-testable; `pollJoystick()` is a thin `sf::Joystick` wrapper.
- **Movement**: polled + OR-merged into the per-player input in `run()` after `processEvents()` and **before** `handleNetworkCommunication()`, so CLIENT gamepad input reaches the host. Single `!m_debug.active()` gate; mode gates mirror the keyboard exactly (P1: LOCAL/HOST; P2: (LOCAL||CLIENT) && !m_ai; joystick 0→P1, 1→P2, CLIENT's local pad → P2).
- **Attack**: event-based via `sf::Event::JoystickButtonPressed` (like keyboard `KeyPressed`) — never dropped, survives the network-send ordering, no reconnect glitch.
- Two-pad local play; hot-plug fallback to keyboard. Gamepad **remapping / settings-UI is deferred** (a follow-up); a sensible fixed default mapping is documented.

**Validation:** window-free — 0-warning `-Werror` build, 105/105 unit tests (+11 gamepad mapping tests), clang-format v18 clean. Real-controller feel is a documented manual playtest (no hardware in CI). Plan converged over 2 review rounds (caught + fixed a CLIENT input-ordering bug).
