### PR TITLE
docs: refresh CLAUDE.md + docs for shipped state (post-SFML 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ working in this repository. Keep this file concise; link out to [docs/](docs/) f
 
 ## What this repo is
 
-A **local two-player dungeon fighting game** built in C++ on **SFML 2.x**. Two sprite-animated
+A **local two-player dungeon fighting game** built in C++ on **SFML 3**. Two sprite-animated
 fighters trade sword/laser attacks in an arena while dodging fire hazards; first to out-score
 the other before the clock runs out wins. It runs as a native desktop window (macOS / Linux /
 Windows) — there is no server component beyond optional peer-to-peer online play.
@@ -48,9 +48,11 @@ The load-bearing pieces:
 
 ## Conventions
 
-- **C++17**, warnings-as-signal (`-Wall -Wextra -Wpedantic`; `-Werror` in CI). See issue #6.
+- **C++17**, warnings-as-signal (`-Wall -Wextra -Wpedantic`; `-Werror` in CI).
 - Format with `clang-format` and lint with `clang-tidy` (configs at repo root) before committing.
-- Prefer RAII and value/smart-pointer ownership over raw `new`/`delete` (see issue #9).
+  Match CI's **clang-format 18** — Apple's bundled v17 formats differently; use a pinned v18 binary
+  (see [docs/building.md](docs/building.md#warnings--tooling)).
+- Prefer RAII and value/smart-pointer ownership over raw `new`/`delete`.
 - Keep gameplay/AI/network logic **separable from rendering** so it is unit-testable without a
   window (SFML opens a real window + audio device). See [docs/architecture.md](docs/architecture.md).
 - Follow existing patterns; if a pattern looks wrong or fragile, flag it rather than copying it.
@@ -66,14 +68,44 @@ The load-bearing pieces:
 - **Online play is peer-to-peer** (one player hosts, the other joins); the host is authoritative
   for shared state. There is no dedicated server.
 
+## Load-bearing quirks (don't "fix" without understanding)
+
+These look wrong but are intentional; changing them breaks gameplay in non-obvious ways.
+
+- **`geometry.h` negative-width rects.** `objectBounds()` yields a negative `size.x` for
+  left-facing (scale.x < 0) objects; collision relies on SFML 3's `findIntersection()`
+  normalising internally (verified in `Rect.inl`). Do not "fix" `objectBounds()`.
+  `normalizedBounds()` is the positive-extent variant for edge math only — not collision.
+- **`sprite_anim.h` int-ceil.** `advanceFrameRect` pins `(int)ceil(curr/nx)` (integer division
+  *before* ceil) — the frame-advance math depends on it.
+- **Score field inversion.** `captureGameState` sets `p1_score = p2points` (rocket/P1) and
+  `p2_score = points` (robot/P2). Counterintuitive — verify direction before touching scoring.
+- **Scale-aware wrap/bounds math.** `getWidth()/getHeight()` return the *unscaled* frame size,
+  but the **rocket renders at scale ±2, the robot at ±1**. Any screen-wrap / edge / hazard math
+  must multiply by scale (`scale.x` flips sign with facing → use `std::abs`; `scale.y` stays +2).
+  This bug class bit both the Y-wrap (#28d) and X-wrap (#33).
+- **`std::optional<sf::Sprite/Sound/Text>` members.** SFML 3 removed these types' default ctors,
+  so they are held as optionals and `emplace()`d after the asset loads. The invariant
+  `m_valid ⟺ m_sprite.has_value()` is load-bearing: `changeValid(true)` must `emplace(m_texture)`
+  or the `m_valid`-guarded mutators dereference an empty optional (UB).
+- **The `apieceofcrap` variable name** (the minutes accumulator in `Game.cpp`). Do not rename it
+  to something sensible — it was deliberately restored (#30) and is considered load-bearing for
+  reasons no one has been able to establish. Leave it exactly as is.
+
 ## Working in this repo
 
 - **Merge convention:** feature branches off `master`, **squash-merged to `master`** via PR. One
   PR per coherent effort (may span multiple issues). See [docs/contributing.md](docs/contributing.md).
 - Run the four gates before declaring a change done: **build**, **clang-format --dry-run**,
-  **clang-tidy**, **ctest** — all must pass. CI enforces the same on every PR.
+  **clang-tidy**, **ctest** — all must pass. CI enforces the same on every PR across 3 platforms.
+- `dungeon_lib` is **one `-Werror` static library** built from all of `src/*.cpp`, and the test
+  targets link it — so a broad edit leaves the whole tree red until *everything* compiles (no
+  partial `ctest` mid-refactor).
+- **Local test etiquette:** `ctest -L unit` is headless and safe. The full/integration suite
+  constructs `Game`, which opens a **real macOS window** (no xvfb locally) and steals focus —
+  validate windowed behaviour on CI, not locally. Build + clang-format + unit are the safe local
+  gates. `TEST_CASE` names must be **ASCII-only** (Windows CTest mangles non-ASCII → "no tests
+  matched").
 - This game opens a real window; for automated/headless testing use the debug harness
-  (screenshots + scriptable input + `--frames N`) — see issue #13 and
+  (screenshots + scriptable input + `--frames N`) — see
   [docs/contributing.md](docs/contributing.md#automated-playtesting).
-- The overhaul in progress is tracked in GitHub issues #1–#13; read the relevant issue before
-  starting work in its area.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # Architecture
 
 A conceptual map of the game. File paths are given where stable, but the emphasis is on
-concepts that survive refactors (the physical layout is being reorganized under issue #8).
+concepts that survive refactors.
 
 ## The game in one paragraph
 
@@ -39,9 +39,9 @@ validity, origin. Two implementations:
 - **`AnimatedGameObject`** — a sprite sheet advanced frame-by-frame in `update()`; constructed with
   frame dimensions + count. Players, fire, and menu buttons are animated objects.
 
-Objects are currently created with raw `new` and stored as `GameObject*` (including the `stuff`
-vector of arena props). Ownership is being moved to smart pointers / RAII (issue #9); note the base
-class currently has **no virtual destructor**.
+Objects are owned via `std::unique_ptr<GameObject>` (the players `m_rocket`/`m_robot` and the
+`m_arena` vector of props); `GameObject` has a `virtual` destructor. Construct new objects with
+`std::make_unique` rather than raw `new`.
 
 ## The game loop
 
@@ -60,32 +60,37 @@ class currently has **no virtual destructor**.
 > per-frame timing, hazard-damage loop, and cooldown countdown. When extending hazard logic, edit
 > `run()`, not `update()`.
 
-**Timing caveats (issue #11):** movement scales with `deltaT` (good), but sprite animation uses a
-`time > .1f` reset accumulator (a frame-rate-sensitive hack), and the window is a fixed
-non-resizable `1920x1080` while menus are `1024x576`. Fixed-timestep + a scalable view are the
-intended fixes, and are also what makes deterministic replay (#13) and AI testing (#12) possible.
+**Timing & view:** the loop runs a **fixed timestep** — `run()` accumulates real time and drains
+it in `kFixedDt` (1/60 s) `simStep()` steps, so movement and the `time > .1f` sprite-animation
+accumulator advance deterministically (this is what makes replay and AI testing reproducible). The
+window renders through a **letterboxed scalable view** (`makeLetterboxView`, reapplied on
+`sf::Event::Resized`): the logical arena is `1920x1080` and menus `1024x576`, but the window is
+resizable and the view preserves aspect ratio.
 
 ## Scoring, hazards, cooldown
 
-- **Attacks:** each attack builds a `sf::Rect` extending from the attacker in its facing direction
-  and tests overlap with the opponent (`Game::collision(sf::Rect, GameObject*)`). A hit scores and
-  sets `reset`, which recenters both fighters and enters `wait` (cooldown).
-- **Hazards:** the `stuff` vector holds a wall + fire objects; touching one decrements score,
+- **Attacks:** each attack builds a `sf::FloatRect` extending from the attacker in its facing
+  direction and tests overlap with the opponent (`Game::collision(sf::FloatRect, const GameObject&)`).
+  A hit scores and sets `reset`, which recenters both fighters and enters `wait` (cooldown).
+- **Hazards:** the `m_arena` vector holds a wall + fire objects; touching one decrements score,
   gated by a per-player timeout so damage can't repeat every frame.
 - **Cooldown (`wait`):** after a score, the loop pauses gameplay ~1.75s (showing an intermission
   banner) before resuming with a gong.
 
-> Internal score naming is currently inverted/confusing (`points` tracks the robot/p2 score,
-> `p2points` tracks the rocket/p1 score); this is a known smell (#9) — verify against the HUD
-> strings and the `run()` return tuple before relying on either name.
+> Internal score naming is inverted (`points` tracks the robot/p2 score, `p2points` tracks the
+> rocket/p1 score), and `captureGameState` mirrors that inversion into `GameState`. This is
+> intentional and load-bearing (see CLAUDE.md) — verify against the HUD strings and the `run()`
+> return tuple before relying on either name; do not "fix" it.
 
 ## Network model
 
 `NetworkManager` wraps an `sf::TcpListener` + `sf::TcpSocket`. `PlayerInput` and `GameState`
-serialize via `sf::Packet`. The host is authoritative: it receives the client's `PlayerInput`,
-simulates, and returns the full `GameState` each frame. Known hardening work (issue #2): packets
-are demultiplexed by a leading type byte but mismatches are silently dropped, disconnection isn't
-detected, full state is sent every frame with no interpolation, and join input isn't validated.
+serialize via `sf::Packet`, demultiplexed by a leading type byte (mismatched packets are dropped).
+The host is authoritative: it receives the client's `PlayerInput`, simulates, and returns the full
+`GameState` each frame. Hardening (from #2) is in place: peer disconnection is detected
+(`isConnected()`/`peerLost()`), sends are one-slot drop-if-pending (no unbounded queue), and
+`lerpPos()` provides position interpolation. Received states are buffered (`m_stateBuf`, cap 8)
+with arrival timestamps.
 
 ## Testability seams
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -78,11 +78,39 @@ headless in CI (below).
   xvfb-run -s "-screen 0 1920x1080x24" ./build/dungeon_game --frames 120 --screenshot-every 30
   ```
 - **macOS:** there is no true headless mode (native Cocoa/OpenGL); a real window must open. Use a
-  local window plus the debug harness (issue #13) for playtesting.
+  local window plus the debug harness for playtesting (see
+  [contributing.md](contributing.md#automated-playtesting)).
 
 ## Warnings & tooling
 
 Builds enable `-Wall -Wextra -Wpedantic` (and `-Werror` in CI). Format with `clang-format` and
 statically analyze with `clang-tidy` using the repo-root configs; install both via `brew install
-llvm` on macOS or your distro's LLVM packages on Linux. See issue #6 and
-[contributing.md](contributing.md).
+llvm` on macOS or your distro's LLVM packages on Linux. See [contributing.md](contributing.md).
+
+> **Match CI's clang-format version (18).** Apple's bundled `clang-format` is v17 and produces
+> different formatting, so it can fail the CI `--dry-run --Werror` gate even when it looks clean
+> locally. Use a pinned v18 binary, e.g. the one shipped with the `clang-format` pip package
+> (`.../site-packages/clang_format/data/bin/clang-format`), or otherwise ensure v18.
+
+`dungeon_lib` is a single static library compiled from all of `src/*.cpp` under `-Werror`, and the
+test targets link it — so a broad change won't produce a runnable binary (or any `ctest`) until
+the *entire* tree compiles cleanly.
+
+## Releases & packaging
+
+`.github/workflows/release.yml` builds redistributable per-OS zips:
+
+- **Trigger:** push a `v*` tag → creates a GitHub Release and attaches Linux/macOS/Windows zips.
+  Tags like `v1.0.0-rc1` / `-beta` are auto-marked as pre-releases.
+- **Dry-run:** the workflow also accepts `workflow_dispatch` (run it from the Actions tab on any
+  branch) — it builds the three zips as **artifacts without creating a release**. Use this to
+  verify packaging before tagging.
+- **macOS packaging:** under SFML 3 the binary links **only system frameworks and `/usr/lib`**
+  (freetype is static-linked, audio uses miniaudio rather than an OpenAL framework), so **no
+  dylib/framework bundling is needed**. The macOS stage still runs `otool -L` and relinks any
+  non-system dylib defensively, but in practice bundles nothing. (This is what eliminated the
+  SFML 2 `@rpath/../Frameworks/*` dyld crash that broke the first v1.0.0 build.)
+- **Windows:** static build (`-DBUILD_SHARED_LIBS=OFF`), no OpenAL DLL (miniaudio).
+
+> The next `v*` tag will be the **first real tagged release on SFML 3** — the packaging dry-run
+> passes, but the full tag path (Release + all three zips) has not run end-to-end yet.


### PR DESCRIPTION
Docs-only. Consolidates durable gotchas into CLAUDE.md and corrects docs that described now-shipped work (RAII #9, fixed-timestep + letterbox #11, netcode hardening #2) as in-progress. Also fixes the stale 'SFML 2.x' description and drops closed-issue references. No code change (master already validated by #38/#39).