### PR TITLE
Migrate SFML 2.6.2 → 3.0.2 (#25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/build/_deps
-          key: ${{ runner.os }}-sfmldeps-v1-${{ hashFiles('CMakeLists.txt', '.github/workflows/ci.yml') }}
-          restore-keys: ${{ runner.os }}-sfmldeps-v1-
+          key: ${{ runner.os }}-sfmldeps-v2-${{ hashFiles('CMakeLists.txt', '.github/workflows/ci.yml') }}
+          restore-keys: ${{ runner.os }}-sfmldeps-v2-
 
       - name: Configure
         run: |
@@ -99,8 +99,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/build/_deps
-          key: ${{ runner.os }}-sfmldeps-v1-${{ hashFiles('CMakeLists.txt', '.github/workflows/ci.yml') }}
-          restore-keys: ${{ runner.os }}-sfmldeps-v1-
+          key: ${{ runner.os }}-sfmldeps-v2-${{ hashFiles('CMakeLists.txt', '.github/workflows/ci.yml') }}
+          restore-keys: ${{ runner.os }}-sfmldeps-v2-
 
       - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DDUNGEON_BUILD_TESTS=ON
@@ -123,8 +123,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/build/_deps
-          key: ${{ runner.os }}-sfmldeps-v1-${{ hashFiles('CMakeLists.txt', '.github/workflows/ci.yml') }}
-          restore-keys: ${{ runner.os }}-sfmldeps-v1-
+          key: ${{ runner.os }}-sfmldeps-v2-${{ hashFiles('CMakeLists.txt', '.github/workflows/ci.yml') }}
+          restore-keys: ${{ runner.os }}-sfmldeps-v2-
 
       - name: Configure
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/build/_deps
-          key: ${{ runner.os }}-sfmldeps-release-v1-${{ hashFiles('CMakeLists.txt', '.github/workflows/release.yml') }}
-          restore-keys: ${{ runner.os }}-sfmldeps-release-v1-
+          key: ${{ runner.os }}-sfmldeps-release-v2-${{ hashFiles('CMakeLists.txt', '.github/workflows/release.yml') }}
+          restore-keys: ${{ runner.os }}-sfmldeps-release-v2-
 
       - name: Configure (Windows)
         if: matrix.os == 'windows-latest'
@@ -88,31 +88,45 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path dungeon-game-windows
           Copy-Item build/Release/dungeon_game.exe dungeon-game-windows/
-          Copy-Item build/Release/openal32.dll     dungeon-game-windows/
+          # SFML 3 uses miniaudio internally — no openal32.dll is shipped/needed.
           Copy-Item -Recurse build/Release/assets  dungeon-game-windows/
 
       - name: Stage (macOS)
         if: matrix.os == 'macos-latest'
         run: |
+          # TODO #25 — re-verify framework bundling for SFML 3.
+          # SFML 2.6.2's extlibs/libs-osx/Frameworks/ (freetype/OpenAL/vorbis/FLAC) does
+          # NOT exist in SFML 3: with BUILD_SHARED_LIBS=OFF + FetchContent, SFML 3 static-
+          # links freetype and uses miniaudio (no OpenAL framework), so typically nothing
+          # needs bundling. Inspect otool -L below and bundle any non-system dylib before
+          # relying on this zip. Gate merge on a workflow_dispatch dry-run of this workflow:
+          # download the macos zip and run the bundled binary on a clean path.
           mkdir -p dungeon-game-macos/Frameworks
           cp build/dungeon_game dungeon-game-macos/
           cp -R build/assets    dungeon-game-macos/
-          # SFML 2.6.2 on macOS does NOT static-link its third-party libs — it links
-          # bundled frameworks via @rpath (pointed at the build tree). Bundle those
-          # frameworks next to the binary and repoint the rpath so the zip is portable.
-          fwsrc=build/_deps/sfml-src/extlibs/libs-osx/Frameworks
-          for fw in freetype OpenAL vorbisenc vorbisfile vorbis ogg FLAC; do
-            cp -R "$fwsrc/$fw.framework" dungeon-game-macos/Frameworks/
-          done
           bin=dungeon-game-macos/dungeon_game
-          old_rpath=$(otool -l "$bin" | awk '$1=="path"{print $2; exit}')
-          [ -n "$old_rpath" ] && install_name_tool -delete_rpath "$old_rpath" "$bin"
-          install_name_tool -add_rpath @executable_path/Frameworks "$bin"
-          # Sanity: the executable-relative rpath must be present and the stale
-          # build-tree rpath (…/libs-osx/…) must be gone, else the zip won't launch.
-          rpaths=$(otool -l "$bin" | awk '$1=="path"{print $2}')
-          echo "$rpaths" | grep -qx "@executable_path/Frameworks" || { echo "rpath fix missing"; exit 1; }
-          echo "$rpaths" | grep -q "libs-osx" && { echo "stale build-tree rpath remains"; exit 1; } || true
+          echo "== otool -L $bin =="
+          otool -L "$bin"
+          # Copy every non-system dylib the binary references into Frameworks/ and repoint.
+          bundled=0
+          while read -r dylib; do
+            case "$dylib" in
+              /usr/lib/*|/System/*|@rpath/*|@executable_path/*|"") continue ;;
+            esac
+            if [ -f "$dylib" ]; then
+              cp "$dylib" dungeon-game-macos/Frameworks/
+              base=$(basename "$dylib")
+              install_name_tool -change "$dylib" "@executable_path/Frameworks/$base" "$bin"
+              bundled=$((bundled+1))
+            fi
+          done < <(otool -L "$bin" | tail -n +2 | awk '{print $1}')
+          if [ "$bundled" -gt 0 ]; then
+            install_name_tool -add_rpath @executable_path/Frameworks "$bin" || true
+            echo "Bundled $bundled non-system dylib(s)."
+          else
+            rmdir dungeon-game-macos/Frameworks 2>/dev/null || true
+            echo "No non-system dylibs to bundle (SFML 3 static link)."
+          fi
 
       - name: Stage (Linux)
         if: matrix.os == 'ubuntu-latest'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ single-player AI opponent (Easy/Medium/Hard), and a scripted replay/debug harnes
 
 ## Build, run, test
 
-The build system is **CMake** (≥3.16). SFML 2.6.2 is fetched and pinned via `FetchContent`, so
-no system SFML install is required (a `find_package` fallback is used if a compatible SFML 2 is
+The build system is **CMake** (≥3.16). SFML 3.0.2 is fetched and pinned via `FetchContent`, so
+no system SFML install is required (a `find_package` fallback is used if a compatible SFML 3 is
 already present). Full details in [docs/building.md](docs/building.md).
 
 ```bash
@@ -57,9 +57,9 @@ The load-bearing pieces:
 
 ## Design decisions (don't "fix" these without reason)
 
-- **SFML pinned at 2.6.2 via FetchContent**, not the system package. Reproducible across
-  machines/CI and matches the SFML 2.x API the code uses. A full SFML 3 migration is a separate,
-  out-of-scope effort.
+- **SFML pinned at 3.0.2 via FetchContent**, not the system package. Reproducible across
+  machines/CI and matches the SFML 3.x API the code uses. Do not install a system SFML 3
+  locally — it would make `find_package` skip FetchContent and diverge from CI.
 - **`PlayerInput` is the single input abstraction.** Local input, network packets, the AI
   opponent, and the replay/debug harness all produce a `PlayerInput` per frame that flows through
   one code path — do not special-case per-mode behavior in the update loop.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 # ── SFML: fast-path via find_package, fallback to FetchContent ──────────────
-find_package(SFML 2.5 COMPONENTS graphics window system audio network QUIET)
+find_package(SFML 3 COMPONENTS Graphics Window System Audio Network QUIET)
 if(NOT SFML_FOUND)
     include(FetchContent)
     set(SFML_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
@@ -21,7 +21,7 @@ if(NOT SFML_FOUND)
     FetchContent_Declare(
         SFML
         GIT_REPOSITORY https://github.com/SFML/SFML.git
-        GIT_TAG        2.6.2
+        GIT_TAG        3.0.2
         GIT_SHALLOW    TRUE
     )
     FetchContent_MakeAvailable(SFML)
@@ -45,11 +45,11 @@ add_library(dungeon_lib STATIC
 target_include_directories(dungeon_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 target_link_libraries(dungeon_lib PUBLIC
-    sfml-graphics
-    sfml-window
-    sfml-system
-    sfml-audio
-    sfml-network
+    SFML::Graphics
+    SFML::Window
+    SFML::System
+    SFML::Audio
+    SFML::Network
 )
 
 # ── dungeon_game executable ──────────────────────────────────────────────────
@@ -80,14 +80,6 @@ add_custom_command(TARGET dungeon_game POST_BUILD
         $<TARGET_FILE_DIR:dungeon_game>/assets
     COMMENT "Copying assets/ to output directory"
 )
-
-if(WIN32 AND DEFINED sfml_SOURCE_DIR)
-    add_custom_command(TARGET dungeon_game POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            ${sfml_SOURCE_DIR}/extlibs/bin/x64/openal32.dll
-            $<TARGET_FILE_DIR:dungeon_game>
-        COMMENT "Copying openal32.dll next to dungeon_game.exe")
-endif()
 
 # ── Coverage instrumentation (clang only; propagated PUBLIC so test binaries
 #    that link dungeon_lib also get the flags) ─────────────────────────────────

--- a/docs/building.md
+++ b/docs/building.md
@@ -14,10 +14,16 @@
 
 ## SFML
 
-SFML **2.6.2** is pinned and built via CMake `FetchContent`, so a system SFML install is **not**
-required and every machine/CI runner builds against the same version. If a compatible SFML 2 is
-already discoverable, a `find_package(SFML 2 ...)` fast path is used instead to skip the source
-build. (A full SFML 3 migration is intentionally out of scope — the code targets the SFML 2.x API.)
+SFML **3.0.2** is pinned and built via CMake `FetchContent`, so a system SFML install is **not**
+required and every machine/CI runner builds against the same version. If a compatible SFML 3 is
+already discoverable, a `find_package(SFML 3 ...)` fast path is used instead to skip the source
+build. The code targets the SFML 3.x API.
+
+> **Keep local and CI identical:** do **not** `brew install sfml` (or otherwise install a
+> system SFML 3). If `find_package(SFML 3 ...)` finds a system copy it will take the fast path
+> and skip FetchContent, so the dev box would build against a different SFML than CI (which has
+> no system SFML and always uses the pinned FetchContent build). With no system SFML installed,
+> both use the identical pinned 3.0.2.
 
 The first configure fetches and compiles SFML, which takes a few minutes; subsequent builds reuse
 the cached build tree.
@@ -52,9 +58,8 @@ cmake --build build --config Release
 build\Release\dungeon_game.exe
 ```
 
-SFML 2.6.2 is fetched automatically on the first configure. The build system copies `openal32.dll`
-from the fetched SFML tree next to `dungeon_game.exe`, so the game runs without a separate OpenAL
-install. Assets are also copied next to the binary.
+SFML 3.0.2 is fetched automatically on the first configure. SFML 3 uses miniaudio internally, so
+no separate OpenAL DLL is needed next to the executable. Assets are copied next to the binary.
 
 ## Tests
 

--- a/include/AnimatedGameObject.h
+++ b/include/AnimatedGameObject.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "GameObject.h"
+#include <optional>
 
 class AnimatedGameObject : public GameObject {
 public:
@@ -42,10 +43,11 @@ public:
     sf::FloatRect getGlobalBounds() const override;
 
 private:
-    sf::Sprite m_sprite;
+    std::optional<sf::Sprite> m_sprite;
     sf::Texture m_texture;
     std::string m_filename;
     bool m_valid = false;
+    int m_angle = 0;
     double xsize;
     double ysize;
     int howmanyx;

--- a/include/Game.h
+++ b/include/Game.h
@@ -16,6 +16,7 @@
 #include <SFML/Audio.hpp>
 #include <SFML/Graphics.hpp>
 #include <memory>
+#include <optional>
 #include <tuple>
 #include <vector>
 
@@ -60,7 +61,7 @@ private:
     void handlePlayerInput(sf::Keyboard::Key key, bool isDown);
     // check collision with walls or other objects
     bool collision(const GameObject& a, const GameObject& b);
-    bool collision(sf::Rect<float> a, const GameObject& b);
+    bool collision(sf::FloatRect a, const GameObject& b);
 
     // Fixed-timestep deterministic sim body.
     void simStep();
@@ -81,14 +82,14 @@ private:
     sf::SoundBuffer speedbuffer;
     sf::SoundBuffer slowbuffer;
     sf::SoundBuffer burnbuffer;
-    sf::Sound gong;
-    sf::Sound sword;
-    sf::Sound p2hit;
-    sf::Sound laser;
-    sf::Sound metal;
-    sf::Sound speed_up;
-    sf::Sound slow_down;
-    sf::Sound burn;
+    std::optional<sf::Sound> gong;
+    std::optional<sf::Sound> sword;
+    std::optional<sf::Sound> p2hit;
+    std::optional<sf::Sound> laser;
+    std::optional<sf::Sound> metal;
+    std::optional<sf::Sound> speed_up;
+    std::optional<sf::Sound> slow_down;
+    std::optional<sf::Sound> burn;
 
     sf::Music background;
 
@@ -101,11 +102,11 @@ private:
     sf::Font font;
     sf::Font tfont;
     sf::Font block;
-    sf::Text m_rocketScoreText;
-    sf::Text m_robotScoreText;
-    sf::Text timer;
-    sf::Text pause_text;
-    sf::Text info;
+    std::optional<sf::Text> m_rocketScoreText;
+    std::optional<sf::Text> m_robotScoreText;
+    std::optional<sf::Text> timer;
+    std::optional<sf::Text> pause_text;
+    std::optional<sf::Text> info;
 
     float m_speed = 1200.0f;
     float m_cooldownEnd = 0;

--- a/include/NetworkManager.h
+++ b/include/NetworkManager.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include <SFML/Network.hpp>
+#include <cstdint>
 #include <deque>
 #include <string>
 
 enum class NetworkMode { LOCAL, HOST, CLIENT };
 
-enum class MsgType : sf::Uint8 { Input = 1, State = 2 };
+enum class MsgType : std::uint8_t { Input = 1, State = 2 };
 
 struct PlayerInput {
     bool up = false;

--- a/include/RegularGameObject.h
+++ b/include/RegularGameObject.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "GameObject.h"
+#include <optional>
 
 class RegularGameObject : public GameObject {
 public:
@@ -40,7 +41,7 @@ public:
     sf::FloatRect getGlobalBounds() const override;
 
 private:
-    sf::Sprite m_sprite;
+    std::optional<sf::Sprite> m_sprite;
     sf::Texture m_texture;
     std::string m_filename;
     bool m_valid = false;

--- a/include/asset_load.h
+++ b/include/asset_load.h
@@ -9,7 +9,7 @@
 // sf::Music streams from disk so uses openFromFile; others use loadFromFile / .load().
 
 inline void loadOrThrow(sf::Font& f, const std::string& path) {
-    if (!f.loadFromFile(path))
+    if (!f.openFromFile(path))
         throw std::runtime_error("failed to load asset: " + path);
 }
 

--- a/include/gamepad.h
+++ b/include/gamepad.h
@@ -7,20 +7,20 @@ inline constexpr unsigned kAttackButton = 0;
 
 // Pure: maps raw joystick axis values to a movement-only PlayerInput.
 //
-//   x, y       — left-stick axes      (sf::Joystick::X / Y),    range [-100, 100]
-//   povX, povY — D-pad POV axes       (sf::Joystick::PovX / Y), same range
+//   x, y       — left-stick axes      (sf::Joystick::Axis::X / Y),    range [-100, 100]
+//   povX, povY — D-pad POV axes       (sf::Joystick::Axis::PovX / Y), same range
 //   deadzone   — absolute threshold; |value| <= deadzone → no input
 //
 // Directions: +x=right, -x=left, +y=down, -y=up (SFML 2 analog convention).
 // Left-stick and POV hat are OR-combined per direction.
-// NOTE: sf::Joystick::PovY is inverted on Windows XInput (+100=up, -100=down).
+// NOTE: sf::Joystick::Axis::PovY is inverted on Windows XInput (+100=up, -100=down).
 // If D-pad up/down are reversed on Windows, invert povY at the call site.
 // Attack is NOT part of this function — it is event-driven via JoystickButtonPressed.
 inline PlayerInput axisToInput(float x, float y, float povX, float povY, float deadzone) {
     PlayerInput in;
     in.right = (x > deadzone) || (povX > deadzone);
     in.left = (x < -deadzone) || (povX < -deadzone);
-    // NOTE: sf::Joystick::PovY is inverted on Windows XInput (+100=up, -100=down).
+    // NOTE: sf::Joystick::Axis::PovY is inverted on Windows XInput (+100=up, -100=down).
     // If D-pad up/down are reversed on Windows, pass -povY here.
     in.down = (y > deadzone) || (povY > deadzone);
     in.up = (y < -deadzone) || (povY < -deadzone);
@@ -35,10 +35,10 @@ inline PlayerInput pollJoystick(unsigned id, float deadzone = kJoyDeadzone) {
     // CI
     if (!sf::Joystick::isConnected(id))
         return {};
-    float x = sf::Joystick::getAxisPosition(id, sf::Joystick::X);
-    float y = sf::Joystick::getAxisPosition(id, sf::Joystick::Y);
-    float povX = sf::Joystick::getAxisPosition(id, sf::Joystick::PovX);
-    float povY = sf::Joystick::getAxisPosition(id, sf::Joystick::PovY);
+    float x = sf::Joystick::getAxisPosition(id, sf::Joystick::Axis::X);
+    float y = sf::Joystick::getAxisPosition(id, sf::Joystick::Axis::Y);
+    float povX = sf::Joystick::getAxisPosition(id, sf::Joystick::Axis::PovX);
+    float povY = sf::Joystick::getAxisPosition(id, sf::Joystick::Axis::PovY);
     return axisToInput(x, y, povX, povY, deadzone);
     // LCOV_EXCL_STOP
 }

--- a/include/geometry.h
+++ b/include/geometry.h
@@ -18,13 +18,13 @@ inline sf::FloatRect objectBounds(const GameObject& obj) {
 // for collision: intersects() relies on the raw negative-width form.
 inline sf::FloatRect normalizedBounds(const GameObject& obj) {
     sf::FloatRect r = objectBounds(obj);
-    if (r.width < 0.f) {
-        r.left += r.width;
-        r.width = -r.width;
+    if (r.size.x < 0.f) {
+        r.position.x += r.size.x;
+        r.size.x = -r.size.x;
     }
-    if (r.height < 0.f) {
-        r.top += r.height;
-        r.height = -r.height;
+    if (r.size.y < 0.f) {
+        r.position.y += r.size.y;
+        r.size.y = -r.size.y;
     }
     return r;
 }

--- a/include/geometry.h
+++ b/include/geometry.h
@@ -4,8 +4,8 @@
 
 // Build the axis-aligned bounding rect for a game object using its position,
 // width, height, and scale.  Note: scale.x may be negative (P2 default -1),
-// which produces a negative-width rect; SFML intersects() normalises it, and
-// that normalisation is load-bearing for hit detection — do not "fix" it.
+// which produces a negative-width rect; SFML findIntersection() normalises it,
+// and that normalisation is load-bearing for hit detection — do not "fix" it.
 inline sf::FloatRect objectBounds(const GameObject& obj) {
     return sf::FloatRect(obj.getPosition(), sf::Vector2f(obj.getWidth() * obj.getScale().x,
                                                          obj.getHeight() * obj.getScale().y));
@@ -15,7 +15,7 @@ inline sf::FloatRect objectBounds(const GameObject& obj) {
 // left-facing object has scale.x = -1, so objectBounds() yields a negative
 // width).  Use this wherever edge arithmetic needs a canonical left/top and
 // positive extent — e.g. the AI's nearest-edge distance math.  Do NOT use it
-// for collision: intersects() relies on the raw negative-width form.
+// for collision: findIntersection() relies on the raw negative-width form.
 inline sf::FloatRect normalizedBounds(const GameObject& obj) {
     sf::FloatRect r = objectBounds(obj);
     if (r.size.x < 0.f) {

--- a/include/key_bindings.h
+++ b/include/key_bindings.h
@@ -31,7 +31,7 @@ KeyBindings defaultBindings();
 KeyBindings loadBindings(std::istream& in);
 
 // Convert between SFML key enum and the string names used in controls.cfg.
-// keyFromName returns sf::Keyboard::Unknown for unrecognised names.
+// keyFromName returns sf::Keyboard::Key::Unknown for unrecognised names.
 // nameFromKey returns "Unknown" for keys not in the table.
 sf::Keyboard::Key keyFromName(const std::string& name);
 std::string nameFromKey(sf::Keyboard::Key key);

--- a/include/letterbox.h
+++ b/include/letterbox.h
@@ -14,14 +14,14 @@ inline sf::View makeLetterboxView(sf::Vector2f logicalSize, sf::Vector2u windowP
     if (windowAspect >= logicalAspect) {
         // Window is wider than logical canvas → pillarbox (black bars on sides).
         float vpW = logicalAspect / windowAspect;
-        viewport = sf::FloatRect((1.f - vpW) / 2.f, 0.f, vpW, 1.f);
+        viewport = sf::FloatRect({(1.f - vpW) / 2.f, 0.f}, {vpW, 1.f});
     } else {
         // Window is taller than logical canvas → letterbox (black bars top/bottom).
         float vpH = windowAspect / logicalAspect;
-        viewport = sf::FloatRect(0.f, (1.f - vpH) / 2.f, 1.f, vpH);
+        viewport = sf::FloatRect({0.f, (1.f - vpH) / 2.f}, {1.f, vpH});
     }
 
-    sf::View view(sf::FloatRect(0.f, 0.f, logicalSize.x, logicalSize.y));
+    sf::View view(sf::FloatRect({0.f, 0.f}, {logicalSize.x, logicalSize.y}));
     view.setViewport(viewport);
     return view;
 }

--- a/include/menu_layout.h
+++ b/include/menu_layout.h
@@ -56,7 +56,7 @@ struct ButtonSpec {
 // READY_TO_START:  START only (centered, no Back)
 // SETTINGS:        (empty — layout driven by settingsButtonSpecs)
 inline std::vector<ButtonSpec> menuButtonRects(MenuState state) {
-    const sf::FloatRect backRect{20.f, 20.f, 120.f, 38.f};
+    const sf::FloatRect backRect{{20.f, 20.f}, {120.f, 38.f}};
 
     if (state == MenuState::SETTINGS)
         return {};
@@ -64,20 +64,20 @@ inline std::vector<ButtonSpec> menuButtonRects(MenuState state) {
     if (state == MenuState::MAIN_MENU) {
         auto ys = stackedButtonCenters(kMenuH, kBtnH, kBtnGap, 6);
         return {
-            {{kMenuW / 2.f - kBtnW / 2.f, ys[0] - kBtnH / 2.f, kBtnW, kBtnH}, "1 PLAYER"},
-            {{kMenuW / 2.f - kBtnW / 2.f, ys[1] - kBtnH / 2.f, kBtnW, kBtnH}, "2 PLAYER"},
-            {{kMenuW / 2.f - kBtnW / 2.f, ys[2] - kBtnH / 2.f, kBtnW, kBtnH}, "HOST"},
-            {{kMenuW / 2.f - kBtnW / 2.f, ys[3] - kBtnH / 2.f, kBtnW, kBtnH}, "JOIN"},
-            {{kMenuW / 2.f - kBtnW / 2.f, ys[4] - kBtnH / 2.f, kBtnW, kBtnH}, "CONTROLS"},
-            {{kMenuW / 2.f - kBtnW / 2.f, ys[5] - kBtnH / 2.f, kBtnW, kBtnH}, "QUIT"},
+            {{{kMenuW / 2.f - kBtnW / 2.f, ys[0] - kBtnH / 2.f}, {kBtnW, kBtnH}}, "1 PLAYER"},
+            {{{kMenuW / 2.f - kBtnW / 2.f, ys[1] - kBtnH / 2.f}, {kBtnW, kBtnH}}, "2 PLAYER"},
+            {{{kMenuW / 2.f - kBtnW / 2.f, ys[2] - kBtnH / 2.f}, {kBtnW, kBtnH}}, "HOST"},
+            {{{kMenuW / 2.f - kBtnW / 2.f, ys[3] - kBtnH / 2.f}, {kBtnW, kBtnH}}, "JOIN"},
+            {{{kMenuW / 2.f - kBtnW / 2.f, ys[4] - kBtnH / 2.f}, {kBtnW, kBtnH}}, "CONTROLS"},
+            {{{kMenuW / 2.f - kBtnW / 2.f, ys[5] - kBtnH / 2.f}, {kBtnW, kBtnH}}, "QUIT"},
         };
     }
     if (state == MenuState::AI_DIFFICULTY) {
         auto ys = stackedButtonCenters(kMenuH, kBtnH, kBtnGap, 3);
         return {
-            {{kMenuW / 2.f - kBtnW / 2.f, ys[0] - kBtnH / 2.f, kBtnW, kBtnH}, "EASY"},
-            {{kMenuW / 2.f - kBtnW / 2.f, ys[1] - kBtnH / 2.f, kBtnW, kBtnH}, "MEDIUM"},
-            {{kMenuW / 2.f - kBtnW / 2.f, ys[2] - kBtnH / 2.f, kBtnW, kBtnH}, "HARD"},
+            {{{kMenuW / 2.f - kBtnW / 2.f, ys[0] - kBtnH / 2.f}, {kBtnW, kBtnH}}, "EASY"},
+            {{{kMenuW / 2.f - kBtnW / 2.f, ys[1] - kBtnH / 2.f}, {kBtnW, kBtnH}}, "MEDIUM"},
+            {{{kMenuW / 2.f - kBtnW / 2.f, ys[2] - kBtnH / 2.f}, {kBtnW, kBtnH}}, "HARD"},
             {backRect, "BACK"},
         };
     }
@@ -85,7 +85,7 @@ inline std::vector<ButtonSpec> menuButtonRects(MenuState state) {
         return {{backRect, "BACK"}};
     }
     // READY_TO_START
-    return {{{kMenuW / 2.f - kBtnW / 2.f, kMenuH / 2.f - kBtnH / 2.f, kBtnW, kBtnH}, "START"}};
+    return {{{{kMenuW / 2.f - kBtnW / 2.f, kMenuH / 2.f - kBtnH / 2.f}, {kBtnW, kBtnH}}, "START"}};
 }
 
 // Settings screen: 12 specs in fixed order.
@@ -94,7 +94,7 @@ inline std::vector<ButtonSpec> menuButtonRects(MenuState state) {
 // [10]   RESET TO DEFAULTS (centered)
 // [11]   BACK (top-left)
 inline std::vector<ButtonSpec> settingsButtonSpecs(const KeyBindings& b) {
-    const sf::FloatRect backRect{20.f, 20.f, 120.f, 38.f};
+    const sf::FloatRect backRect{{20.f, 20.f}, {120.f, 38.f}};
     const float rowY0 = 120.f;
     const float rowStep = kSettingsRowH + kSettingsRowGap;
     const float p1x = 256.f - kSettingsRowW / 2.f;
@@ -120,16 +120,18 @@ inline std::vector<ButtonSpec> settingsButtonSpecs(const KeyBindings& b) {
         std::string label =
             std::string(p1rows[i].action) + "  [" + nameFromKey(p1rows[i].key) + "]";
         specs.push_back(
-            {{p1x, rowY0 + static_cast<float>(i) * rowStep, kSettingsRowW, kSettingsRowH}, label});
+            {{{p1x, rowY0 + static_cast<float>(i) * rowStep}, {kSettingsRowW, kSettingsRowH}},
+             label});
     }
     for (int i = 0; i < 5; ++i) {
         std::string label =
             std::string(p2rows[i].action) + "  [" + nameFromKey(p2rows[i].key) + "]";
         specs.push_back(
-            {{p2x, rowY0 + static_cast<float>(i) * rowStep, kSettingsRowW, kSettingsRowH}, label});
+            {{{p2x, rowY0 + static_cast<float>(i) * rowStep}, {kSettingsRowW, kSettingsRowH}},
+             label});
     }
     // RESET
-    specs.push_back({{kMenuW / 2.f - kBtnW / 2.f, 400.f, kBtnW, kBtnH}, "RESET TO DEFAULTS"});
+    specs.push_back({{{kMenuW / 2.f - kBtnW / 2.f, 400.f}, {kBtnW, kBtnH}}, "RESET TO DEFAULTS"});
     // BACK
     specs.push_back({backRect, "BACK"});
 
@@ -143,7 +145,7 @@ inline sf::Vector2f settingsColumnHeaderPos(int col) { return {col == 0 ? 256.f 
 // Semi-transparent backing panel for HOST_WAITING and JOIN_INPUT text.
 // Spans y=78–498 on a 576-high canvas, covering all text positions.
 inline sf::FloatRect menuInfoPanelRect() {
-    return {(kMenuW - 560.f) / 2.f, (kMenuH - 420.f) / 2.f, 560.f, 420.f};
+    return {{(kMenuW - 560.f) / 2.f, (kMenuH - 420.f) / 2.f}, {560.f, 420.f}};
 }
 
 // Pause button geometry (game window: kGameW x kGameH from game_canvas.h).
@@ -151,5 +153,5 @@ inline sf::FloatRect menuInfoPanelRect() {
 inline sf::FloatRect pauseButtonRect(int index) {
     constexpr float w = 220.f, h = 55.f, gap = 16.f;
     float top = kGameH / 2.f - h - gap / 2.f + static_cast<float>(index) * (h + gap);
-    return {kGameW / 2.f - w / 2.f, top, w, h};
+    return {{kGameW / 2.f - w / 2.f, top}, {w, h}};
 }

--- a/include/screenshot.h
+++ b/include/screenshot.h
@@ -1,12 +1,13 @@
 #pragma once
 #include <SFML/Graphics.hpp>
+#include <iostream>
 #include <string>
 
 // LCOV_EXCL_START — requires a live RenderWindow; not testable headless
 inline void captureScreenshot(const sf::RenderWindow& w, const std::string& path) {
-    sf::Texture t;
-    t.create(w.getSize().x, w.getSize().y);
+    sf::Texture t(w.getSize());
     t.update(w);
-    t.copyToImage().saveToFile(path);
+    if (!t.copyToImage().saveToFile(path))
+        std::cerr << "captureScreenshot: failed to save " << path << "\n";
 }
 // LCOV_EXCL_STOP

--- a/include/sprite_anim.h
+++ b/include/sprite_anim.h
@@ -24,17 +24,18 @@ inline FrameResult advanceFrameRect(sf::IntRect rect, int curr, int nx, int ny, 
     if (curr < howmany) {
         int check = curr % nx;
         if (check == 0) {
-            rect = sf::IntRect(0, rect.top + rect.height, (int)std::floor(xsize / (double)nx),
-                               (int)std::floor(ysize / (double)ny));
+            rect = sf::IntRect(
+                {0, rect.position.y + rect.size.y},
+                {(int)std::floor(xsize / (double)nx), (int)std::floor(ysize / (double)ny)});
         } else {
             int h = (int)std::floor(ysize / (double)ny);
-            rect = sf::IntRect(rect.left + rect.width, ((int)std::ceil(curr / nx)) * h, rect.width,
-                               (int)(ysize / ny));
+            rect = sf::IntRect({rect.position.x + rect.size.x, ((int)std::ceil(curr / nx)) * h},
+                               {rect.size.x, (int)(ysize / ny)});
         }
         curr++;
     } else {
-        rect = sf::IntRect(0, 0, (int)std::floor(xsize / (double)nx),
-                           (int)std::floor(ysize / (double)ny));
+        rect = sf::IntRect(
+            {0, 0}, {(int)std::floor(xsize / (double)nx), (int)std::floor(ysize / (double)ny)});
         curr = 1;
     }
     return {rect, curr};

--- a/src/AnimatedGameObject.cpp
+++ b/src/AnimatedGameObject.cpp
@@ -48,7 +48,8 @@ void AnimatedGameObject::update(float Tsec) {
         auto res = advanceFrameRect(rect, curr, howmanyx, howmanyy, howmany, xsize, ysize);
         rect = res.rect;
         curr = res.curr;
-        m_sprite->setTextureRect(rect);
+        if (m_sprite)
+            m_sprite->setTextureRect(rect);
     }
 }
 
@@ -100,7 +101,14 @@ sf::Vector2f AnimatedGameObject::getScale() const {
         return sf::Vector2f(0, 0);
 }
 
-void AnimatedGameObject::changeValid(bool a) { m_valid = a; }
+void AnimatedGameObject::changeValid(bool a) {
+    m_valid = a;
+    // SFML 3's sf::Sprite has no default ctor; keep m_valid ⇒ m_sprite live so the
+    // m_valid-guarded mutators never dereference an empty optional (see
+    // RegularGameObject::changeValid).
+    if (a && !m_sprite)
+        m_sprite.emplace(m_texture);
+}
 
 bool AnimatedGameObject::isValid() { return m_valid; }
 

--- a/src/AnimatedGameObject.cpp
+++ b/src/AnimatedGameObject.cpp
@@ -15,7 +15,7 @@ AnimatedGameObject::AnimatedGameObject() {
 }
 
 AnimatedGameObject::AnimatedGameObject(double x, double y, int nx, int ny, int n, int angle) {
-    m_sprite.setRotation(angle);
+    m_angle = angle;
     xsize = x;
     ysize = y;
     howmanyx = nx;
@@ -27,9 +27,11 @@ AnimatedGameObject::AnimatedGameObject(double x, double y, int nx, int ny, int n
 bool AnimatedGameObject::load(const std::string& filename) {
     if (m_texture.loadFromFile(filename)) {
         m_filename = filename;
-        m_sprite.setTexture(m_texture);
-        rect = sf::IntRect(0, 0, floor(xsize / (double)howmanyx), floor(ysize / (double)howmanyy));
-        m_sprite.setTextureRect(rect);
+        m_sprite.emplace(m_texture);
+        m_sprite->setRotation(sf::degrees(static_cast<float>(m_angle)));
+        rect = sf::IntRect({0, 0}, {static_cast<int>(floor(xsize / (double)howmanyx)),
+                                    static_cast<int>(floor(ysize / (double)howmanyy))});
+        m_sprite->setTextureRect(rect);
         m_valid = true;
         return true;
     }
@@ -46,50 +48,54 @@ void AnimatedGameObject::update(float Tsec) {
         auto res = advanceFrameRect(rect, curr, howmanyx, howmanyy, howmany, xsize, ysize);
         rect = res.rect;
         curr = res.curr;
-        m_sprite.setTextureRect(rect);
+        m_sprite->setTextureRect(rect);
     }
 }
 
 void AnimatedGameObject::draw(sf::RenderWindow& window) {
     if (m_valid) {
-        window.draw(m_sprite);
+        window.draw(*m_sprite);
     }
 }
 
 void AnimatedGameObject::move(sf::Vector2f loc) {
     if (m_valid)
-        m_sprite.move(loc);
+        m_sprite->move(loc);
 }
 
 void AnimatedGameObject::setPosition(float x, float y) {
     if (m_valid)
-        m_sprite.setPosition(x, y);
+        m_sprite->setPosition({x, y});
 }
 
 sf::Vector2f AnimatedGameObject::getPosition() const {
     if (m_valid)
-        return m_sprite.getPosition();
+        return m_sprite->getPosition();
     else
         return sf::Vector2f(0, 0);
 }
 
-float AnimatedGameObject::getHeight() const { return m_sprite.getLocalBounds().height; }
+float AnimatedGameObject::getHeight() const {
+    return m_sprite ? m_sprite->getLocalBounds().size.y : 0.f;
+}
 
-float AnimatedGameObject::getWidth() const { return m_sprite.getLocalBounds().width; }
+float AnimatedGameObject::getWidth() const {
+    return m_sprite ? m_sprite->getLocalBounds().size.x : 0.f;
+}
 
 void AnimatedGameObject::setScale(float scale) {
     if (m_valid)
-        m_sprite.setScale(scale, scale);
+        m_sprite->setScale({scale, scale});
 }
 
 void AnimatedGameObject::setScale(float x, float y) {
     if (m_valid)
-        m_sprite.setScale(x, y);
+        m_sprite->setScale({x, y});
 }
 
 sf::Vector2f AnimatedGameObject::getScale() const {
     if (m_valid)
-        return m_sprite.getScale();
+        return m_sprite->getScale();
     else
         return sf::Vector2f(0, 0);
 }
@@ -98,13 +104,17 @@ void AnimatedGameObject::changeValid(bool a) { m_valid = a; }
 
 bool AnimatedGameObject::isValid() { return m_valid; }
 
-sf::FloatRect AnimatedGameObject::getGlobalBounds() const { return m_sprite.getGlobalBounds(); }
+sf::FloatRect AnimatedGameObject::getGlobalBounds() const {
+    return m_sprite ? m_sprite->getGlobalBounds() : sf::FloatRect();
+}
 
 void AnimatedGameObject::setOrigin() {
-    if (m_sprite.getOrigin().x == 0) {
-        m_sprite.setOrigin((m_sprite.getLocalBounds().width) / 2,
-                           (m_sprite.getLocalBounds().height) / 2);
+    if (!m_sprite)
+        return;
+    if (m_sprite->getOrigin().x == 0) {
+        m_sprite->setOrigin(
+            {(m_sprite->getLocalBounds().size.x) / 2, (m_sprite->getLocalBounds().size.y) / 2});
     } else {
-        m_sprite.setOrigin(0, 0);
+        m_sprite->setOrigin({0, 0});
     }
 }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -24,9 +24,10 @@ void Game::toggleFullscreen() {
                               : m_networkMode == NetworkMode::HOST ? "Dungeon Game - Host"
                                                                    : "Dungeon Game - Client";
     if (m_fullscreen) {
-        m_window.create(sf::VideoMode::getDesktopMode(), title, sf::Style::Fullscreen);
+        m_window.create(sf::VideoMode::getDesktopMode(), title, sf::Style::Default,
+                        sf::State::Fullscreen);
     } else {
-        m_window.create(sf::VideoMode(1920, 1080), title, sf::Style::Default);
+        m_window.create(sf::VideoMode({1920u, 1080u}), title, sf::Style::Default);
     }
     // Re-apply display settings after create() resets them.
     // NOTE (macOS): SFML 2 create() reconstructs the GL context; textures
@@ -42,7 +43,7 @@ void Game::toggleFullscreen() {
 Game::Game() : Game(NetworkMode::LOCAL, nullptr) {}
 
 Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
-    : m_window(sf::VideoMode(1920, 1080),
+    : m_window(sf::VideoMode({1920u, 1080u}),
                mode == NetworkMode::LOCAL  ? "Dungeon Game"
                : mode == NetworkMode::HOST ? "Dungeon Game - Host"
                                            : "Dungeon Game - Client",
@@ -88,41 +89,41 @@ Game::Game(NetworkMode mode, std::shared_ptr<NetworkManager> netManager)
     loadOrThrow(tfont, resource_path + "timer.ttf");
     loadOrThrow(block, resource_path + "Blockt.ttf");
 
-    pause_text = sf::Text("Cooldown", block, 400);
-    pause_text.setPosition(kGameW / 2 - 850, 100);
-    pause_text.setFillColor(sf::Color::Black);
+    pause_text.emplace(block, "Cooldown", 400);
+    pause_text->setPosition({kGameW / 2 - 850, 100});
+    pause_text->setFillColor(sf::Color::Black);
 
-    info = sf::Text("a short intermission", font, 50);
-    info.setPosition(pause_text.getPosition().x + 150, pause_text.getPosition().y + 500);
-    info.setFillColor(sf::Color::Black);
+    info.emplace(font, "a short intermission", 50);
+    info->setPosition({pause_text->getPosition().x + 150, pause_text->getPosition().y + 500});
+    info->setFillColor(sf::Color::Black);
 
-    m_rocketScoreText = sf::Text("Rocket Score: 0", font, 40);
-    m_robotScoreText = sf::Text("Robot Score: 0", font, 40);
-    timer = sf::Text("timer", tfont, 60);
-    timer.setPosition(kGameW / 2 - 60, 0);
-    m_rocketScoreText.setPosition(10, 0);
-    m_robotScoreText.setPosition(kGameW - m_robotScoreText.getGlobalBounds().width, 0);
-    m_robotScoreText.setFillColor(sf::Color::Green);
-    timer.setFillColor(sf::Color::Black);
-    m_rocketScoreText.setFillColor(sf::Color::Blue);
+    m_rocketScoreText.emplace(font, "Rocket Score: 0", 40);
+    m_robotScoreText.emplace(font, "Robot Score: 0", 40);
+    timer.emplace(tfont, "timer", 60);
+    timer->setPosition({kGameW / 2 - 60, 0});
+    m_rocketScoreText->setPosition({10, 0});
+    m_robotScoreText->setPosition({kGameW - m_robotScoreText->getGlobalBounds().size.x, 0});
+    m_robotScoreText->setFillColor(sf::Color::Green);
+    timer->setFillColor(sf::Color::Black);
+    m_rocketScoreText->setFillColor(sf::Color::Blue);
 
     loadOrThrow(sbuffer, resource_path + "sword_miss.wav");
-    sword.setBuffer(sbuffer);
+    sword.emplace(sbuffer);
     loadOrThrow(p2hitbuffer, resource_path + "skeleton.wav");
-    p2hit.setBuffer(p2hitbuffer);
+    p2hit.emplace(p2hitbuffer);
     loadOrThrow(laserbuffer, resource_path + "new_laser.wav");
-    laser.setBuffer(laserbuffer);
+    laser.emplace(laserbuffer);
     loadOrThrow(metalbuffer, resource_path + "metal_hit.wav");
-    metal.setBuffer(metalbuffer);
+    metal.emplace(metalbuffer);
     loadOrThrow(speedbuffer, resource_path + "SpeedUp.wav");
-    speed_up.setBuffer(speedbuffer);
+    speed_up.emplace(speedbuffer);
     loadOrThrow(slowbuffer, resource_path + "SlowDown.wav");
-    slow_down.setBuffer(slowbuffer);
+    slow_down.emplace(slowbuffer);
     loadOrThrow(burnbuffer, resource_path + "burn.wav");
-    burn.setBuffer(burnbuffer);
+    burn.emplace(burnbuffer);
     loadOrThrow(gongbuffer, resource_path + "gong.wav");
-    gong.setBuffer(gongbuffer);
-    laser.setVolume(60);
+    gong.emplace(gongbuffer);
+    laser->setVolume(60);
 }
 
 // ── debug config ──────────────────────────────────────────────────────────────
@@ -160,12 +161,12 @@ AiView Game::makeAiView() const {
     // picks the far edge and the AI thinks it is a full body-width too far).
     view.selfBounds = normalizedBounds(*m_robot);
     view.selfPos = m_robot->getPosition();
-    view.selfPos.y += view.selfBounds.height * 0.5f; // anchor → body centre
+    view.selfPos.y += view.selfBounds.size.y * 0.5f; // anchor → body centre
 
     view.selfFacingLeft = m_p2FacingLeft;
     view.oppBounds = normalizedBounds(*m_rocket);
     view.oppPos = m_rocket->getPosition();
-    view.oppPos.y += view.oppBounds.height * 0.5f; // anchor → body centre
+    view.oppPos.y += view.oppBounds.size.y * 0.5f; // anchor → body centre
 
     // arena[0] is the brick floor; arena[1..3] are the three fire hazards.
     for (int i = 0; i < 3; ++i)
@@ -189,9 +190,9 @@ std::tuple<int, int, float, int, bool, bool> Game::run() {
 
     sf::Clock clock;
     background.play();
-    background.setLoop(true);
+    background.setLooping(true);
     background.setVolume(40);
-    gong.setVolume(50);
+    gong->setVolume(50);
 
     float apieceofcrap = 0.f;
     int seconds = 0;
@@ -207,7 +208,7 @@ std::tuple<int, int, float, int, bool, bool> Game::run() {
             seconds = totalSecs % 60;
             char gClock[10];
             std::snprintf(gClock, sizeof(gClock), "%02.0f:%02d", apieceofcrap, seconds);
-            timer.setString(gClock);
+            timer->setString(gClock);
         }
 
         float iterDt = std::min(clock.restart().asSeconds(), 0.25f);
@@ -283,7 +284,7 @@ void Game::simStep() {
         m_cooldownEnd = static_cast<float>(gameSeconds()) + 1.75f;
     } else if (gameSeconds() > static_cast<double>(m_cooldownEnd)) {
         m_inCooldown = false;
-        gong.play();
+        gong->play();
     }
 
     // Animation accumulator (matches original pattern: reset-then-increment).
@@ -300,13 +301,13 @@ void Game::simStep() {
     // Hazard collision + scoring.
     for (int x = 1; x < static_cast<int>(m_arena.size()); x++) {
         if (collision(*m_arena[x], *m_rocket) && m_p1HazardReady) {
-            burn.play();
+            burn->play();
             m_rocketScore--;
             m_p1HazardReady = false;
             m_p1HazardCooldownEnd = static_cast<float>(gameSeconds()) + 2.2f;
         }
         if (collision(*m_arena[x], *m_robot) && m_p2HazardReady) {
-            burn.play();
+            burn->play();
             m_robotScore--;
             m_p2HazardReady = false;
             m_p2HazardCooldownEnd = static_cast<float>(gameSeconds()) + 2.2f;
@@ -354,31 +355,23 @@ void Game::captureIfDue() {
 // ── processEvents ─────────────────────────────────────────────────────────────
 
 void Game::processEvents() {
-    sf::Event event;
-    while (m_window.pollEvent(event)) {
-        switch (event.type) {
+    while (const auto event = m_window.pollEvent()) {
         // LCOV_EXCL_START — UI events not generated in harness/headless runs
-        case sf::Event::KeyPressed:
-            if (event.key.code == sf::Keyboard::F11 && !m_debug.active()) {
+        if (const auto* kp = event->getIf<sf::Event::KeyPressed>()) {
+            if (kp->code == sf::Keyboard::Key::F11 && !m_debug.active()) {
                 toggleFullscreen();
                 return; // restart event loop with the new window
             }
-            handlePlayerInput(event.key.code, true);
-            break;
-        case sf::Event::KeyReleased:
-            handlePlayerInput(event.key.code, false);
-            break;
-        case sf::Event::Resized:
-            m_window.setView(
-                makeLetterboxView({kGameW, kGameH}, {event.size.width, event.size.height}));
-            break;
-        case sf::Event::Closed:
+            handlePlayerInput(kp->code, true);
+        } else if (const auto* kr = event->getIf<sf::Event::KeyReleased>()) {
+            handlePlayerInput(kr->code, false);
+        } else if (const auto* rs = event->getIf<sf::Event::Resized>()) {
+            m_window.setView(makeLetterboxView({kGameW, kGameH}, rs->size));
+        } else if (event->is<sf::Event::Closed>()) {
             m_window.close();
-            break;
-        case sf::Event::MouseButtonReleased:
-            if (m_paused && event.mouseButton.button == sf::Mouse::Left) {
-                sf::Vector2f mp =
-                    m_window.mapPixelToCoords({event.mouseButton.x, event.mouseButton.y});
+        } else if (const auto* mb = event->getIf<sf::Event::MouseButtonReleased>()) {
+            if (m_paused && mb->button == sf::Mouse::Button::Left) {
+                sf::Vector2f mp = m_window.mapPixelToCoords(mb->position);
                 if (pauseButtonRect(0).contains(mp)) {
                     m_paused = false;
                     background.play();
@@ -390,27 +383,24 @@ void Game::processEvents() {
                     m_window.close();
                 }
             }
-            break;
-        case sf::Event::JoystickButtonPressed:
+        } else if (const auto* jb = event->getIf<sf::Event::JoystickButtonPressed>()) {
             // NOTE: gamepad attack fires on button PRESS; P2 keyboard attack fires on
             // key RELEASE (see handlePlayerInput — m_p2Attack = !isDown). Pre-existing
             // discrepancy tracked in issue #37.
-            if (!m_debug.active() && event.joystickButton.button == kAttackButton) {
+            if (!m_debug.active() && jb->button == kAttackButton) {
                 if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::HOST) {
-                    if (event.joystickButton.joystickId == 0)
+                    if (jb->joystickId == 0)
                         m_p1Attack = true;
                 }
                 if ((m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::CLIENT) &&
                     !m_ai) {
                     unsigned joyP2 = (m_networkMode == NetworkMode::CLIENT) ? 0u : 1u;
-                    if (event.joystickButton.joystickId == joyP2)
+                    if (jb->joystickId == joyP2)
                         m_p2Attack = true;
                 }
             }
-            break;
-        // JoystickMoved is entirely hardware-driven (never fires in headless CI), so the
-        // whole case stays inside this LCOV exclusion block.
-        case sf::Event::JoystickMoved: {
+        } else if (const auto* jm = event->getIf<sf::Event::JoystickMoved>()) {
+            // JoystickMoved is entirely hardware-driven (never fires in headless CI).
             // Event-driven movement: SFML fires JoystickMoved when any axis moves,
             // including return-to-center. We ASSIGN (not OR) so bools clear when
             // the stick centers — mirrors keyboard KeyPressed/KeyReleased exactly.
@@ -419,7 +409,7 @@ void Game::processEvents() {
             // gamepad on one player the gamepad state wins — acceptable per the
             // one-control-source-at-a-time contract.
             if (!m_debug.active()) {
-                unsigned id = event.joystickMove.joystickId;
+                unsigned id = jm->joystickId;
                 // P1 (rocket): joystick 0 in LOCAL or HOST.
                 if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::HOST) {
                     if (id == 0) {
@@ -444,12 +434,8 @@ void Game::processEvents() {
                     }
                 }
             }
-            break;
         }
         // LCOV_EXCL_STOP
-        default:
-            break;
-        }
     }
 }
 
@@ -461,7 +447,7 @@ void Game::handlePlayerInput(sf::Keyboard::Key key, bool isDown) {
     // keyboard cannot perturb a --frames / --replay run.
     if (!m_debug.active()) {
         // Pause / resume
-        if (key == sf::Keyboard::Escape && isDown) {
+        if (key == sf::Keyboard::Key::Escape && isDown) {
             m_paused = !m_paused;
             if (m_paused)
                 background.pause();
@@ -470,7 +456,7 @@ void Game::handlePlayerInput(sf::Keyboard::Key key, bool isDown) {
         }
 
         // Quit to menu while paused
-        if (m_paused && key == sf::Keyboard::Q && isDown) {
+        if (m_paused && key == sf::Keyboard::Key::Q && isDown) {
             if (m_networkManager)
                 m_networkManager->disconnect();
             m_quitToMenu = true;
@@ -515,13 +501,13 @@ void Game::handlePlayerInput(sf::Keyboard::Key key, bool isDown) {
         if (key == m_bindings.skipCooldown && isDown) {
             if (m_inCooldown) {
                 m_inCooldown = false;
-                gong.play();
+                gong->play();
             }
         }
     }
 
     // Always-active: manual screenshot (F12).
-    if (key == sf::Keyboard::F12 && isDown)
+    if (key == sf::Keyboard::Key::F12 && isDown)
         captureScreenshot(m_window,
                           m_debug.screenshotDir + "/manual_" + std::to_string(m_steps) + ".png");
 }
@@ -670,11 +656,11 @@ void Game::update(sf::Time deltaT, float time) {
         }
 
         if (collision(hit, *m_rocket)) {
-            metal.play();
+            metal->play();
             m_robotScore++;
             reset = true;
         } else {
-            sword.play();
+            sword->play();
         }
 
         m_p2Attack = false;
@@ -696,9 +682,9 @@ void Game::update(sf::Time deltaT, float time) {
         if (collision(hit, *m_robot)) {
             m_rocketScore++;
             reset = true;
-            p2hit.play();
+            p2hit->play();
         } else {
-            laser.play();
+            laser->play();
         }
 
         m_p1Attack = false;
@@ -708,12 +694,12 @@ void Game::update(sf::Time deltaT, float time) {
         if (m_speed < 0)
             m_speed = 1.0f;
         m_slowDownPressed = false;
-        slow_down.play();
+        slow_down->play();
     }
     if (m_speedUpPressed) {
         m_speed = m_speed + 150.0f;
         m_speedUpPressed = false;
-        speed_up.play();
+        speed_up->play();
     }
 
     if ((m_p1Up || m_p1Down || m_p1Left || m_p1Right) && !collision(*m_rocket, *m_robot)) {
@@ -739,9 +725,9 @@ void Game::update(sf::Time deltaT, float time) {
         m_inCooldown = true;
     }
 
-    m_rocketScoreText.setString("Rocket Score: " + std::to_string(m_rocketScore));
-    m_robotScoreText.setString("Robot Score: " + std::to_string(m_robotScore));
-    m_robotScoreText.setPosition(kGameW - m_robotScoreText.getGlobalBounds().width - 20, 0);
+    m_rocketScoreText->setString("Rocket Score: " + std::to_string(m_rocketScore));
+    m_robotScoreText->setString("Robot Score: " + std::to_string(m_robotScore));
+    m_robotScoreText->setPosition({kGameW - m_robotScoreText->getGlobalBounds().size.x - 20, 0});
 }
 
 // ── render ────────────────────────────────────────────────────────────────────
@@ -790,14 +776,14 @@ void Game::render() {
     for (std::size_t x = 0; x < m_arena.size(); ++x) {
         m_arena[x]->draw(m_window);
     }
-    m_window.draw(timer);
-    m_window.draw(m_rocketScoreText);
-    m_window.draw(m_robotScoreText);
+    m_window.draw(*timer);
+    m_window.draw(*m_rocketScoreText);
+    m_window.draw(*m_robotScoreText);
     m_rocket->draw(m_window);
     m_robot->draw(m_window);
     if (m_inCooldown) {
-        m_window.draw(pause_text);
-        m_window.draw(info);
+        m_window.draw(*pause_text);
+        m_window.draw(*info);
     }
     if (m_paused) {
         sf::RectangleShape overlay(sf::Vector2f(kGameW, kGameH));
@@ -808,18 +794,18 @@ void Game::render() {
         auto r1 = pauseButtonRect(1);
         sf::Vector2f mousePos = m_window.mapPixelToCoords(sf::Mouse::getPosition(m_window));
 
-        sf::Text txt("PAUSED", font, 60);
+        sf::Text txt(font, "PAUSED", 60);
         txt.setFillColor(sf::Color::White);
-        txt.setStyle(sf::Text::Bold);
+        txt.setStyle(sf::Text::Style::Bold);
         auto tlb = txt.getLocalBounds();
-        txt.setOrigin(tlb.left + tlb.width / 2.f, tlb.top + tlb.height / 2.f);
-        txt.setPosition(kGameW / 2.f, r0.top - 60.f);
+        txt.setOrigin({tlb.position.x + tlb.size.x / 2.f, tlb.position.y + tlb.size.y / 2.f});
+        txt.setPosition({kGameW / 2.f, r0.position.y - 60.f});
         m_window.draw(txt);
 
-        MenuButton resumeBtn({r0.width, r0.height}, font, "Resume");
-        MenuButton quitBtn({r1.width, r1.height}, font, "Quit to Menu");
-        resumeBtn.setPosition({r0.left + r0.width / 2.f, r0.top + r0.height / 2.f});
-        quitBtn.setPosition({r1.left + r1.width / 2.f, r1.top + r1.height / 2.f});
+        MenuButton resumeBtn({r0.size.x, r0.size.y}, font, "Resume");
+        MenuButton quitBtn({r1.size.x, r1.size.y}, font, "Quit to Menu");
+        resumeBtn.setPosition({r0.position.x + r0.size.x / 2.f, r0.position.y + r0.size.y / 2.f});
+        quitBtn.setPosition({r1.position.x + r1.size.x / 2.f, r1.position.y + r1.size.y / 2.f});
         resumeBtn.setHovered(r0.contains(mousePos));
         quitBtn.setHovered(r1.contains(mousePos));
         resumeBtn.draw(m_window);
@@ -840,11 +826,11 @@ void Game::render() {
 // ── collision ─────────────────────────────────────────────────────────────────
 
 bool Game::collision(const GameObject& a, const GameObject& b) {
-    return objectBounds(a).intersects(objectBounds(b));
+    return objectBounds(a).findIntersection(objectBounds(b)).has_value();
 }
 
-bool Game::collision(sf::Rect<float> a, const GameObject& b) {
-    return a.intersects(objectBounds(b));
+bool Game::collision(sf::FloatRect a, const GameObject& b) {
+    return a.findIntersection(objectBounds(b)).has_value();
 }
 
 // ── handleNetworkCommunication ────────────────────────────────────────────────

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -1,12 +1,13 @@
 #include "NetworkManager.h"
 #include <algorithm>
+#include <cstdint>
 #include <iostream>
 
 // ── free functions ────────────────────────────────────────────────────────────
 
 void dispatchPacket(sf::Packet& pkt, sf::Time arrival, std::deque<TimedState>& stateBuf,
                     std::deque<PlayerInput>& inputQueue, std::size_t cap) {
-    sf::Uint8 typeRaw = 0;
+    std::uint8_t typeRaw = 0;
     if (!(pkt >> typeRaw))
         return;
 
@@ -58,11 +59,11 @@ bool NetworkManager::flushSend() {
     if (!m_hasPending)
         return true;
     auto status = m_socket.send(m_pendingSend);
-    if (status == sf::Socket::Done) {
+    if (status == sf::Socket::Status::Done) {
         m_hasPending = false;
         return true;
     }
-    if (status == sf::Socket::Disconnected || status == sf::Socket::Error)
+    if (status == sf::Socket::Status::Disconnected || status == sf::Socket::Status::Error)
         setDisconnected();
     // Partial: SFML 2.x copies the payload into the SOCKET's internal buffer on the
     // first send() and stores progress there; the next send() on this socket resumes
@@ -74,12 +75,13 @@ bool NetworkManager::flushSend() {
 bool NetworkManager::startHost(unsigned short port) {
     m_isHost = true;
     m_listener.setBlocking(false);
-    if (m_listener.listen(port) != sf::Socket::Done) {
+    if (m_listener.listen(port) != sf::Socket::Status::Done) {
         std::cout << "Failed to bind to port " << port << "\n";
         return false;
     }
     std::cout << "Hosting on port " << m_listener.getLocalPort() << "\n";
-    std::cout << "Your IP: " << sf::IpAddress::getLocalAddress() << "\n";
+    auto local = sf::IpAddress::getLocalAddress();
+    std::cout << "Your IP: " << (local ? local->toString() : "unknown") << "\n";
     return true;
 }
 
@@ -88,8 +90,9 @@ bool NetworkManager::waitForClient(sf::Time timeout) {
         return false; // already accepted; listener is closed
     sf::Clock clock;
     while (timeout == sf::Time::Zero || clock.getElapsedTime() < timeout) {
-        if (m_listener.accept(m_socket) == sf::Socket::Done) {
-            std::cout << "Client connected: " << m_socket.getRemoteAddress() << "\n";
+        if (m_listener.accept(m_socket) == sf::Socket::Status::Done) {
+            auto remote = m_socket.getRemoteAddress();
+            std::cout << "Client connected: " << (remote ? remote->toString() : "unknown") << "\n";
             m_socket.setBlocking(false);
             m_connected = true;
             m_listener.close(); // 1v1: stop accepting new connections
@@ -102,8 +105,8 @@ bool NetworkManager::waitForClient(sf::Time timeout) {
 
 bool NetworkManager::connectToHost(const std::string& ip, unsigned short port) {
     // Validate ip before doing any blocking work — bad input fails instantly.
-    sf::IpAddress addr(ip);
-    if (addr == sf::IpAddress::None) {
+    auto addr = sf::IpAddress::resolve(ip);
+    if (!addr) {
         std::cout << "Invalid IP address: " << ip << "\n";
         return false;
     }
@@ -115,11 +118,11 @@ bool NetworkManager::connectToHost(const std::string& ip, unsigned short port) {
     m_isHost = false;
     std::cout << "Connecting to " << ip << ":" << port << "\n";
     m_socket.setBlocking(true);
-    auto status = m_socket.connect(addr, port, sf::seconds(10));
+    auto status = m_socket.connect(*addr, port, sf::seconds(10));
     m_socket.setBlocking(false);
 
-    if (status != sf::Socket::Done) {
-        std::cout << "Failed to connect (status: " << status << ")\n";
+    if (status != sf::Socket::Status::Done) {
+        std::cout << "Failed to connect (status: " << static_cast<int>(status) << ")\n";
         return false;
     }
     m_connected = true;
@@ -134,7 +137,7 @@ bool NetworkManager::sendInput(const PlayerInput& input) {
         return false; // pending slot still occupied — drop
 
     m_pendingSend.clear();
-    m_pendingSend << static_cast<sf::Uint8>(MsgType::Input);
+    m_pendingSend << static_cast<std::uint8_t>(MsgType::Input);
     input.toPacket(m_pendingSend);
     m_hasPending = true;
     return flushSend();
@@ -147,7 +150,7 @@ bool NetworkManager::sendGameState(const GameState& state) {
         return false;
 
     m_pendingSend.clear();
-    m_pendingSend << static_cast<sf::Uint8>(MsgType::State);
+    m_pendingSend << static_cast<std::uint8_t>(MsgType::State);
     state.toPacket(m_pendingSend);
     m_hasPending = true;
     return flushSend();
@@ -159,9 +162,10 @@ void NetworkManager::poll() {
     sf::Packet pkt;
     for (;;) {
         auto status = m_socket.receive(pkt);
-        if (status == sf::Socket::Done) {
+        if (status == sf::Socket::Status::Done) {
             dispatchPacket(pkt, m_clock.getElapsedTime(), m_stateBuf, m_inputQueue, kStateBufCap);
-        } else if (status == sf::Socket::NotReady || status == sf::Socket::Partial) {
+        } else if (status == sf::Socket::Status::NotReady ||
+                   status == sf::Socket::Status::Partial) {
             // NotReady: no data yet.
             // Partial: SFML stores receive progress inside the socket; resume next poll().
             break;

--- a/src/RegularGameObject.cpp
+++ b/src/RegularGameObject.cpp
@@ -9,7 +9,7 @@ RegularGameObject::RegularGameObject() {}
 bool RegularGameObject::load(const std::string& filename) {
     if (m_texture.loadFromFile(filename)) {
         m_filename = filename;
-        m_sprite.setTexture(m_texture);
+        m_sprite.emplace(m_texture);
         m_valid = true;
         return true;
     }
@@ -20,43 +20,47 @@ void RegularGameObject::update(float /*deltaT*/) {}
 
 void RegularGameObject::draw(sf::RenderWindow& window) {
     if (m_valid)
-        window.draw(m_sprite);
+        window.draw(*m_sprite);
 }
 
 void RegularGameObject::move(sf::Vector2f loc) {
     if (m_valid)
-        m_sprite.move(loc);
+        m_sprite->move(loc);
 }
 
 void RegularGameObject::setPosition(float x, float y) {
     if (m_valid)
-        m_sprite.setPosition(x, y);
+        m_sprite->setPosition({x, y});
 }
 
 sf::Vector2f RegularGameObject::getPosition() const {
     if (m_valid)
-        return m_sprite.getPosition();
+        return m_sprite->getPosition();
     else
         return sf::Vector2f(0, 0);
 }
 
-float RegularGameObject::getHeight() const { return m_sprite.getLocalBounds().height; }
+float RegularGameObject::getHeight() const {
+    return m_sprite ? m_sprite->getLocalBounds().size.y : 0.f;
+}
 
-float RegularGameObject::getWidth() const { return m_sprite.getLocalBounds().width; }
+float RegularGameObject::getWidth() const {
+    return m_sprite ? m_sprite->getLocalBounds().size.x : 0.f;
+}
 
 void RegularGameObject::setScale(float scale) {
     if (m_valid)
-        m_sprite.setScale(scale, scale);
+        m_sprite->setScale({scale, scale});
 }
 
 void RegularGameObject::setScale(float x, float y) {
     if (m_valid)
-        m_sprite.setScale(x, y);
+        m_sprite->setScale({x, y});
 }
 
 sf::Vector2f RegularGameObject::getScale() const {
     if (m_valid)
-        return m_sprite.getScale();
+        return m_sprite->getScale();
     else
         return sf::Vector2f(0, 0);
 }
@@ -65,9 +69,13 @@ void RegularGameObject::changeValid(bool a) { m_valid = a; }
 
 bool RegularGameObject::isValid() { return m_valid; }
 
-sf::FloatRect RegularGameObject::getGlobalBounds() const { return m_sprite.getGlobalBounds(); }
+sf::FloatRect RegularGameObject::getGlobalBounds() const {
+    return m_sprite ? m_sprite->getGlobalBounds() : sf::FloatRect();
+}
 
 void RegularGameObject::setOrigin() {
-    m_sprite.setOrigin((m_sprite.getLocalBounds().width) / 2,
-                       (m_sprite.getLocalBounds().height) / 2);
+    if (!m_sprite)
+        return;
+    m_sprite->setOrigin(
+        {(m_sprite->getLocalBounds().size.x) / 2, (m_sprite->getLocalBounds().size.y) / 2});
 }

--- a/src/RegularGameObject.cpp
+++ b/src/RegularGameObject.cpp
@@ -65,7 +65,15 @@ sf::Vector2f RegularGameObject::getScale() const {
         return sf::Vector2f(0, 0);
 }
 
-void RegularGameObject::changeValid(bool a) { m_valid = a; }
+void RegularGameObject::changeValid(bool a) {
+    m_valid = a;
+    // SFML 3's sf::Sprite has no default ctor, so m_sprite is empty until load().
+    // Marking an unloaded object valid must still give the mutators (guarded on
+    // m_valid) a live sprite to act on — emplace an untextured sprite backed by the
+    // default m_texture, matching SFML 2's always-present default sprite.
+    if (a && !m_sprite)
+        m_sprite.emplace(m_texture);
+}
 
 bool RegularGameObject::isValid() { return m_valid; }
 

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -39,16 +39,16 @@ PlayerInput decideAiInput(const AiView& view, const AiParams& p, std::mt19937& r
     // Priority 3: hazard escape (uses self — not delayed — position + bounds)
     if (p.hazardMargin > 0.f) {
         sf::FloatRect inflated = view.selfBounds;
-        inflated.left -= p.hazardMargin;
-        inflated.top -= p.hazardMargin;
-        inflated.width += 2.f * p.hazardMargin;
-        inflated.height += 2.f * p.hazardMargin;
+        inflated.position.x -= p.hazardMargin;
+        inflated.position.y -= p.hazardMargin;
+        inflated.size.x += 2.f * p.hazardMargin;
+        inflated.size.y += 2.f * p.hazardMargin;
 
         for (const auto& hazard : view.hazards) {
-            if (inflated.intersects(hazard)) {
+            if (inflated.findIntersection(hazard).has_value()) {
                 // Move away from hazard centre horizontally
-                float hcx = hazard.left + hazard.width * 0.5f;
-                float scx = view.selfBounds.left + view.selfBounds.width * 0.5f;
+                float hcx = hazard.position.x + hazard.size.x * 0.5f;
+                float scx = view.selfBounds.position.x + view.selfBounds.size.x * 0.5f;
                 out.right = (hcx <= scx);
                 out.left = (hcx > scx);
                 return out;
@@ -68,8 +68,8 @@ PlayerInput decideAiInput(const AiView& view, const AiParams& p, std::mt19937& r
     // This accounts for the opponent's body width so the AI fires when its weapon can
     // actually connect, not just when the sprite anchors are within attackRange.
     {
-        float nearOppEdge =
-            oppToRight ? view.oppBounds.left : view.oppBounds.left + view.oppBounds.width;
+        float nearOppEdge = oppToRight ? view.oppBounds.position.x
+                                       : view.oppBounds.position.x + view.oppBounds.size.x;
         float horizDist = (view.selfPos.x - nearOppEdge);
         if (horizDist < 0.f)
             horizDist = -horizDist;

--- a/src/key_bindings.cpp
+++ b/src/key_bindings.cpp
@@ -10,85 +10,85 @@
 
 static const std::pair<const char*, sf::Keyboard::Key> kKeyTable[] = {
     // Letters
-    {"A", sf::Keyboard::A},
-    {"B", sf::Keyboard::B},
-    {"C", sf::Keyboard::C},
-    {"D", sf::Keyboard::D},
-    {"E", sf::Keyboard::E},
-    {"F", sf::Keyboard::F},
-    {"G", sf::Keyboard::G},
-    {"H", sf::Keyboard::H},
-    {"I", sf::Keyboard::I},
-    {"J", sf::Keyboard::J},
-    {"K", sf::Keyboard::K},
-    {"L", sf::Keyboard::L},
-    {"M", sf::Keyboard::M},
-    {"N", sf::Keyboard::N},
-    {"O", sf::Keyboard::O},
-    {"P", sf::Keyboard::P},
-    {"Q", sf::Keyboard::Q},
-    {"R", sf::Keyboard::R},
-    {"S", sf::Keyboard::S},
-    {"T", sf::Keyboard::T},
-    {"U", sf::Keyboard::U},
-    {"V", sf::Keyboard::V},
-    {"W", sf::Keyboard::W},
-    {"X", sf::Keyboard::X},
-    {"Y", sf::Keyboard::Y},
-    {"Z", sf::Keyboard::Z},
+    {"A", sf::Keyboard::Key::A},
+    {"B", sf::Keyboard::Key::B},
+    {"C", sf::Keyboard::Key::C},
+    {"D", sf::Keyboard::Key::D},
+    {"E", sf::Keyboard::Key::E},
+    {"F", sf::Keyboard::Key::F},
+    {"G", sf::Keyboard::Key::G},
+    {"H", sf::Keyboard::Key::H},
+    {"I", sf::Keyboard::Key::I},
+    {"J", sf::Keyboard::Key::J},
+    {"K", sf::Keyboard::Key::K},
+    {"L", sf::Keyboard::Key::L},
+    {"M", sf::Keyboard::Key::M},
+    {"N", sf::Keyboard::Key::N},
+    {"O", sf::Keyboard::Key::O},
+    {"P", sf::Keyboard::Key::P},
+    {"Q", sf::Keyboard::Key::Q},
+    {"R", sf::Keyboard::Key::R},
+    {"S", sf::Keyboard::Key::S},
+    {"T", sf::Keyboard::Key::T},
+    {"U", sf::Keyboard::Key::U},
+    {"V", sf::Keyboard::Key::V},
+    {"W", sf::Keyboard::Key::W},
+    {"X", sf::Keyboard::Key::X},
+    {"Y", sf::Keyboard::Key::Y},
+    {"Z", sf::Keyboard::Key::Z},
     // Top-row digits
-    {"0", sf::Keyboard::Num0},
-    {"1", sf::Keyboard::Num1},
-    {"2", sf::Keyboard::Num2},
-    {"3", sf::Keyboard::Num3},
-    {"4", sf::Keyboard::Num4},
-    {"5", sf::Keyboard::Num5},
-    {"6", sf::Keyboard::Num6},
-    {"7", sf::Keyboard::Num7},
-    {"8", sf::Keyboard::Num8},
-    {"9", sf::Keyboard::Num9},
+    {"0", sf::Keyboard::Key::Num0},
+    {"1", sf::Keyboard::Key::Num1},
+    {"2", sf::Keyboard::Key::Num2},
+    {"3", sf::Keyboard::Key::Num3},
+    {"4", sf::Keyboard::Key::Num4},
+    {"5", sf::Keyboard::Key::Num5},
+    {"6", sf::Keyboard::Key::Num6},
+    {"7", sf::Keyboard::Key::Num7},
+    {"8", sf::Keyboard::Key::Num8},
+    {"9", sf::Keyboard::Key::Num9},
     // Numpad
-    {"Num0", sf::Keyboard::Numpad0},
-    {"Num1", sf::Keyboard::Numpad1},
-    {"Num2", sf::Keyboard::Numpad2},
-    {"Num3", sf::Keyboard::Numpad3},
-    {"Num4", sf::Keyboard::Numpad4},
-    {"Num5", sf::Keyboard::Numpad5},
-    {"Num6", sf::Keyboard::Numpad6},
-    {"Num7", sf::Keyboard::Numpad7},
-    {"Num8", sf::Keyboard::Numpad8},
-    {"Num9", sf::Keyboard::Numpad9},
+    {"Num0", sf::Keyboard::Key::Numpad0},
+    {"Num1", sf::Keyboard::Key::Numpad1},
+    {"Num2", sf::Keyboard::Key::Numpad2},
+    {"Num3", sf::Keyboard::Key::Numpad3},
+    {"Num4", sf::Keyboard::Key::Numpad4},
+    {"Num5", sf::Keyboard::Key::Numpad5},
+    {"Num6", sf::Keyboard::Key::Numpad6},
+    {"Num7", sf::Keyboard::Key::Numpad7},
+    {"Num8", sf::Keyboard::Key::Numpad8},
+    {"Num9", sf::Keyboard::Key::Numpad9},
     // Arrow keys
-    {"Up", sf::Keyboard::Up},
-    {"Down", sf::Keyboard::Down},
-    {"Left", sf::Keyboard::Left},
-    {"Right", sf::Keyboard::Right},
+    {"Up", sf::Keyboard::Key::Up},
+    {"Down", sf::Keyboard::Key::Down},
+    {"Left", sf::Keyboard::Key::Left},
+    {"Right", sf::Keyboard::Key::Right},
     // Special keys
-    {"Space", sf::Keyboard::Space},
-    {"Enter", sf::Keyboard::Return},
-    {"Escape", sf::Keyboard::Escape},
-    {"Tab", sf::Keyboard::Tab},
-    {"Backspace", sf::Keyboard::BackSpace},
+    {"Space", sf::Keyboard::Key::Space},
+    {"Enter", sf::Keyboard::Key::Enter},
+    {"Escape", sf::Keyboard::Key::Escape},
+    {"Tab", sf::Keyboard::Key::Tab},
+    {"Backspace", sf::Keyboard::Key::Backspace},
     // Function keys
-    {"F1", sf::Keyboard::F1},
-    {"F2", sf::Keyboard::F2},
-    {"F3", sf::Keyboard::F3},
-    {"F4", sf::Keyboard::F4},
-    {"F5", sf::Keyboard::F5},
-    {"F6", sf::Keyboard::F6},
-    {"F7", sf::Keyboard::F7},
-    {"F8", sf::Keyboard::F8},
-    {"F9", sf::Keyboard::F9},
-    {"F10", sf::Keyboard::F10},
-    {"F11", sf::Keyboard::F11},
-    {"F12", sf::Keyboard::F12},
+    {"F1", sf::Keyboard::Key::F1},
+    {"F2", sf::Keyboard::Key::F2},
+    {"F3", sf::Keyboard::Key::F3},
+    {"F4", sf::Keyboard::Key::F4},
+    {"F5", sf::Keyboard::Key::F5},
+    {"F6", sf::Keyboard::Key::F6},
+    {"F7", sf::Keyboard::Key::F7},
+    {"F8", sf::Keyboard::Key::F8},
+    {"F9", sf::Keyboard::Key::F9},
+    {"F10", sf::Keyboard::Key::F10},
+    {"F11", sf::Keyboard::Key::F11},
+    {"F12", sf::Keyboard::Key::F12},
 };
 
 sf::Keyboard::Key keyFromName(const std::string& name) {
     for (const auto& [n, k] : kKeyTable)
         if (name == n)
             return k;
-    return sf::Keyboard::Unknown;
+    return sf::Keyboard::Key::Unknown;
 }
 
 std::string nameFromKey(sf::Keyboard::Key key) {
@@ -103,26 +103,26 @@ std::string nameFromKey(sf::Keyboard::Key key) {
 KeyBindings defaultBindings() {
     KeyBindings b;
     // P1 (rocket) — numpad
-    b.p1.up = sf::Keyboard::Numpad8;
-    b.p1.down = sf::Keyboard::Numpad5;
-    b.p1.left = sf::Keyboard::Numpad4;
-    b.p1.right = sf::Keyboard::Numpad6;
-    b.p1.attack = sf::Keyboard::Right;
+    b.p1.up = sf::Keyboard::Key::Numpad8;
+    b.p1.down = sf::Keyboard::Key::Numpad5;
+    b.p1.left = sf::Keyboard::Key::Numpad4;
+    b.p1.right = sf::Keyboard::Key::Numpad6;
+    b.p1.attack = sf::Keyboard::Key::Right;
     // P2 (robot) — WASD + Space
-    b.p2.up = sf::Keyboard::W;
-    b.p2.down = sf::Keyboard::S;
-    b.p2.left = sf::Keyboard::A;
-    b.p2.right = sf::Keyboard::D;
-    b.p2.attack = sf::Keyboard::Space;
+    b.p2.up = sf::Keyboard::Key::W;
+    b.p2.down = sf::Keyboard::Key::S;
+    b.p2.left = sf::Keyboard::Key::A;
+    b.p2.right = sf::Keyboard::Key::D;
+    b.p2.attack = sf::Keyboard::Key::Space;
     // Debug/speed keys
-    b.slowDown = sf::Keyboard::O;
-    b.speedUp = sf::Keyboard::P;
-    b.skipCooldown = sf::Keyboard::K;
+    b.slowDown = sf::Keyboard::Key::O;
+    b.speedUp = sf::Keyboard::Key::P;
+    b.skipCooldown = sf::Keyboard::Key::K;
     return b;
 }
 
 bool isReservedKey(sf::Keyboard::Key key, const KeyBindings& b) {
-    return key == sf::Keyboard::F11 || key == sf::Keyboard::F12 || key == b.slowDown ||
+    return key == sf::Keyboard::Key::F11 || key == sf::Keyboard::Key::F12 || key == b.slowDown ||
            key == b.speedUp || key == b.skipCooldown;
 }
 
@@ -156,7 +156,7 @@ KeyBindings loadBindings(std::istream& in) {
             continue;
 
         sf::Keyboard::Key k = keyFromName(val);
-        if (k == sf::Keyboard::Unknown) {
+        if (k == sf::Keyboard::Key::Unknown) {
             std::cerr << "[controls.cfg] Unknown key name '" << val << "' for field '" << field
                       << "', keeping default\n";
             continue; // keep default

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,10 +32,6 @@ static bool showEndscreen(int highscore, int p1score, int p2score, float minutes
 
     sf::Font tfont;
     sf::Font pfont;
-    sf::Text p1scoret;
-    sf::Text p2scoret;
-    sf::Text finalTimet;
-    sf::Text highscoret;
 
     RegularGameObject wall = RegularGameObject();
     loadOrThrow(wall, resource_path + "david_background.png");
@@ -44,33 +40,33 @@ static bool showEndscreen(int highscore, int p1score, int p2score, float minutes
     loadOrThrow(pfont, resource_path + "Joyful_Theatre.otf");
     loadOrThrow(tfont, resource_path + "timer.ttf");
 
-    sf::RenderWindow endscreen(sf::VideoMode(1024, 576), "end game", sf::Style::Default);
+    sf::RenderWindow endscreen(sf::VideoMode({1024u, 576u}), "end game", sf::Style::Default);
     endscreen.setView(makeLetterboxView({kMenuW, kMenuH}, endscreen.getSize()));
 
-    sf::Text peerDisconnectedText("", pfont, 36);
+    sf::Text peerDisconnectedText(pfont, "", 36);
     if (peerLeft) {
         peerDisconnectedText.setString("Peer disconnected");
         peerDisconnectedText.setFillColor(sf::Color::Red);
-        peerDisconnectedText.setStyle(sf::Text::Bold);
-        peerDisconnectedText.setOrigin(peerDisconnectedText.getLocalBounds().width / 2.f, 0);
-        peerDisconnectedText.setPosition(kMenuW / 2.f, 460.f);
+        peerDisconnectedText.setStyle(sf::Text::Style::Bold);
+        peerDisconnectedText.setOrigin({peerDisconnectedText.getLocalBounds().size.x / 2.f, 0.f});
+        peerDisconnectedText.setPosition({kMenuW / 2.f, 460.f});
     }
 
     sf::Music background;
     loadOrThrow(background, resource_path + "m_start_background.wav");
 
-    p1scoret = sf::Text(std::to_string(p1score), pfont, 50);
+    sf::Text p1scoret(pfont, std::to_string(p1score), 50);
     p1scoret.setFillColor(sf::Color::Blue);
-    p2scoret = sf::Text(std::to_string(p2score), pfont, 50);
+    sf::Text p2scoret(pfont, std::to_string(p2score), 50);
     p2scoret.setFillColor(sf::Color::Green);
-    finalTimet = sf::Text(finalTime, tfont, 50);
+    sf::Text finalTimet(tfont, finalTime, 50);
     finalTimet.setFillColor(sf::Color::Blue);
-    highscoret = sf::Text(std::to_string(highscore), pfont, 70);
+    sf::Text highscoret(pfont, std::to_string(highscore), 70);
 
-    p1scoret.setPosition(5, kMenuH / 2);
-    p2scoret.setPosition(kMenuW - p1scoret.getGlobalBounds().width - 5, kMenuH / 2);
-    finalTimet.setPosition(kMenuW / 2 - finalTimet.getGlobalBounds().width + 20, -10);
-    highscoret.setPosition(kMenuW / 2 - highscoret.getGlobalBounds().width, 25);
+    p1scoret.setPosition({5, kMenuH / 2});
+    p2scoret.setPosition({kMenuW - p1scoret.getGlobalBounds().size.x - 5, kMenuH / 2});
+    finalTimet.setPosition({kMenuW / 2 - finalTimet.getGlobalBounds().size.x + 20, -10});
+    highscoret.setPosition({kMenuW / 2 - highscoret.getGlobalBounds().size.x, 25});
 
     if (p1score == highscore)
         highscoret.setFillColor(sf::Color::Blue);
@@ -85,10 +81,8 @@ static bool showEndscreen(int highscore, int p1score, int p2score, float minutes
     loadOrThrow(down_buffer, resource_path + "ButtonOn.wav");
     loadOrThrow(up_buffer, resource_path + "ButtonOff.wav");
 
-    sf::Sound press;
-    sf::Sound up;
-    press.setBuffer(down_buffer);
-    up.setBuffer(up_buffer);
+    sf::Sound press(down_buffer);
+    sf::Sound up(up_buffer);
 
     bool start_updated = false;
     bool quit_updated = false;
@@ -133,34 +127,32 @@ static bool showEndscreen(int highscore, int p1score, int p2score, float minutes
             up.play();
         }
 
-        if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && srect.contains(mousePos)) {
+        if (sf::Mouse::isButtonPressed(sf::Mouse::Button::Left) && srect.contains(mousePos)) {
             background.stop();
             endscreen.close();
             // Play again only for LOCAL; online must go back through menu.
             playAgain = (mode == NetworkMode::LOCAL);
         }
-        if (sf::Mouse::isButtonPressed(sf::Mouse::Left) && qrect.contains(mousePos)) {
+        if (sf::Mouse::isButtonPressed(sf::Mouse::Button::Left) && qrect.contains(mousePos)) {
             background.stop();
             endscreen.close();
         }
 
-        sf::Event event;
-        while (endscreen.pollEvent(event)) {
-            if (event.type == sf::Event::Closed) {
+        while (const auto event = endscreen.pollEvent()) {
+            if (event->is<sf::Event::Closed>()) {
                 background.stop();
                 endscreen.close();
             }
-            if (event.type == sf::Event::Resized) {
-                endscreen.setView(
-                    makeLetterboxView({kMenuW, kMenuH}, {event.size.width, event.size.height}));
+            if (const auto* rs = event->getIf<sf::Event::Resized>()) {
+                endscreen.setView(makeLetterboxView({kMenuW, kMenuH}, rs->size));
             }
-            if (event.type == sf::Event::KeyPressed) {
-                if (event.key.code == sf::Keyboard::Y) {
+            if (const auto* kp = event->getIf<sf::Event::KeyPressed>()) {
+                if (kp->code == sf::Keyboard::Key::Y) {
                     background.stop();
                     endscreen.close();
                     playAgain = (mode == NetworkMode::LOCAL);
                 }
-                if (event.key.code == sf::Keyboard::N) {
+                if (kp->code == sf::Keyboard::Key::N) {
                     background.stop();
                     endscreen.close();
                 }

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -19,9 +19,9 @@
 
 // Build a MenuButton from a ButtonSpec, coloring label by button label text.
 static MenuButton makeButton(const ButtonSpec& spec, const sf::Font& font) {
-    MenuButton btn({spec.rect.width, spec.rect.height}, font, spec.label);
-    btn.setPosition(
-        {spec.rect.left + spec.rect.width / 2.f, spec.rect.top + spec.rect.height / 2.f});
+    MenuButton btn({spec.rect.size.x, spec.rect.size.y}, font, spec.label);
+    btn.setPosition({spec.rect.position.x + spec.rect.size.x / 2.f,
+                     spec.rect.position.y + spec.rect.size.y / 2.f});
     if (spec.label == "1 PLAYER")
         btn.label.setFillColor(sf::Color::Yellow);
     else if (spec.label == "HOST")
@@ -73,8 +73,8 @@ bool parseMenuState(const std::string& name, MenuState& out) {
 // Center a text object horizontally on a given position.
 static void centerText(sf::Text& t, float x, float y) {
     auto lb = t.getLocalBounds();
-    t.setOrigin(lb.left + lb.width / 2.f, lb.top);
-    t.setPosition(x, y);
+    t.setOrigin({lb.position.x + lb.size.x / 2.f, lb.position.y});
+    t.setPosition({x, y});
 }
 
 static void saveControls(const KeyBindings& bindings, std::string& statusMessage) {
@@ -104,15 +104,15 @@ static void renderMenu(sf::RenderWindow& win, RegularGameObject& bg, const sf::F
     bg.draw(win);
 
     if (menuState == MenuState::SETTINGS) {
-        sf::Text title("CONTROLS", font, 40);
+        sf::Text title(font, "CONTROLS", 40);
         title.setFillColor(sf::Color::White);
-        title.setStyle(sf::Text::Bold);
+        title.setStyle(sf::Text::Style::Bold);
         centerText(title, kMenuW / 2.f, 30.f);
         win.draw(title);
 
         const char* headers[2] = {"PLAYER 1", "PLAYER 2"};
         for (int col = 0; col < 2; ++col) {
-            sf::Text hdr(headers[col], font, 24);
+            sf::Text hdr(font, headers[col], 24);
             hdr.setFillColor(sf::Color(200, 200, 200));
             auto pos = settingsColumnHeaderPos(col);
             centerText(hdr, pos.x, pos.y);
@@ -132,7 +132,7 @@ static void renderMenu(sf::RenderWindow& win, RegularGameObject& bg, const sf::F
             btn.draw(win);
         }
         if (!statusMessage.empty()) {
-            sf::Text statusText(statusMessage, font, 22);
+            sf::Text statusText(font, statusMessage, 22);
             statusText.setFillColor(statusMessage.find("Failed") != std::string::npos
                                         ? sf::Color::Red
                                         : sf::Color::Yellow);
@@ -147,53 +147,53 @@ static void renderMenu(sf::RenderWindow& win, RegularGameObject& bg, const sf::F
     if (menuState == MenuState::HOST_WAITING || menuState == MenuState::JOIN_INPUT) {
         // Semi-transparent panel first, then text, then button on top.
         auto pr = menuInfoPanelRect();
-        sf::RectangleShape panel({pr.width, pr.height});
-        panel.setPosition(pr.left, pr.top);
+        sf::RectangleShape panel({pr.size.x, pr.size.y});
+        panel.setPosition({pr.position.x, pr.position.y});
         panel.setFillColor(sf::Color(0, 0, 0, 180));
         win.draw(panel);
 
         if (menuState == MenuState::HOST_WAITING) {
-            sf::Text title("HOSTING GAME", font, 50);
+            sf::Text title(font, "HOSTING GAME", 50);
             title.setFillColor(sf::Color::Green);
-            title.setStyle(sf::Text::Bold);
+            title.setStyle(sf::Text::Style::Bold);
             centerText(title, kMenuW / 2.f, 150.f);
             win.draw(title);
 
-            sf::Text ipText("Your IP: " + hostIpAddress, font, 35);
+            sf::Text ipText(font, "Your IP: " + hostIpAddress, 35);
             ipText.setFillColor(sf::Color::White);
             centerText(ipText, kMenuW / 2.f, 250.f);
             win.draw(ipText);
 
             if (!statusMessage.empty()) {
-                sf::Text statusText(statusMessage, font, 30);
+                sf::Text statusText(font, statusMessage, 30);
                 statusText.setFillColor(sf::Color(200, 200, 200));
                 centerText(statusText, kMenuW / 2.f, 350.f);
                 win.draw(statusText);
             }
         } else {
-            sf::Text title("JOIN GAME", font, 50);
+            sf::Text title(font, "JOIN GAME", 50);
             title.setFillColor(sf::Color::Blue);
-            title.setStyle(sf::Text::Bold);
+            title.setStyle(sf::Text::Style::Bold);
             centerText(title, kMenuW / 2.f, 150.f);
             win.draw(title);
 
-            sf::Text prompt("Enter Host IP Address:", font, 30);
+            sf::Text prompt(font, "Enter Host IP Address:", 30);
             prompt.setFillColor(sf::Color::White);
             centerText(prompt, kMenuW / 2.f, 250.f);
             win.draw(prompt);
 
-            sf::Text ipText(ipInput, font, 40);
+            sf::Text ipText(font, ipInput, 40);
             ipText.setFillColor(sf::Color::Green);
             centerText(ipText, kMenuW / 2.f, 320.f);
             win.draw(ipText);
 
-            sf::Text instruct("Press ENTER to connect", font, 25);
+            sf::Text instruct(font, "Press ENTER to connect", 25);
             instruct.setFillColor(sf::Color(200, 200, 200));
             centerText(instruct, kMenuW / 2.f, 400.f);
             win.draw(instruct);
 
             if (!statusMessage.empty()) {
-                sf::Text statusText(statusMessage, font, 22);
+                sf::Text statusText(font, statusMessage, 22);
                 statusText.setFillColor(statusMessage.find("Failed") != std::string::npos
                                             ? sf::Color::Red
                                             : sf::Color::Yellow);
@@ -202,15 +202,15 @@ static void renderMenu(sf::RenderWindow& win, RegularGameObject& bg, const sf::F
             }
         }
     } else if (menuState == MenuState::AI_DIFFICULTY) {
-        sf::Text diffTitle("SELECT DIFFICULTY", font, 40);
+        sf::Text diffTitle(font, "SELECT DIFFICULTY", 40);
         diffTitle.setFillColor(sf::Color::White);
-        diffTitle.setStyle(sf::Text::Bold);
+        diffTitle.setStyle(sf::Text::Style::Bold);
         centerText(diffTitle, kMenuW / 2.f, 80.f);
         win.draw(diffTitle);
     } else if (menuState == MenuState::READY_TO_START && !statusMessage.empty()) {
-        sf::Text statusText(statusMessage, font, 30);
+        sf::Text statusText(font, statusMessage, 30);
         statusText.setFillColor(sf::Color::Green);
-        statusText.setStyle(sf::Text::Bold);
+        statusText.setStyle(sf::Text::Style::Bold);
         centerText(statusText, kMenuW / 2.f, 350.f);
         win.draw(statusText);
     }
@@ -258,27 +258,25 @@ MenuResult showMenu(KeyBindings& bindings, const DebugConfig& cfg) {
     loadOrThrow(background, resource_path + "m_start_background.wav");
     background.play();
     background.setVolume(60);
-    background.setLoop(true);
+    background.setLooping(true);
 
     sf::SoundBuffer down_buffer;
     loadOrThrow(down_buffer, resource_path + "ButtonOn.wav");
 
-    sf::Sound press;
-    press.setBuffer(down_buffer);
+    sf::Sound press(down_buffer);
 
     sf::Font font;
     loadOrThrow(font, resource_path + "oswald.ttf");
 
-    sf::RenderWindow startscreen(sf::VideoMode(1024, 576), "Dungeon Game", sf::Style::Default);
+    sf::RenderWindow startscreen(sf::VideoMode({1024u, 576u}), "Dungeon Game", sf::Style::Default);
     startscreen.setView(makeLetterboxView({kMenuW, kMenuH}, startscreen.getSize()));
 
     // ── Harness loop (bounded; exits after cfg.frames or window close) ─────────
     if (cfg.menuMode()) {
         const int effectiveFrames = (cfg.frames > 0 ? cfg.frames : 5);
         for (int frame = 0; frame < effectiveFrames; ++frame) {
-            sf::Event event;
-            while (startscreen.pollEvent(event)) {
-                if (event.type == sf::Event::Closed)
+            while (const auto event = startscreen.pollEvent()) {
+                if (event->is<sf::Event::Closed>())
                     startscreen.close();
             }
             if (!startscreen.isOpen())
@@ -300,44 +298,43 @@ MenuResult showMenu(KeyBindings& bindings, const DebugConfig& cfg) {
 
     // ── Normal interactive loop ────────────────────────────────────────────────
     while (startscreen.isOpen()) {
-        sf::Event event;
-        while (startscreen.pollEvent(event)) {
-            if (event.type == sf::Event::Closed) {
+        while (const auto event = startscreen.pollEvent()) {
+            if (event->is<sf::Event::Closed>()) {
                 background.stop();
                 startscreen.close();
                 result.quit = true;
                 return result;
             }
-            if (event.type == sf::Event::Resized) {
-                startscreen.setView(
-                    makeLetterboxView({kMenuW, kMenuH}, {event.size.width, event.size.height}));
+            if (const auto* rs = event->getIf<sf::Event::Resized>()) {
+                startscreen.setView(makeLetterboxView({kMenuW, kMenuH}, rs->size));
             }
-            if (event.type == sf::Event::KeyPressed) {
+            if (const auto* kp = event->getIf<sf::Event::KeyPressed>()) {
                 if (menuState == MenuState::SETTINGS) {
                     if (capturingIdx >= 0) {
-                        if (event.key.code == sf::Keyboard::Escape) {
+                        if (kp->code == sf::Keyboard::Key::Escape) {
                             capturingIdx = -1;
-                        } else if (nameFromKey(event.key.code) == "Unknown") {
+                        } else if (nameFromKey(kp->code) == "Unknown") {
                             // Key not in kKeyTable (IME, multimedia, etc.) — silently cancel.
                             capturingIdx = -1;
-                        } else if (isReservedKey(event.key.code, bindings)) {
+                        } else if (isReservedKey(kp->code, bindings)) {
                             capturingIdx = -1;
                             statusMessage = "Reserved key";
                         } else {
-                            bindings = applyBindingEdit(bindings, capturingIdx, event.key.code);
+                            bindings = applyBindingEdit(bindings, capturingIdx, kp->code);
                             saveControls(bindings, statusMessage);
                             capturingIdx = -1;
                         }
-                    } else if (event.key.code == sf::Keyboard::Escape) {
+                    } else if (kp->code == sf::Keyboard::Key::Escape) {
                         capturingIdx = -1;
                         menuState = MenuState::MAIN_MENU;
                     }
                 }
             }
-            if (menuState == MenuState::JOIN_INPUT && event.type == sf::Event::TextEntered) {
-                if (event.text.unicode == '\b' && !ipInput.empty()) {
+            if (const auto* te = event->getIf<sf::Event::TextEntered>();
+                te && menuState == MenuState::JOIN_INPUT) {
+                if (te->unicode == '\b' && !ipInput.empty()) {
                     ipInput.pop_back();
-                } else if (event.text.unicode == '\r' || event.text.unicode == '\n') {
+                } else if (te->unicode == '\r' || te->unicode == '\n') {
                     netManager = std::make_shared<NetworkManager>();
                     statusMessage = "Connecting...";
                     if (netManager->connectToHost(ipInput)) {
@@ -348,17 +345,15 @@ MenuResult showMenu(KeyBindings& bindings, const DebugConfig& cfg) {
                         statusMessage = "Failed to connect (invalid IP or host unreachable)";
                         netManager = nullptr;
                     }
-                } else if (event.text.unicode < 128 && event.text.unicode != '\b' &&
-                           ipInput.length() < 30) {
-                    char c = static_cast<char>(event.text.unicode);
+                } else if (te->unicode < 128 && te->unicode != '\b' && ipInput.length() < 30) {
+                    char c = static_cast<char>(te->unicode);
                     if ((c >= '0' && c <= '9') || c == '.' || c == ':')
                         ipInput += c;
                 }
             }
-            if (event.type == sf::Event::MouseButtonReleased &&
-                event.mouseButton.button == sf::Mouse::Left) {
-                sf::Vector2f mp =
-                    startscreen.mapPixelToCoords({event.mouseButton.x, event.mouseButton.y});
+            if (const auto* mb = event->getIf<sf::Event::MouseButtonReleased>();
+                mb && mb->button == sf::Mouse::Button::Left) {
+                sf::Vector2f mp = startscreen.mapPixelToCoords(mb->position);
 
                 if (menuState == MenuState::MAIN_MENU) {
                     auto specs = menuButtonRects(menuState);
@@ -375,7 +370,10 @@ MenuResult showMenu(KeyBindings& bindings, const DebugConfig& cfg) {
                         if (netManager->startHost()) {
                             mode = NetworkMode::HOST;
                             menuState = MenuState::HOST_WAITING;
-                            hostIpAddress = sf::IpAddress::getLocalAddress().toString();
+                            {
+                                auto local = sf::IpAddress::getLocalAddress();
+                                hostIpAddress = local ? local->toString() : "unknown";
+                            }
                             statusMessage = "Waiting for player 2...";
                         } else {
                             statusMessage = "Failed to start host!";

--- a/src/menu_button.cpp
+++ b/src/menu_button.cpp
@@ -6,9 +6,9 @@ static const sf::Color kOutlineColor(180, 180, 200, 180);
 
 MenuButton::MenuButton(sf::Vector2f size, const sf::Font& font, const std::string& text,
                        unsigned charSize)
-    : label(text, font, charSize) {
+    : label(font, text, charSize) {
     shape.setSize(size);
-    shape.setOrigin(size.x / 2.f, size.y / 2.f);
+    shape.setOrigin({size.x / 2.f, size.y / 2.f});
     shape.setFillColor(kNormalFill);
     shape.setOutlineColor(kOutlineColor);
     shape.setOutlineThickness(1.5f);
@@ -17,7 +17,7 @@ MenuButton::MenuButton(sf::Vector2f size, const sf::Font& font, const std::strin
 void MenuButton::setPosition(sf::Vector2f centre) {
     shape.setPosition(centre);
     auto lb = label.getLocalBounds();
-    label.setOrigin(lb.left + lb.width / 2.f, lb.top + lb.height / 2.f);
+    label.setOrigin({lb.position.x + lb.size.x / 2.f, lb.position.y + lb.size.y / 2.f});
     label.setPosition(centre);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,19 +35,6 @@ target_compile_definitions(dungeon_integration_tests PRIVATE
 # Ensure dungeon_game (and thus assets/ copy) is built before integration tests
 add_dependencies(dungeon_integration_tests dungeon_game)
 
-# Static sfml-audio still imports openal32.dll at runtime; copy it next to each
-# test binary (they live in their own dir under a multi-config generator) so a
-# developer can run either exe / ctest directly without a DLL-load failure.
-if(WIN32 AND DEFINED sfml_SOURCE_DIR)
-    foreach(t dungeon_tests dungeon_integration_tests)
-        add_custom_command(TARGET ${t} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                ${sfml_SOURCE_DIR}/extlibs/bin/x64/openal32.dll
-                $<TARGET_FILE_DIR:${t}>
-            COMMENT "Copying openal32.dll next to ${t}")
-    endforeach()
-endif()
-
 # ── Warnings (mirror root settings) ──────────────────────────────────────────
 foreach(t dungeon_tests dungeon_integration_tests)
     if(MSVC)

--- a/tests/test_ai.cpp
+++ b/tests/test_ai.cpp
@@ -13,14 +13,14 @@ static AiView makeView(float selfX, float selfY, float oppX, float oppY, bool fa
                        bool inCooldown = false) {
     AiView v;
     v.selfPos = {selfX, selfY};
-    v.selfBounds = {selfX - 60.f, selfY - 90.f, 120.f, 180.f}; // normalised positive rect
+    v.selfBounds = {{selfX - 60.f, selfY - 90.f}, {120.f, 180.f}}; // normalised positive rect
     v.selfFacingLeft = facingLeft;
     v.oppPos = {oppX, oppY};
-    v.oppBounds = {oppX - 60.f, oppY - 90.f, 120.f, 180.f};
+    v.oppBounds = {{oppX - 60.f, oppY - 90.f}, {120.f, 180.f}};
     // Hazards far off-screen
-    v.hazards = {sf::FloatRect{-2000.f, -2000.f, 1.f, 1.f},
-                 sf::FloatRect{-2000.f, -2000.f, 1.f, 1.f},
-                 sf::FloatRect{-2000.f, -2000.f, 1.f, 1.f}};
+    v.hazards = {sf::FloatRect{{-2000.f, -2000.f}, {1.f, 1.f}},
+                 sf::FloatRect{{-2000.f, -2000.f}, {1.f, 1.f}},
+                 sf::FloatRect{{-2000.f, -2000.f}, {1.f, 1.f}}};
     v.inCooldown = inCooldown;
     v.selfScore = 0;
     v.oppScore = 0;
@@ -61,7 +61,7 @@ TEST_CASE("ai: near-edge attack - wide opponent to the right, anchor out but edg
     // Robot at x=960; opponent anchor at x=1410 (dx=+450 > attackRange -> anchor out of range).
     AiView v = makeView(960.f, 400.f, 1410.f, 400.f, /*facingLeft=*/false);
     // Wide opponent: near (left) edge at 1260 -> edge distance 300 < attackRange=320.
-    v.oppBounds = sf::FloatRect{1260.f, 310.f, 300.f, 180.f};
+    v.oppBounds = sf::FloatRect{{1260.f, 310.f}, {300.f, 180.f}};
 
     PlayerInput out = decideAiInput(v, p, rng);
     REQUIRE(out.attack == true); // fires on near-edge distance, not the far anchor
@@ -119,7 +119,7 @@ TEST_CASE("ai: selfBounds in hazard -> moves out, no attack", "[ai]") {
     // Place a hazard overlapping the inflated selfBounds
     // selfBounds = {900, 310, 120, 180}; inflated by 80 -> {820, 230, 280, 340}
     // Hazard at x=830, width=20 -> overlaps inflated bounds
-    v.hazards[0] = sf::FloatRect{830.f, 250.f, 20.f, 300.f};
+    v.hazards[0] = sf::FloatRect{{830.f, 250.f}, {20.f, 300.f}};
 
     PlayerInput out = decideAiInput(v, p, rng);
     REQUIRE(out.attack == false);
@@ -201,7 +201,7 @@ TEST_CASE("ai: reaction delay - teleport seen after reactionSteps", "[ai]") {
 
     // Now teleport opponent to far left - AI should NOT react immediately
     v.oppPos = {100.f, 400.f};
-    v.oppBounds = {40.f, 310.f, 120.f, 180.f};
+    v.oppBounds = {{40.f, 310.f}, {120.f, 180.f}};
     v.step = p.reactionSteps - 1;
     PlayerInput at_teleport = ctrl.step(v);
     // Still sees old position (reactionSteps - 1 steps of new pos; need reactionSteps)

--- a/tests/test_loopback.cpp
+++ b/tests/test_loopback.cpp
@@ -87,12 +87,12 @@ TEST_CASE("loopback: unknown message type is discarded", "[loopback][unit]") {
 
     sf::TcpSocket rawSender;
     rawSender.setBlocking(true);
-    REQUIRE(rawSender.connect(sf::IpAddress::LocalHost, port2) == sf::Socket::Done);
+    REQUIRE(rawSender.connect(sf::IpAddress::LocalHost, port2) == sf::Socket::Status::Done);
     REQUIRE(host2.waitForClient(sf::seconds(5)));
 
     sf::Packet unknownPkt;
-    unknownPkt << static_cast<sf::Uint8>(99);
-    rawSender.send(unknownPkt);
+    unknownPkt << static_cast<std::uint8_t>(99);
+    (void)rawSender.send(unknownPkt);
 
     for (int i = 0; i < 100; ++i) {
         host2.poll();

--- a/tests/test_netcode.cpp
+++ b/tests/test_netcode.cpp
@@ -83,7 +83,7 @@ TEST_CASE("dispatchPacket routes State into stateBuf", "[netcode][unit]") {
     s.p1_y = 7.f;
 
     sf::Packet pkt;
-    pkt << static_cast<sf::Uint8>(2); // MsgType::State
+    pkt << static_cast<std::uint8_t>(2); // MsgType::State
     s.toPacket(pkt);
 
     dispatchPacket(pkt, sf::seconds(1.f), stateBuf, inputQueue, 4);
@@ -106,7 +106,7 @@ TEST_CASE("dispatchPacket routes Input into inputQueue", "[netcode][unit]") {
     inp.attack = true;
 
     sf::Packet pkt;
-    pkt << static_cast<sf::Uint8>(1); // MsgType::Input
+    pkt << static_cast<std::uint8_t>(1); // MsgType::Input
     inp.toPacket(pkt);
 
     dispatchPacket(pkt, sf::seconds(0.f), stateBuf, inputQueue, 4);
@@ -125,7 +125,7 @@ TEST_CASE("dispatchPacket discards unknown message type", "[netcode][unit]") {
     std::deque<PlayerInput> inputQueue;
 
     sf::Packet pkt;
-    pkt << static_cast<sf::Uint8>(99); // unknown
+    pkt << static_cast<std::uint8_t>(99); // unknown
 
     dispatchPacket(pkt, sf::seconds(0.f), stateBuf, inputQueue, 4);
 
@@ -141,7 +141,7 @@ TEST_CASE("dispatchPacket evicts oldest state when cap reached", "[netcode][unit
 
     for (int i = 0; i < 5; ++i) {
         sf::Packet pkt;
-        pkt << static_cast<sf::Uint8>(2);
+        pkt << static_cast<std::uint8_t>(2);
         GameState s;
         s.p1_x = static_cast<float>(i);
         s.toPacket(pkt);

--- a/tests/test_unit.cpp
+++ b/tests/test_unit.cpp
@@ -54,7 +54,7 @@ public:
     void setOrigin() override {}
     sf::FloatRect getGlobalBounds() const override {
         // Centered-origin convention: matches AnimatedGameObject post-setOrigin().
-        return {px - w * sx / 2.f, py - h * sy / 2.f, w * sx, h * sy};
+        return {{px - w * sx / 2.f, py - h * sy / 2.f}, {w * sx, h * sy}};
     }
 };
 
@@ -70,10 +70,10 @@ TEST_CASE("objectBounds: positive scale produces correct rect", "[geometry][unit
     obj.sy = 2;
 
     sf::FloatRect r = objectBounds(obj);
-    REQUIRE(r.left == Catch::Approx(100.f));
-    REQUIRE(r.top == Catch::Approx(200.f));
-    REQUIRE(r.width == Catch::Approx(100.f)); // 50 * 2
-    REQUIRE(r.height == Catch::Approx(60.f)); // 30 * 2
+    REQUIRE(r.position.x == Catch::Approx(100.f));
+    REQUIRE(r.position.y == Catch::Approx(200.f));
+    REQUIRE(r.size.x == Catch::Approx(100.f)); // 50 * 2
+    REQUIRE(r.size.y == Catch::Approx(60.f));  // 30 * 2
 }
 
 TEST_CASE("objectBounds: negative scale.x produces negative-width rect (pinned quirk)",
@@ -89,10 +89,10 @@ TEST_CASE("objectBounds: negative scale.x produces negative-width rect (pinned q
     obj.sy = 1;
 
     sf::FloatRect r = objectBounds(obj);
-    REQUIRE(r.left == Catch::Approx(500.f));
-    REQUIRE(r.top == Catch::Approx(400.f));
-    REQUIRE(r.width == Catch::Approx(-119.f)); // negative - NOT normalised here
-    REQUIRE(r.height == Catch::Approx(180.f));
+    REQUIRE(r.position.x == Catch::Approx(500.f));
+    REQUIRE(r.position.y == Catch::Approx(400.f));
+    REQUIRE(r.size.x == Catch::Approx(-119.f)); // negative - NOT normalised here
+    REQUIRE(r.size.y == Catch::Approx(180.f));
 }
 
 // ── normalizedBounds ─────────────────────────────────────────────────────────
@@ -112,37 +112,37 @@ TEST_CASE("normalizedBounds: normalises every scale-sign combination", "[geometr
         obj.sx = 2;
         obj.sy = 2;
         sf::FloatRect r = normalizedBounds(obj);
-        REQUIRE(r.left == Catch::Approx(500.f));
-        REQUIRE(r.top == Catch::Approx(400.f));
-        REQUIRE(r.width == Catch::Approx(238.f));
-        REQUIRE(r.height == Catch::Approx(360.f));
+        REQUIRE(r.position.x == Catch::Approx(500.f));
+        REQUIRE(r.position.y == Catch::Approx(400.f));
+        REQUIRE(r.size.x == Catch::Approx(238.f));
+        REQUIRE(r.size.y == Catch::Approx(360.f));
     }
     SECTION("negative scale.x - left shifts, width positive") {
         obj.sx = -1;
         obj.sy = 1;
         sf::FloatRect r = normalizedBounds(obj);
-        REQUIRE(r.left == Catch::Approx(381.f)); // 500 + (-119)
-        REQUIRE(r.top == Catch::Approx(400.f));
-        REQUIRE(r.width == Catch::Approx(119.f));
-        REQUIRE(r.height == Catch::Approx(180.f));
+        REQUIRE(r.position.x == Catch::Approx(381.f)); // 500 + (-119)
+        REQUIRE(r.position.y == Catch::Approx(400.f));
+        REQUIRE(r.size.x == Catch::Approx(119.f));
+        REQUIRE(r.size.y == Catch::Approx(180.f));
     }
     SECTION("negative scale.y - top shifts, height positive") {
         obj.sx = 1;
         obj.sy = -1;
         sf::FloatRect r = normalizedBounds(obj);
-        REQUIRE(r.left == Catch::Approx(500.f));
-        REQUIRE(r.top == Catch::Approx(220.f)); // 400 + (-180)
-        REQUIRE(r.width == Catch::Approx(119.f));
-        REQUIRE(r.height == Catch::Approx(180.f));
+        REQUIRE(r.position.x == Catch::Approx(500.f));
+        REQUIRE(r.position.y == Catch::Approx(220.f)); // 400 + (-180)
+        REQUIRE(r.size.x == Catch::Approx(119.f));
+        REQUIRE(r.size.y == Catch::Approx(180.f));
     }
     SECTION("both negative - both axes corrected") {
         obj.sx = -1;
         obj.sy = -1;
         sf::FloatRect r = normalizedBounds(obj);
-        REQUIRE(r.left == Catch::Approx(381.f));
-        REQUIRE(r.top == Catch::Approx(220.f));
-        REQUIRE(r.width == Catch::Approx(119.f));
-        REQUIRE(r.height == Catch::Approx(180.f));
+        REQUIRE(r.position.x == Catch::Approx(381.f));
+        REQUIRE(r.position.y == Catch::Approx(220.f));
+        REQUIRE(r.size.x == Catch::Approx(119.f));
+        REQUIRE(r.size.y == Catch::Approx(180.f));
     }
 }
 
@@ -169,7 +169,7 @@ TEST_CASE("objectBounds: touching rects with negative-width rect do not crash",
     // Overlap on x: [200,200] -> touching (not overlapping); intersects() returns false.
     sf::FloatRect ra = objectBounds(a);
     sf::FloatRect rb = objectBounds(b);
-    bool result = ra.intersects(rb);
+    bool result = ra.findIntersection(rb).has_value();
     (void)result; // touching rects; key point is no crash, not the bool result
     SUCCEED("negative-width intersects() did not crash");
 }
@@ -189,7 +189,7 @@ TEST_CASE("objectBounds: disjoint objects do not intersect", "[geometry][unit]")
     b.sx = 1;
     b.sy = 1;
 
-    REQUIRE(!objectBounds(a).intersects(objectBounds(b)));
+    REQUIRE(!objectBounds(a).findIntersection(objectBounds(b)).has_value());
 }
 
 TEST_CASE("objectBounds: overlapping objects intersect", "[geometry][unit]") {
@@ -207,7 +207,7 @@ TEST_CASE("objectBounds: overlapping objects intersect", "[geometry][unit]") {
     b.sx = 1;
     b.sy = 1;
 
-    REQUIRE(objectBounds(a).intersects(objectBounds(b)));
+    REQUIRE(objectBounds(a).findIntersection(objectBounds(b)).has_value());
 }
 
 // ── advanceFrameRect ───────────────────────────────────────────────────────────
@@ -223,7 +223,7 @@ TEST_CASE("objectBounds: overlapping objects intersect", "[geometry][unit]") {
 
 TEST_CASE("advanceFrameRect: fire sheet - full cycle resets to frame 1", "[anim][unit]") {
     // Walk all 10 frames of the fire sheet, verify reset after frame 10
-    sf::IntRect rect(0, 0, 43, 72); // initial rect from load()
+    sf::IntRect rect({0, 0}, {43, 72}); // initial rect from load()
     int curr = 1;
 
     for (int step = 0; step < 10; ++step) {
@@ -233,20 +233,20 @@ TEST_CASE("advanceFrameRect: fire sheet - full cycle resets to frame 1", "[anim]
     }
     // After 10 advances, curr resets to 1 and rect resets to (0,0,43,72)
     REQUIRE(curr == 1);
-    REQUIRE(rect.left == 0);
-    REQUIRE(rect.top == 0);
-    REQUIRE(rect.width == 43);
-    REQUIRE(rect.height == 72);
+    REQUIRE(rect.position.x == 0);
+    REQUIRE(rect.position.y == 0);
+    REQUIRE(rect.size.x == 43);
+    REQUIRE(rect.size.y == 72);
 }
 
 TEST_CASE("advanceFrameRect: fire sheet - row wrap at curr%nx==0", "[anim][unit]") {
     // curr=5 (last in row 0, 0-indexed), check==0 -> new row
-    sf::IntRect rect(4 * 43, 0, 43, 72); // curr=5, check = 5%5 = 0
+    sf::IntRect rect({4 * 43, 0}, {43, 72}); // curr=5, check = 5%5 = 0
     int curr = 5;
 
     auto res = advanceFrameRect(rect, curr, 5, 3, 10, 216.0, 216.0);
-    REQUIRE(res.rect.left == 0);
-    REQUIRE(res.rect.top == 72); // new row: old top(0) + height(72)
+    REQUIRE(res.rect.position.x == 0);
+    REQUIRE(res.rect.position.y == 72); // new row: old top(0) + height(72)
     REQUIRE(res.curr == 6);
 }
 
@@ -254,21 +254,21 @@ TEST_CASE("advanceFrameRect: fire sheet - int-ceil quirk pinned", "[anim][unit]"
     // curr=3, check = 3%5 = 3 ≠ 0 -> else branch
     // ((int)ceil(3/5)) = ((int)ceil(0)) = 0   ← int division BEFORE ceil
     // So top = 0 * 72 = 0
-    sf::IntRect rect(43, 0, 43, 72); // curr=2, but we'll test curr=3
-    rect = sf::IntRect(2 * 43, 0, 43, 72);
+    sf::IntRect rect({43, 0}, {43, 72}); // curr=2, but we'll test curr=3
+    rect = sf::IntRect({2 * 43, 0}, {43, 72});
     int curr = 3;
 
     auto res = advanceFrameRect(rect, curr, 5, 3, 10, 216.0, 216.0);
     // check = 3%5 = 3 ≠ 0 -> else branch
     // h = floor(216/3) = 72
     // top = ceil(3/5) * 72 = ceil(0) * 72 = 0  (int division first)
-    REQUIRE(res.rect.top == 0);
+    REQUIRE(res.rect.position.y == 0);
     REQUIRE(res.curr == 4);
 }
 
 TEST_CASE("advanceFrameRect: player sheet (rocket) - full cycle", "[anim][unit]") {
     // AnimatedGameObject(404, 206, 3, 3, 9, 0): frame 134x68, 9 frames total
-    sf::IntRect rect(0, 0, 134, 68);
+    sf::IntRect rect({0, 0}, {134, 68});
     int curr = 1;
 
     for (int step = 0; step < 9; ++step) {
@@ -277,21 +277,21 @@ TEST_CASE("advanceFrameRect: player sheet (rocket) - full cycle", "[anim][unit]"
         curr = res.curr;
     }
     REQUIRE(curr == 1);
-    REQUIRE(rect.left == 0);
-    REQUIRE(rect.top == 0);
+    REQUIRE(rect.position.x == 0);
+    REQUIRE(rect.position.y == 0);
 }
 
 TEST_CASE("advanceFrameRect: robot sheet - walk first frame", "[anim][unit]") {
     // AnimatedGameObject(959, 180, 8, 1, 8, 0): frame floor(959/8)=119, 8 frames total
-    sf::IntRect rect(0, 0, 119, 180);
+    sf::IntRect rect({0, 0}, {119, 180});
     int curr = 1;
 
     auto res = advanceFrameRect(rect, curr, 8, 1, 8, 959.0, 180.0);
     // curr=1, check=1%8=1 ≠ 0 -> else branch
     // h = floor(180/1) = 180
     // top = ceil(1/8)*180 = ceil(0)*180 = 0  (int division: 1/8=0)
-    REQUIRE(res.rect.left == 119);
-    REQUIRE(res.rect.top == 0);
+    REQUIRE(res.rect.position.x == 119);
+    REQUIRE(res.rect.position.y == 0);
     REQUIRE(res.curr == 2);
 }
 
@@ -402,10 +402,10 @@ TEST_CASE("makeLetterboxView: wider window -> pillarbox viewport", "[letterbox][
     // vpW = 1.777/2.370 = 0.75, vpX = 0.125
     auto view = makeLetterboxView({1920.f, 1080.f}, {2560u, 1080u});
     auto vp = view.getViewport();
-    REQUIRE(vp.left == Catch::Approx(0.125f).margin(0.001f));
-    REQUIRE(vp.top == Catch::Approx(0.f).margin(0.001f));
-    REQUIRE(vp.width == Catch::Approx(0.75f).margin(0.001f));
-    REQUIRE(vp.height == Catch::Approx(1.f).margin(0.001f));
+    REQUIRE(vp.position.x == Catch::Approx(0.125f).margin(0.001f));
+    REQUIRE(vp.position.y == Catch::Approx(0.f).margin(0.001f));
+    REQUIRE(vp.size.x == Catch::Approx(0.75f).margin(0.001f));
+    REQUIRE(vp.size.y == Catch::Approx(1.f).margin(0.001f));
 }
 
 TEST_CASE("makeLetterboxView: taller window -> letterbox viewport", "[letterbox][unit]") {
@@ -414,19 +414,19 @@ TEST_CASE("makeLetterboxView: taller window -> letterbox viewport", "[letterbox]
     // vpH = 1.333/1.777 = 0.75, vpY = 0.125
     auto view = makeLetterboxView({1920.f, 1080.f}, {1920u, 1440u});
     auto vp = view.getViewport();
-    REQUIRE(vp.left == Catch::Approx(0.f).margin(0.001f));
-    REQUIRE(vp.top == Catch::Approx(0.125f).margin(0.001f));
-    REQUIRE(vp.width == Catch::Approx(1.f).margin(0.001f));
-    REQUIRE(vp.height == Catch::Approx(0.75f).margin(0.001f));
+    REQUIRE(vp.position.x == Catch::Approx(0.f).margin(0.001f));
+    REQUIRE(vp.position.y == Catch::Approx(0.125f).margin(0.001f));
+    REQUIRE(vp.size.x == Catch::Approx(1.f).margin(0.001f));
+    REQUIRE(vp.size.y == Catch::Approx(0.75f).margin(0.001f));
 }
 
 TEST_CASE("makeLetterboxView: exact aspect -> full viewport", "[letterbox][unit]") {
     auto view = makeLetterboxView({1920.f, 1080.f}, {1920u, 1080u});
     auto vp = view.getViewport();
-    REQUIRE(vp.left == Catch::Approx(0.f).margin(0.001f));
-    REQUIRE(vp.top == Catch::Approx(0.f).margin(0.001f));
-    REQUIRE(vp.width == Catch::Approx(1.f).margin(0.001f));
-    REQUIRE(vp.height == Catch::Approx(1.f).margin(0.001f));
+    REQUIRE(vp.position.x == Catch::Approx(0.f).margin(0.001f));
+    REQUIRE(vp.position.y == Catch::Approx(0.f).margin(0.001f));
+    REQUIRE(vp.size.x == Catch::Approx(1.f).margin(0.001f));
+    REQUIRE(vp.size.y == Catch::Approx(1.f).margin(0.001f));
 }
 
 TEST_CASE("makeLetterboxView: view maps logical rect [0,0,w,h]", "[letterbox][unit]") {
@@ -443,40 +443,40 @@ TEST_CASE("makeLetterboxView: view maps logical rect [0,0,w,h]", "[letterbox][un
 // ── key_bindings ───────────────────────────────────────────────────────────────
 
 TEST_CASE("keyFromName / nameFromKey round-trip", "[key_bindings][unit]") {
-    REQUIRE(keyFromName("Num8") == sf::Keyboard::Numpad8);
-    REQUIRE(nameFromKey(sf::Keyboard::Numpad8) == "Num8");
-    REQUIRE(keyFromName("Space") == sf::Keyboard::Space);
-    REQUIRE(nameFromKey(sf::Keyboard::Space) == "Space");
-    REQUIRE(keyFromName("Right") == sf::Keyboard::Right);
-    REQUIRE(nameFromKey(sf::Keyboard::Right) == "Right");
-    REQUIRE(keyFromName("W") == sf::Keyboard::W);
-    REQUIRE(nameFromKey(sf::Keyboard::W) == "W");
+    REQUIRE(keyFromName("Num8") == sf::Keyboard::Key::Numpad8);
+    REQUIRE(nameFromKey(sf::Keyboard::Key::Numpad8) == "Num8");
+    REQUIRE(keyFromName("Space") == sf::Keyboard::Key::Space);
+    REQUIRE(nameFromKey(sf::Keyboard::Key::Space) == "Space");
+    REQUIRE(keyFromName("Right") == sf::Keyboard::Key::Right);
+    REQUIRE(nameFromKey(sf::Keyboard::Key::Right) == "Right");
+    REQUIRE(keyFromName("W") == sf::Keyboard::Key::W);
+    REQUIRE(nameFromKey(sf::Keyboard::Key::W) == "W");
 }
 
 TEST_CASE("keyFromName: unknown name returns Unknown", "[key_bindings][unit]") {
-    REQUIRE(keyFromName("INVALID_KEY") == sf::Keyboard::Unknown);
-    REQUIRE(keyFromName("") == sf::Keyboard::Unknown);
+    REQUIRE(keyFromName("INVALID_KEY") == sf::Keyboard::Key::Unknown);
+    REQUIRE(keyFromName("") == sf::Keyboard::Key::Unknown);
 }
 
 TEST_CASE("nameFromKey: unknown key returns 'Unknown'", "[key_bindings][unit]") {
-    REQUIRE(nameFromKey(sf::Keyboard::Unknown) == "Unknown");
+    REQUIRE(nameFromKey(sf::Keyboard::Key::Unknown) == "Unknown");
 }
 
 TEST_CASE("defaultBindings: hard-coded keys match original layout", "[key_bindings][unit]") {
     auto b = defaultBindings();
-    REQUIRE(b.p1.up == sf::Keyboard::Numpad8);
-    REQUIRE(b.p1.down == sf::Keyboard::Numpad5);
-    REQUIRE(b.p1.left == sf::Keyboard::Numpad4);
-    REQUIRE(b.p1.right == sf::Keyboard::Numpad6);
-    REQUIRE(b.p1.attack == sf::Keyboard::Right);
-    REQUIRE(b.p2.up == sf::Keyboard::W);
-    REQUIRE(b.p2.down == sf::Keyboard::S);
-    REQUIRE(b.p2.left == sf::Keyboard::A);
-    REQUIRE(b.p2.right == sf::Keyboard::D);
-    REQUIRE(b.p2.attack == sf::Keyboard::Space);
-    REQUIRE(b.slowDown == sf::Keyboard::O);
-    REQUIRE(b.speedUp == sf::Keyboard::P);
-    REQUIRE(b.skipCooldown == sf::Keyboard::K);
+    REQUIRE(b.p1.up == sf::Keyboard::Key::Numpad8);
+    REQUIRE(b.p1.down == sf::Keyboard::Key::Numpad5);
+    REQUIRE(b.p1.left == sf::Keyboard::Key::Numpad4);
+    REQUIRE(b.p1.right == sf::Keyboard::Key::Numpad6);
+    REQUIRE(b.p1.attack == sf::Keyboard::Key::Right);
+    REQUIRE(b.p2.up == sf::Keyboard::Key::W);
+    REQUIRE(b.p2.down == sf::Keyboard::Key::S);
+    REQUIRE(b.p2.left == sf::Keyboard::Key::A);
+    REQUIRE(b.p2.right == sf::Keyboard::Key::D);
+    REQUIRE(b.p2.attack == sf::Keyboard::Key::Space);
+    REQUIRE(b.slowDown == sf::Keyboard::Key::O);
+    REQUIRE(b.speedUp == sf::Keyboard::Key::P);
+    REQUIRE(b.skipCooldown == sf::Keyboard::Key::K);
 }
 
 TEST_CASE("loadBindings: empty stream returns defaults", "[key_bindings][unit]") {
@@ -491,8 +491,8 @@ TEST_CASE("loadBindings: empty stream returns defaults", "[key_bindings][unit]")
 TEST_CASE("loadBindings: parses valid p1/p2 fields", "[key_bindings][unit]") {
     std::istringstream cfg("p1_up = W\np2_attack = Enter\n");
     auto b = loadBindings(cfg);
-    REQUIRE(b.p1.up == sf::Keyboard::W);
-    REQUIRE(b.p2.attack == sf::Keyboard::Return);
+    REQUIRE(b.p1.up == sf::Keyboard::Key::W);
+    REQUIRE(b.p2.attack == sf::Keyboard::Key::Enter);
     // Unspecified fields keep defaults
     REQUIRE(b.p1.down == defaultBindings().p1.down);
 }
@@ -500,7 +500,7 @@ TEST_CASE("loadBindings: parses valid p1/p2 fields", "[key_bindings][unit]") {
 TEST_CASE("loadBindings: strips comments and blank lines", "[key_bindings][unit]") {
     std::istringstream cfg("# comment\n\np1_up = A # inline comment\n");
     auto b = loadBindings(cfg);
-    REQUIRE(b.p1.up == sf::Keyboard::A);
+    REQUIRE(b.p1.up == sf::Keyboard::Key::A);
 }
 
 TEST_CASE("loadBindings: unknown key name warns and keeps default", "[key_bindings][unit]") {
@@ -516,19 +516,19 @@ TEST_CASE("loadBindings: all 13 fields parsed", "[key_bindings][unit]") {
         "p2_up = F6\np2_down = F7\np2_left = F8\np2_right = F9\np2_attack = F10\n"
         "slow_down = F11\nspeed_up = F12\nskip_cooldown = Tab\n");
     auto b = loadBindings(cfg);
-    REQUIRE(b.p1.up == sf::Keyboard::F1);
-    REQUIRE(b.p1.down == sf::Keyboard::F2);
-    REQUIRE(b.p1.left == sf::Keyboard::F3);
-    REQUIRE(b.p1.right == sf::Keyboard::F4);
-    REQUIRE(b.p1.attack == sf::Keyboard::F5);
-    REQUIRE(b.p2.up == sf::Keyboard::F6);
-    REQUIRE(b.p2.down == sf::Keyboard::F7);
-    REQUIRE(b.p2.left == sf::Keyboard::F8);
-    REQUIRE(b.p2.right == sf::Keyboard::F9);
-    REQUIRE(b.p2.attack == sf::Keyboard::F10);
-    REQUIRE(b.slowDown == sf::Keyboard::F11);
-    REQUIRE(b.speedUp == sf::Keyboard::F12);
-    REQUIRE(b.skipCooldown == sf::Keyboard::Tab);
+    REQUIRE(b.p1.up == sf::Keyboard::Key::F1);
+    REQUIRE(b.p1.down == sf::Keyboard::Key::F2);
+    REQUIRE(b.p1.left == sf::Keyboard::Key::F3);
+    REQUIRE(b.p1.right == sf::Keyboard::Key::F4);
+    REQUIRE(b.p1.attack == sf::Keyboard::Key::F5);
+    REQUIRE(b.p2.up == sf::Keyboard::Key::F6);
+    REQUIRE(b.p2.down == sf::Keyboard::Key::F7);
+    REQUIRE(b.p2.left == sf::Keyboard::Key::F8);
+    REQUIRE(b.p2.right == sf::Keyboard::Key::F9);
+    REQUIRE(b.p2.attack == sf::Keyboard::Key::F10);
+    REQUIRE(b.slowDown == sf::Keyboard::Key::F11);
+    REQUIRE(b.speedUp == sf::Keyboard::Key::F12);
+    REQUIRE(b.skipCooldown == sf::Keyboard::Key::Tab);
 }
 
 // ── menu_layout unit tests ────────────────────────────────────────────────────
@@ -573,21 +573,21 @@ TEST_CASE("menuButtonRects: no two buttons overlap per state", "[menu][unit]") {
             for (std::size_t j = i + 1; j < specs.size(); ++j) {
                 INFO("state " << static_cast<int>(state) << " buttons " << i << " and " << j
                               << " overlap");
-                REQUIRE(!specs[i].rect.intersects(specs[j].rect));
+                REQUIRE(!specs[i].rect.findIntersection(specs[j].rect).has_value());
             }
         }
     }
 }
 
 TEST_CASE("menuButtonRects: all rects fit within canvas", "[menu][unit]") {
-    sf::FloatRect canvas{0.f, 0.f, kMenuW, kMenuH};
+    sf::FloatRect canvas{{0.f, 0.f}, {kMenuW, kMenuH}};
     for (auto state : {MenuState::MAIN_MENU, MenuState::AI_DIFFICULTY, MenuState::HOST_WAITING,
                        MenuState::JOIN_INPUT, MenuState::READY_TO_START, MenuState::SETTINGS}) {
         for (const auto& spec : menuButtonRects(state)) {
-            REQUIRE(spec.rect.left >= 0.f);
-            REQUIRE(spec.rect.top >= 0.f);
-            REQUIRE(spec.rect.left + spec.rect.width <= canvas.width);
-            REQUIRE(spec.rect.top + spec.rect.height <= canvas.height);
+            REQUIRE(spec.rect.position.x >= 0.f);
+            REQUIRE(spec.rect.position.y >= 0.f);
+            REQUIRE(spec.rect.position.x + spec.rect.size.x <= canvas.size.x);
+            REQUIRE(spec.rect.position.y + spec.rect.size.y <= canvas.size.y);
         }
     }
 }
@@ -600,31 +600,31 @@ TEST_CASE("MenuButton::bounds equals drawn rect", "[menu][unit]") {
     sf::Font f{};
     MenuButton btn({200.f, 50.f}, f, "Test");
     btn.setPosition({300.f, 200.f});
-    REQUIRE(btn.bounds().left == Catch::Approx(198.5f));
-    REQUIRE(btn.bounds().top == Catch::Approx(173.5f));
-    REQUIRE(btn.bounds().width == Catch::Approx(203.f));
-    REQUIRE(btn.bounds().height == Catch::Approx(53.f));
+    REQUIRE(btn.bounds().position.x == Catch::Approx(198.5f));
+    REQUIRE(btn.bounds().position.y == Catch::Approx(173.5f));
+    REQUIRE(btn.bounds().size.x == Catch::Approx(203.f));
+    REQUIRE(btn.bounds().size.y == Catch::Approx(53.f));
 }
 
 TEST_CASE("pauseButtonRect: non-overlap and in-canvas", "[menu][unit]") {
     auto r0 = pauseButtonRect(0);
     auto r1 = pauseButtonRect(1);
-    REQUIRE(!r0.intersects(r1));
-    REQUIRE(r0.left >= 0.f);
-    REQUIRE(r0.top >= 0.f);
-    REQUIRE(r0.left + r0.width <= kGameW);
-    REQUIRE(r0.top + r0.height <= kGameH);
-    REQUIRE(r1.left >= 0.f);
-    REQUIRE(r1.top >= 0.f);
-    REQUIRE(r1.left + r1.width <= kGameW);
-    REQUIRE(r1.top + r1.height <= kGameH);
+    REQUIRE(!r0.findIntersection(r1).has_value());
+    REQUIRE(r0.position.x >= 0.f);
+    REQUIRE(r0.position.y >= 0.f);
+    REQUIRE(r0.position.x + r0.size.x <= kGameW);
+    REQUIRE(r0.position.y + r0.size.y <= kGameH);
+    REQUIRE(r1.position.x >= 0.f);
+    REQUIRE(r1.position.y >= 0.f);
+    REQUIRE(r1.position.x + r1.size.x <= kGameW);
+    REQUIRE(r1.position.y + r1.size.y <= kGameH);
 }
 
 TEST_CASE("menuInfoPanelRect: covers expected text positions", "[menu][unit]") {
     auto panel = menuInfoPanelRect();
     for (float y : {150.f, 250.f, 320.f, 350.f, 400.f, 460.f}) {
         INFO("panel should contain y=" << y);
-        REQUIRE(panel.contains(kMenuW / 2.f, y));
+        REQUIRE(panel.contains({kMenuW / 2.f, y}));
     }
 }
 
@@ -648,7 +648,7 @@ TEST_CASE("settingsButtonSpecs: no two rects overlap", "[settings][unit]") {
     for (std::size_t i = 0; i < specs.size(); ++i) {
         for (std::size_t j = i + 1; j < specs.size(); ++j) {
             INFO("specs " << i << " and " << j << " overlap");
-            REQUIRE(!specs[i].rect.intersects(specs[j].rect));
+            REQUIRE(!specs[i].rect.findIntersection(specs[j].rect).has_value());
         }
     }
 }
@@ -657,10 +657,10 @@ TEST_CASE("settingsButtonSpecs: all rects fit in canvas", "[settings][unit]") {
     auto b = defaultBindings();
     auto specs = settingsButtonSpecs(b);
     for (const auto& spec : specs) {
-        REQUIRE(spec.rect.left >= 0.f);
-        REQUIRE(spec.rect.top >= 0.f);
-        REQUIRE(spec.rect.left + spec.rect.width <= kMenuW);
-        REQUIRE(spec.rect.top + spec.rect.height <= kMenuH);
+        REQUIRE(spec.rect.position.x >= 0.f);
+        REQUIRE(spec.rect.position.y >= 0.f);
+        REQUIRE(spec.rect.position.x + spec.rect.size.x <= kMenuW);
+        REQUIRE(spec.rect.position.y + spec.rect.size.y <= kMenuH);
     }
 }
 
@@ -709,35 +709,35 @@ TEST_CASE("saveBindings round-trips with loadBindings", "[key_bindings][unit]") 
 
 TEST_CASE("saveBindings preserves non-default bindings", "[key_bindings][unit]") {
     auto b = defaultBindings();
-    b.p1.up = sf::Keyboard::F1;
+    b.p1.up = sf::Keyboard::Key::F1;
     std::ostringstream oss;
     saveBindings(b, oss);
     std::istringstream iss(oss.str());
     auto reloaded = loadBindings(iss);
-    REQUIRE(reloaded.p1.up == sf::Keyboard::F1);
+    REQUIRE(reloaded.p1.up == sf::Keyboard::Key::F1);
     // Other fields unchanged from defaults
     REQUIRE(reloaded.p1.down == defaultBindings().p1.down);
 }
 
 TEST_CASE("isReservedKey: rejects hard-coded and current debug keys", "[key_bindings][unit]") {
     auto b = defaultBindings();
-    REQUIRE(isReservedKey(sf::Keyboard::F11, b));
-    REQUIRE(isReservedKey(sf::Keyboard::F12, b));
+    REQUIRE(isReservedKey(sf::Keyboard::Key::F11, b));
+    REQUIRE(isReservedKey(sf::Keyboard::Key::F12, b));
     REQUIRE(isReservedKey(b.slowDown, b));
     REQUIRE(isReservedKey(b.speedUp, b));
     REQUIRE(isReservedKey(b.skipCooldown, b));
-    REQUIRE_FALSE(isReservedKey(sf::Keyboard::F3, b));
+    REQUIRE_FALSE(isReservedKey(sf::Keyboard::Key::F3, b));
 
-    b.slowDown = sf::Keyboard::F1;
-    REQUIRE(isReservedKey(sf::Keyboard::F1, b));
-    REQUIRE_FALSE(isReservedKey(sf::Keyboard::O, b));
+    b.slowDown = sf::Keyboard::Key::F1;
+    REQUIRE(isReservedKey(sf::Keyboard::Key::F1, b));
+    REQUIRE_FALSE(isReservedKey(sf::Keyboard::Key::O, b));
 }
 
 TEST_CASE("applyBindingEdit: sets new key with no conflict", "[key_bindings][unit]") {
     auto b = defaultBindings();
     // F3 is not used by any default binding
-    auto result = applyBindingEdit(b, 0, sf::Keyboard::F3);
-    REQUIRE(result.p1.up == sf::Keyboard::F3);
+    auto result = applyBindingEdit(b, 0, sf::Keyboard::Key::F3);
+    REQUIRE(result.p1.up == sf::Keyboard::Key::F3);
     // Other slots unchanged
     REQUIRE(result.p1.down == b.p1.down);
 }
@@ -747,8 +747,8 @@ TEST_CASE("applyBindingEdit: swap on conflict", "[key_bindings][unit]") {
     // rowIdx 0 = p1.up (Numpad8); newKey = b.p2.up (W) which is rowIdx 5
     sf::Keyboard::Key oldP1Up = b.p1.up;
     auto result = applyBindingEdit(b, 0, b.p2.up);
-    REQUIRE(result.p1.up == sf::Keyboard::W); // p2.up moved to p1.up
-    REQUIRE(result.p2.up == oldP1Up);         // old p1.up swapped to p2.up
+    REQUIRE(result.p1.up == sf::Keyboard::Key::W); // p2.up moved to p1.up
+    REQUIRE(result.p2.up == oldP1Up);              // old p1.up swapped to p2.up
 }
 
 TEST_CASE("applyBindingEdit: no-op when same key", "[key_bindings][unit]") {
@@ -765,7 +765,7 @@ TEST_CASE("applyBindingEdit: swap at P1/P2 boundary (rowIdx=4 vs rowIdx=5)",
     // rowIdx 4 = p1.attack (Right); rowIdx 5 = p2.up (W)
     sf::Keyboard::Key oldP1Attack = b.p1.attack;
     auto result = applyBindingEdit(b, 4, b.p2.up);
-    REQUIRE(result.p1.attack == sf::Keyboard::W);
+    REQUIRE(result.p1.attack == sf::Keyboard::Key::W);
     REQUIRE(result.p2.up == oldP1Attack);
 }
 


### PR DESCRIPTION
Closes #25.

Migrates the codebase from SFML 2.6.2 to **SFML 3.0.2** — a pure API port with no gameplay, netcode wire-format, or test-expectation changes. The 3-platform CI (build + unit + integration + menu-screenshot) is the correctness gate.

## What changed (by module)
- **CMake / CI / docs:** `find_package(SFML 3 …)`, `GIT_TAG 3.0.2`, `SFML::Graphics`/`Window`/`System`/`Audio`/`Network`. Removed all three `openal32.dll` copies (SFML 3 uses miniaudio). Updated `docs/building.md` + `CLAUDE.md` (pin + out-of-scope text), bumped CI cache keys.
- **Scoped enums:** `sf::Keyboard::Key::`, `Mouse::Button::`, `Joystick::Axis::`, `Socket::Status::`; renames `Return→Enter`, `BackSpace→Backspace`; `sf::Uint8→std::uint8_t`.
- **Rects (incl. `ai.cpp`):** `.left/.top/.width/.height → .position/.size`; `intersects()→findIntersection().has_value()`; 4-arg ctor → `{{pos},{size}}`. `geometry.h`'s negative-width collision trick is preserved (SFML 3 `findIntersection`/`contains` normalize internally).
- **Sprite/Texture:** `std::optional<sf::Sprite>` + `emplace(texture)`; `Texture::create()→sf::Texture(Vector2u)`; `Font::loadFromFile→openFromFile`.
- **Audio/Text:** `std::optional<sf::Sound>`/`<sf::Text>` members + emplace after load; `sf::Text(font, str, size)` (font first); `setRotation(sf::degrees())`; Vector2 `setPosition/setScale/setOrigin`; `setLoop→setLooping`.
- **Events:** variant API — `while (const auto ev = window.pollEvent())` + `ev->getIf<sf::Event::KeyPressed>()`.
- **Network:** `sf::IpAddress::resolve/getLocalAddress/getRemoteAddress` → `std::optional`.
- **Window:** `sf::VideoMode(Vector2u)`; `sf::Style::Fullscreen → sf::State::Fullscreen`.
- **Tests:** `tests/*.cpp` migrated (rects/enums/uint8/socket) so the suite compiles + passes.

## Validation
- Local four gates green: build (`-Werror`, zero warnings), clang-format v18, ctest **135/135** (unit + integration + smoke + menu CLI).
- The plan was validated through a two-reviewer loop against the real SFML 3.0.2 headers (see #25 comment).

## ⚠️ Before merge — macOS packaging dry-run required
SFML 3 drops the `extlibs/libs-osx/Frameworks/` bundle (static freetype + miniaudio), so the release-workflow macOS step was rewritten to `otool -L`-driven bundling. Given this repo's prior dyld history, a `workflow_dispatch` release dry-run (download the macOS zip and run it end-to-end on a clean path) is a **hard pre-merge gate** — do not merge on green CI alone.
