### PR TITLE
rc playtest follow-ups: rocket X-wrap scale + unified attack timing (#33, #37)

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -384,9 +384,8 @@ void Game::processEvents() {
                 }
             }
         } else if (const auto* jb = event->getIf<sf::Event::JoystickButtonPressed>()) {
-            // NOTE: gamepad attack fires on button PRESS; P2 keyboard attack fires on
-            // key RELEASE (see handlePlayerInput — m_p2Attack = !isDown). Pre-existing
-            // discrepancy tracked in issue #37.
+            // Gamepad attack fires on button PRESS, matching keyboard attack for both
+            // players (handlePlayerInput — m_pXAttack = isDown). Unified in #37.
             if (!m_debug.active() && jb->button == kAttackButton) {
                 if (m_networkMode == NetworkMode::LOCAL || m_networkMode == NetworkMode::HOST) {
                     if (jb->joystickId == 0)
@@ -490,7 +489,7 @@ void Game::handlePlayerInput(sf::Keyboard::Key key, bool isDown) {
             if (key == m_bindings.p2.right)
                 m_p2Right = isDown;
             if (key == m_bindings.p2.attack)
-                m_p2Attack = !isDown;
+                m_p2Attack = isDown;
         }
 
         // Speed tweaks and wait-skip
@@ -522,6 +521,9 @@ void Game::update(sf::Time deltaT, float time) {
     sf::Vector2f p2movement(0.0f, 0.0f);
 
     const float rocketH = m_rocket->getHeight() * m_rocket->getScale().y; // rendered: 68*2=136
+    // Rendered width: getWidth() is the unscaled frame width (134); scale.x flips sign with
+    // facing direction (±2), so use its magnitude for the horizontal screen-wrap (#33).
+    const float rocketW = m_rocket->getWidth() * std::abs(m_rocket->getScale().x); // 134*2=268
     if (m_p1Up) {
         if (m_rocket->getPosition().y < -rocketH) {
             m_rocket->setPosition(m_rocket->getPosition().x, kGameH - rocketH);
@@ -546,7 +548,7 @@ void Game::update(sf::Time deltaT, float time) {
         }
     }
     if (m_p1Left) {
-        if (m_rocket->getPosition().x < -(m_rocket->getWidth())) {
+        if (m_rocket->getPosition().x < -rocketW) {
             m_rocket->setPosition(kGameW, m_rocket->getPosition().y);
         }
         if (!m_p1FacingLeft) {
@@ -567,7 +569,7 @@ void Game::update(sf::Time deltaT, float time) {
         m_rocket->setScale(2.0f, 2);
 
         if (m_rocket->getPosition().x > kGameW) {
-            m_rocket->setPosition(-(m_rocket->getWidth()), m_rocket->getPosition().y);
+            m_rocket->setPosition(-rocketW, m_rocket->getPosition().y);
         }
 
         if (m_p1FacingLeft) {

--- a/tests/data/p1_wrap_left.replay
+++ b/tests/data/p1_wrap_left.replay
@@ -1,8 +1,26 @@
 # p1_wrap_left.replay — P1 moves left until it wraps to the right side of screen
 # P1 starts at x=134.  Direction flip on frame 1 shifts to x=402.
-# After 28 left steps total, position < -134 → wraps to x=1920.
-# Used with --replay-p1.
+# Moving left ~20px/frame; wraps once x < -(rendered width 268) — see #33 — around
+# frame 40, repositioning to x=1920, then continues left. Used with --replay-p1.
 # up down left right attack
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
+0 0 1 0 0
 0 0 1 0 0
 0 0 1 0 0
 0 0 1 0 0

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -229,11 +229,13 @@ TEST_CASE("integration: P2 hazard clamps points at 0", "[integration]") {
 }
 
 // ── 8. P1 left wraparound ─────────────────────────────────────────────────────
-// P1 moves left 30 steps; wraps from ~x=-138 to x=1920, ends up on right side.
+// P1 moves left ~20px/frame; wraps once x < -(rendered width = getWidth()*|scale.x| = 268,
+// see #33) around frame 40, repositioning to x=1920, then continues left. Ends on the
+// right side of the arena.
 
 TEST_CASE("integration: P1 wraps around left edge", "[integration]") {
     DebugConfig cfg;
-    cfg.frames = 35;
+    cfg.frames = 45;
     cfg.replayPathP1 = dataPath("p1_wrap_left.replay");
     auto [t, s] = runGame(cfg);
 


### PR DESCRIPTION
Two rc-playtest follow-ups found during the #28/#29 reviews.

**Closes #33** — Rocket X-wrap used unscaled `getWidth()` (134px) while the rocket renders at 268px (`|scale.x|=2`), so it wrapped ~134px too early on both horizontal edges. Now uses `getWidth() * std::abs(getScale().x)` at the two rocket wrap sites (`src/Game.cpp`), mirroring the #28d Y-wrap fix. Robot is unaffected (`scale.x=±1`). Integration test 8 (P1 left wrap) and its replay retuned for the corrected 268px threshold.

**Closes #37** — P2 keyboard attack fired on key **release** (`m_p2Attack = !isDown`) while P1 keyboard and both gamepad paths fire on **press**. Unified P2 to fire on press (`m_p2Attack = isDown`), so all four control sources are consistent. (Keyboard event injection isn't exercisable by the replay harness, so this mirrors P1's already-correct behavior by inspection; no test drives the keyboard press/release path.)

Local gates green: build (`-Werror`, zero warnings), clang-format v18, ctest **135/135**.
