### PR TITLE
ci: guard load-bearing identifier names with a ctest case

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,10 @@ These look wrong but are intentional; changing them breaks gameplay in non-obvio
   or the `m_valid`-guarded mutators dereference an empty optional (UB).
 - **The `apieceofcrap` variable name** (the minutes accumulator in `Game.cpp`). Do not rename it
   to something sensible — it was deliberately restored (#30) and is considered load-bearing for
-  reasons no one has been able to establish. Leave it exactly as is.
+  reasons no one has been able to establish. Leave it exactly as is. **Enforced by CI:** the
+  `load_bearing_names` ctest case (label `unit`, so it runs on all 3 platforms) fails if the name
+  disappears from `src/Game.cpp`. The guarded list lives in
+  [cmake/check_load_bearing_names.cmake](cmake/check_load_bearing_names.cmake).
 
 ## Working in this repo
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,16 @@ endif()
 
 # ── Tests (guarded: only if tests/ subdir exists and option is ON) ───────────
 enable_testing()
+
+# Guards the deliberately-odd identifiers listed in CLAUDE.md → "Load-bearing
+# quirks". Needs no build, so it stays outside the DUNGEON_BUILD_TESTS guard.
+add_test(NAME load_bearing_names
+    COMMAND ${CMAKE_COMMAND}
+        -DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/check_load_bearing_names.cmake
+)
+set_tests_properties(load_bearing_names PROPERTIES LABELS "unit")
+
 option(DUNGEON_BUILD_TESTS "Build the dungeon_game test suite" ON)
 if(DUNGEON_BUILD_TESTS AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/CMakeLists.txt)
     add_subdirectory(tests)

--- a/cmake/check_load_bearing_names.cmake
+++ b/cmake/check_load_bearing_names.cmake
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.16)
+
+# ── Load-bearing identifier guard ─────────────────────────────────────────────
+# A few identifiers in this tree are deliberately odd and documented as
+# "do not rename" under CLAUDE.md → "Load-bearing quirks". A *partial* rename is
+# already a compile error, but a complete, consistent rename would sail through
+# every other gate — so check the names are still there. One surviving mention
+# per file is enough: anything less than a full rename won't build.
+#
+# Run: cmake -DSOURCE_DIR=<repo root> -P cmake/check_load_bearing_names.cmake
+
+if(NOT SOURCE_DIR)
+    message(FATAL_ERROR "check_load_bearing_names.cmake requires -DSOURCE_DIR=<repo root>")
+endif()
+
+# "<path relative to repo root>|<identifier that must still appear in it>"
+set(GUARDED_IDENTIFIERS
+    "src/Game.cpp|apieceofcrap"   # minutes accumulator; deliberately restored in #30
+)
+
+set(failures "")
+foreach(entry IN LISTS GUARDED_IDENTIFIERS)
+    string(REPLACE "|" ";" parts "${entry}")
+    list(GET parts 0 relpath)
+    list(GET parts 1 identifier)
+
+    if(NOT EXISTS "${SOURCE_DIR}/${relpath}")
+        list(APPEND failures "${relpath} does not exist (moved or deleted?) — '${identifier}' cannot be verified")
+        continue()
+    endif()
+
+    file(READ "${SOURCE_DIR}/${relpath}" contents)
+    if(NOT contents MATCHES "(^|[^A-Za-z0-9_])${identifier}([^A-Za-z0-9_]|$)")
+        list(APPEND failures "${relpath} no longer mentions '${identifier}'")
+    endif()
+endforeach()
+
+if(failures)
+    set(report "")
+    foreach(f IN LISTS failures)
+        string(APPEND report "\n  - ${f}")
+    endforeach()
+    message(FATAL_ERROR
+        "Load-bearing identifier check failed:${report}\n"
+        "These names are intentional. See CLAUDE.md → \"Load-bearing quirks\". If a rename is "
+        "genuinely wanted, update GUARDED_IDENTIFIERS in cmake/check_load_bearing_names.cmake "
+        "and the CLAUDE.md entry in the same change.")
+endif()
+
+message(STATUS "Load-bearing identifiers OK")


### PR DESCRIPTION
## Why

`apieceofcrap` (the minutes accumulator in `src/Game.cpp`) is documented in CLAUDE.md as load-bearing and was deliberately restored in #30 — but nothing actually enforced it. `-Werror` does not help here: a *partial* rename is a compile error, while a **complete, consistent rename compiles cleanly** and passes every existing gate (build, clang-format, clang-tidy, ctest).

## What

- `cmake/check_load_bearing_names.cmake` — standalone `cmake -P` script (portable, so it behaves identically on Linux/macOS/Windows) with a data-driven list of `file|identifier` pairs. Fails with a message pointing at the CLAUDE.md quirk entry when one goes missing.
- Registered in `CMakeLists.txt` as ctest case `load_bearing_names` with label **`unit`** — all three CI jobs already run `ctest -L unit`, so this is enforced on every platform with **no workflow changes**. It compiles nothing, so it sits outside the `DUNGEON_BUILD_TESTS` guard and runs in 0.01s.
- CLAUDE.md quirk entry extended to note the enforcement and where the guarded list lives, so a genuinely-wanted rename updates both in one change.

## Design notes

- **One mention is enough.** Requiring an occurrence *count* would be brittle — legitimate refactors change how many times a local is read. Since a partial rename already fails to compile, a single surviving mention is a sound signal.
- **Only name-based quirks are guarded.** The other CLAUDE.md quirks (score-field inversion, the `m_valid ⟺ has_value` invariant, the `sprite_anim.h` int-ceil) are semantic rather than name-based; a text guard cannot express them, so they were left out rather than adding checks that give false confidence.

## Verification

| Case | Result |
| --- | --- |
| `ctest -L unit` (108 tests incl. the new guard) | pass |
| Full rename `apieceofcrap` → `minutes` | fails, exit 1 |
| `src/Game.cpp` moved/deleted | fails, exit 1 |
| Substring only (`apieceofcrappy`) | fails, exit 1 |